### PR TITLE
Use qsort instead of insertion sort

### DIFF
--- a/core/src/anchor.c
+++ b/core/src/anchor.c
@@ -3,6 +3,7 @@
 #include "anchor.h"
 #include "board.h"
 #include "constants.h"
+#include "stdlib.h"
 #include "util.h"
 
 AnchorList *create_anchor_list() {
@@ -25,21 +26,10 @@ void destroy_anchor_list(AnchorList *al) {
   free(al);
 }
 
-void insert_anchor(AnchorList *al, int row, int col, int last_anchor_col,
+void add_anchor(AnchorList *al, int row, int col, int last_anchor_col,
                    int transpose_state, int vertical,
                    double highest_possible_equity) {
   int i = al->count;
-  for (; i > 0 &&
-         al->anchors[i - 1]->highest_possible_equity < highest_possible_equity;
-       i--) {
-    al->anchors[i]->row = al->anchors[i - 1]->row;
-    al->anchors[i]->col = al->anchors[i - 1]->col;
-    al->anchors[i]->last_anchor_col = al->anchors[i - 1]->last_anchor_col;
-    al->anchors[i]->transpose_state = al->anchors[i - 1]->transpose_state;
-    al->anchors[i]->vertical = al->anchors[i - 1]->vertical;
-    al->anchors[i]->highest_possible_equity =
-        al->anchors[i - 1]->highest_possible_equity;
-  }
   al->anchors[i]->row = row;
   al->anchors[i]->col = col;
   al->anchors[i]->last_anchor_col = last_anchor_col;
@@ -47,6 +37,22 @@ void insert_anchor(AnchorList *al, int row, int col, int last_anchor_col,
   al->anchors[i]->vertical = vertical;
   al->anchors[i]->highest_possible_equity = highest_possible_equity;
   al->count++;
+}
+
+int compare_anchors(const void *a, const void *b) {
+  const Anchor *anchor_a = *(const Anchor **)a;
+  const Anchor *anchor_b = *(const Anchor **)b;
+  if (anchor_a->highest_possible_equity > anchor_b->highest_possible_equity) {
+    return -1;
+  } else if (anchor_a->highest_possible_equity < anchor_b->highest_possible_equity) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+void sort_anchor_list(AnchorList *al) {
+  qsort(al->anchors, al->count, sizeof(Anchor *), compare_anchors);
 }
 
 void reset_anchor_list(AnchorList *al) { al->count = 0; }

--- a/core/src/anchor.h
+++ b/core/src/anchor.h
@@ -20,9 +20,9 @@ typedef struct AnchorList {
 AnchorList *create_anchor_list();
 void destroy_anchor_list(AnchorList *al);
 void add_anchor(AnchorList *al, int row, int col, int last_anchor_col,
-                   int transpose_state, int vertical,
-                   double highest_possible_equity);
-void sort_anchor_list(AnchorList *al);                   
+                int transpose_state, int vertical,
+                double highest_possible_equity);
+void sort_anchor_list(AnchorList *al);
 void reset_anchor_list(AnchorList *al);
 
 #endif

--- a/core/src/anchor.h
+++ b/core/src/anchor.h
@@ -19,9 +19,10 @@ typedef struct AnchorList {
 
 AnchorList *create_anchor_list();
 void destroy_anchor_list(AnchorList *al);
-void insert_anchor(AnchorList *al, int row, int col, int last_anchor_col,
+void add_anchor(AnchorList *al, int row, int col, int last_anchor_col,
                    int transpose_state, int vertical,
                    double highest_possible_equity);
+void sort_anchor_list(AnchorList *al);                   
 void reset_anchor_list(AnchorList *al);
 
 #endif

--- a/core/src/movegen.c
+++ b/core/src/movegen.c
@@ -693,9 +693,9 @@ void shadow_play_for_anchor(Generator *gen, int col, Player *player,
   }
 
   shadow_start(gen, get_cross_set_index(gen, player->index), opp_rack);
-  insert_anchor(gen->anchor_list, gen->current_row_index, col,
-                gen->last_anchor_col, gen->board->transposed, gen->vertical,
-                gen->highest_shadow_equity);
+  add_anchor(gen->anchor_list, gen->current_row_index, col,
+             gen->last_anchor_col, gen->board->transposed, gen->vertical,
+             gen->highest_shadow_equity);
 }
 
 void shadow_by_orientation(Generator *gen, Player *player, int dir,
@@ -758,6 +758,7 @@ void generate_moves(Generator *gen, Player *player, Rack *opp_rack,
   // Reset the reused generator fields
   gen->tiles_played = 0;
 
+  sort_anchor_list(gen->anchor_list);
   for (int i = 0; i < gen->anchor_list->count; i++) {
     if (player->strategy_params->play_recorder_type == MOVE_RECORDER_BEST &&
         better_play_has_been_found(


### PR DESCRIPTION
This only makes generate_moves about 0.1% faster but I'd like to add a step to movegen that splits anchors into bingo and nonbingo versions and so it makes sense to sort later (plus this will increase the number of anchors and make the sort algo matter more).