### PR TITLE
incrementally sort descending effective multipliers

### DIFF
--- a/src/impl/autoplay.c
+++ b/src/impl/autoplay.c
@@ -20,7 +20,6 @@
 #include "move_gen.h"
 
 #include "../str/autoplay_string.h"
-#include "../str/game_string.h"
 
 #include "../util/util.h"
 
@@ -80,9 +79,6 @@ void play_autoplay_game(Game *game, MoveList *move_list,
   game_set_starting_player_index(game, starting_player_index);
   draw_starting_racks(game);
   while (game_get_game_end_reason(game) == GAME_END_REASON_NONE) {
-    //StringBuilder *sb = create_string_builder();
-    //string_builder_add_game(game, NULL, sb);
-    //printf("%s\n", string_builder_peek(sb));
     play_move(get_top_equity_move(game, thread_index, move_list), game);
   }
   record_results(game, autoplay_results, starting_player_index);

--- a/src/impl/autoplay.c
+++ b/src/impl/autoplay.c
@@ -20,6 +20,7 @@
 #include "move_gen.h"
 
 #include "../str/autoplay_string.h"
+#include "../str/game_string.h"
 
 #include "../util/util.h"
 
@@ -79,6 +80,9 @@ void play_autoplay_game(Game *game, MoveList *move_list,
   game_set_starting_player_index(game, starting_player_index);
   draw_starting_racks(game);
   while (game_get_game_end_reason(game) == GAME_END_REASON_NONE) {
+    //StringBuilder *sb = create_string_builder();
+    //string_builder_add_game(game, NULL, sb);
+    //printf("%s\n", string_builder_peek(sb));
     play_move(get_top_equity_move(game, thread_index, move_list), game);
   }
   record_results(game, autoplay_results, starting_player_index);

--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -29,12 +29,31 @@
 
 #define INITIAL_LAST_ANCHOR_COL (BOARD_DIM)
 
+typedef struct MovableMultiplier {
+  uint8_t multiplier;
+  uint8_t column;
+} MovableMultiplier;
+
 typedef struct MoveGen {
   // Owned by this MoveGen struct
   int current_row_index;
   int current_anchor_col;
   uint64_t anchor_left_extension_set;
   uint64_t anchor_right_extension_set;
+
+  // Used to insert "movable" multipliers into a descending list for calculating
+  // the maximum score for an anchor. We don't know which tiles will go in which
+  // multipliers so we keep a sorted list. The inner product of those and the
+  // descending tile scores is the highest possible score of a permutation of
+  // tiles in those squares.
+  MovableMultiplier descending_cross_word_multipliers[WORD_ALIGNING_RACK_SIZE];
+  uint16_t descending_effective_letter_multipliers[WORD_ALIGNING_RACK_SIZE];
+  uint8_t num_movable_multipliers;
+  // Used to reset the arrays after finishing shadow_play_right, which may have
+  // rearranged the ordering of the multipliiers used while shadowing left.
+  MovableMultiplier desc_xw_muls_copy[WORD_ALIGNING_RACK_SIZE];
+  uint16_t desc_eff_lettter_muls_copy[WORD_ALIGNING_RACK_SIZE];
+
   int last_anchor_col;
   int dir;
   int max_tiles_to_play;
@@ -519,42 +538,12 @@ shadow_board_is_letter_allowed_in_cross_set(const MoveGen *gen, int col) {
   return (cross_set & gen->rack_cross_set) != 0;
 }
 
-void shadow_record(MoveGen *gen, int left_col, int right_col,
-                   int main_played_through_score,
+void shadow_record(MoveGen *gen, int main_played_through_score,
                    int perpendicular_additional_score, int word_multiplier) {
-  uint16_t sorted_effective_letter_multipliers[WORD_ALIGNING_RACK_SIZE];
-  memset(sorted_effective_letter_multipliers, 0,
-         sizeof(sorted_effective_letter_multipliers));
-  int current_tiles_played = 0;
-  for (int current_col = left_col; current_col <= right_col; current_col++) {
-    const uint8_t current_letter = gen_cache_get_letter(gen, current_col);
-    if (current_letter == ALPHABET_EMPTY_SQUARE_MARKER) {
-      const uint8_t bonus_square = gen_cache_get_bonus_square(gen, current_col);
-      uint16_t this_word_multiplier = bonus_square >> 4;
-      uint16_t letter_multiplier = bonus_square & 0x0F;
-      bool is_cross_word = gen_cache_get_is_cross_word(gen, current_col);
-      uint16_t effective_letter_multiplier =
-          letter_multiplier *
-          ((this_word_multiplier * is_cross_word) + word_multiplier);
-      // Insert the effective multiplier.
-      int insert_index = current_tiles_played;
-      for (; insert_index > 0 &&
-             sorted_effective_letter_multipliers[insert_index - 1] <
-                 effective_letter_multiplier;
-           insert_index--) {
-        sorted_effective_letter_multipliers[insert_index] =
-            sorted_effective_letter_multipliers[insert_index - 1];
-      }
-      sorted_effective_letter_multipliers[insert_index] =
-          effective_letter_multiplier;
-      current_tiles_played++;
-    }
-  }
-
   uint16_t tiles_played_score = 0;
   for (int i = 0; i < RACK_SIZE; i++) {
-    tiles_played_score +=
-        gen->descending_tile_scores[i] * sorted_effective_letter_multipliers[i];
+    tiles_played_score += gen->descending_tile_scores[i] *
+                          gen->descending_effective_letter_multipliers[i];
   }
 
   int bingo_bonus = 0;
@@ -580,12 +569,96 @@ void shadow_record(MoveGen *gen, int left_col, int right_col,
   }
 }
 
+static inline void insert_movable_cross_word_multiplier(MoveGen *gen,
+                                                        uint8_t multiplier,
+                                                        int col) {
+  int insert_index = gen->num_movable_multipliers;
+  for (; insert_index > 0 &&
+         gen->descending_cross_word_multipliers[insert_index - 1].multiplier <
+             multiplier;
+       insert_index--) {
+    gen->descending_cross_word_multipliers[insert_index] =
+        gen->descending_cross_word_multipliers[insert_index - 1];
+  }
+  gen->descending_cross_word_multipliers[insert_index].multiplier = multiplier;
+  gen->descending_cross_word_multipliers[insert_index].column = col;
+}
+
+static inline void insert_movable_effective_letter_multiplier(
+    MoveGen *gen, uint8_t multiplier) {
+  int insert_index = gen->num_movable_multipliers;
+  for (; insert_index > 0 &&
+         gen->descending_effective_letter_multipliers[insert_index - 1] <
+             multiplier;
+       insert_index--) {
+    gen->descending_effective_letter_multipliers[insert_index] =
+        gen->descending_effective_letter_multipliers[insert_index - 1];
+  }
+  gen->descending_effective_letter_multipliers[insert_index] = multiplier;
+}
+
+// Recalculate and reinsert all movable effective letter multipliers, triggered
+// by a change in the word multiplier.
+static inline void recalculate_effective_multipliers(MoveGen *gen,
+                                                     int word_multiplier) {
+  const int original_num_movable_multipliers = gen->num_movable_multipliers;
+  gen->num_movable_multipliers = 0;
+  // We insert the columns with highest cross wordletter multipliers first
+  // so the list will mostly sort in the the order it is traversed,
+  // minimizing the number of swaps.
+  for (int i = 0; i < original_num_movable_multipliers; i++) {
+    const uint8_t xw_multiplier =
+        gen->descending_cross_word_multipliers[i].multiplier;
+    const uint8_t col = gen->descending_cross_word_multipliers[i].column;
+    const uint8_t bonus_square = gen_cache_get_bonus_square(gen, col);
+    const uint8_t letter_multiplier = bonus_square & 0x0F;
+    const uint8_t effective_letter_multiplier =
+        word_multiplier * letter_multiplier + xw_multiplier;
+    insert_movable_effective_letter_multiplier(gen,
+                                               effective_letter_multiplier);
+    gen->num_movable_multipliers++;
+  }
+}
+
+static inline void insert_movable_multipliers(MoveGen *gen, int col,
+                                              int old_word_multiplier,
+                                              int word_multiplier) {
+  // If the current square changes the word multiplier, previously-inserted
+  // multipliers have changed, and their ordering might have also changed.
+  if (old_word_multiplier != word_multiplier) {
+    recalculate_effective_multipliers(gen, word_multiplier);
+  }
+
+  const bool is_cross_word = gen_cache_get_is_cross_word(gen, col);
+  const uint8_t bonus_square = gen_cache_get_bonus_square(gen, col);
+  const uint8_t letter_multiplier = bonus_square & 0x0F;
+  const uint8_t this_word_multiplier = bonus_square >> 4;
+  const uint8_t effective_cross_word_multiplier =
+      letter_multiplier * this_word_multiplier * is_cross_word;
+  insert_movable_cross_word_multiplier(gen, effective_cross_word_multiplier,
+                                       col);
+  const uint8_t main_word_multiplier = word_multiplier * letter_multiplier;
+  insert_movable_effective_letter_multiplier(
+      gen, main_word_multiplier + effective_cross_word_multiplier);
+  gen->num_movable_multipliers++;
+}
+
 static inline void shadow_play_right(MoveGen *gen,
                                      int main_played_through_score,
                                      int perpendicular_additional_score,
                                      int word_multiplier, bool is_unique) {
-  int original_current_right_col = gen->current_right_col;
-  int original_tiles_played = gen->tiles_played;
+  // Save the state of the movable multiplier arrays so they can be restored
+  // after exhausting the rightward shadow plays. Shadowing right changes the
+  // values of multipliers found while shadowing left. We need to restore them
+  // to how they were before looking further left.
+  const int original_num_movable_multipliers = gen->num_movable_multipliers;
+  memory_copy(gen->desc_xw_muls_copy, gen->descending_cross_word_multipliers,
+              sizeof(gen->descending_cross_word_multipliers));
+  memory_copy(gen->desc_eff_lettter_muls_copy,
+              gen->descending_effective_letter_multipliers,
+              sizeof(gen->descending_effective_letter_multipliers));
+  const int original_current_right_col = gen->current_right_col;
+  const int original_tiles_played = gen->tiles_played;
   while (gen->current_right_col < (BOARD_DIM - 1) &&
          gen->tiles_played < gen->number_of_letters_on_rack) {
     gen->current_right_col++;
@@ -602,8 +675,15 @@ static inline void shadow_play_right(MoveGen *gen,
         gen_cache_get_cross_score(gen, gen->current_right_col);
     int this_word_multiplier = bonus_square >> 4;
     perpendicular_additional_score += cross_score * this_word_multiplier;
+    // If this is only the second tile played, the previous word multiplier as
+    // used for computing effective letter multipliers might have actually been
+    // zero. By showing a changed word multiplier, we force a recalculation of
+    // all effective letter multipliers to correct them.
+    const int old_word_multiplier =
+        (gen->tiles_played > 2) ? word_multiplier : 0;
     word_multiplier *= this_word_multiplier;
-
+    insert_movable_multipliers(gen, gen->current_right_col, old_word_multiplier,
+                               word_multiplier);
     if (cross_set == TRIVIAL_CROSS_SET) {
       is_unique = true;
     }
@@ -618,12 +698,17 @@ static inline void shadow_play_right(MoveGen *gen,
     }
 
     if (gen->tiles_played + is_unique >= 2) {
-      shadow_record(gen, gen->current_left_col, gen->current_right_col,
-                    main_played_through_score, perpendicular_additional_score,
-                    word_multiplier);
+      shadow_record(gen, main_played_through_score,
+                    perpendicular_additional_score, word_multiplier);
     }
   }
 
+  gen->num_movable_multipliers = original_num_movable_multipliers;
+  memory_copy(gen->descending_cross_word_multipliers, gen->desc_xw_muls_copy,
+              sizeof(gen->descending_cross_word_multipliers));
+  memory_copy(gen->descending_effective_letter_multipliers,
+              gen->desc_eff_lettter_muls_copy,
+              sizeof(gen->descending_effective_letter_multipliers));
   gen->current_right_col = original_current_right_col;
   gen->tiles_played = original_tiles_played;
 }
@@ -653,11 +738,14 @@ nonplaythrough_shadow_play_left(MoveGen *gen, int main_played_through_score,
     const uint8_t bonus_square =
         gen_cache_get_bonus_square(gen, gen->current_left_col);
     int this_word_multiplier = bonus_square >> 4;
+    const int old_word_multiplier =
+        (gen->tiles_played > 2) ? word_multiplier : 0;
     word_multiplier *= this_word_multiplier;
-
-    shadow_record(gen, gen->current_left_col, gen->current_right_col,
-                  main_played_through_score, perpendicular_additional_score,
-                  word_multiplier);
+    insert_movable_multipliers(gen, gen->current_left_col, old_word_multiplier,
+                               word_multiplier);
+                               
+    shadow_record(gen, main_played_through_score,
+                  perpendicular_additional_score, word_multiplier);
   }
 }
 
@@ -695,7 +783,10 @@ static inline void playthrough_shadow_play_left(MoveGen *gen,
         gen_cache_get_cross_score(gen, gen->current_left_col);
     const int this_word_multiplier = bonus_square >> 4;
     perpendicular_additional_score += cross_score * this_word_multiplier;
+    const int old_word_multiplier = word_multiplier;
     word_multiplier *= this_word_multiplier;
+    insert_movable_multipliers(gen, gen->current_left_col, old_word_multiplier,
+                               word_multiplier);
 
     if (cross_set == TRIVIAL_CROSS_SET) {
       // See equivalent in shadow_play_right for the reasoning here.
@@ -703,9 +794,8 @@ static inline void playthrough_shadow_play_left(MoveGen *gen,
     }
 
     if (gen->tiles_played + is_unique >= 2) {
-      shadow_record(gen, gen->current_left_col, gen->current_right_col,
-                    main_played_through_score, perpendicular_additional_score,
-                    word_multiplier);
+      shadow_record(gen, main_played_through_score,
+                    perpendicular_additional_score, word_multiplier);
     }
   }
 }
@@ -724,12 +814,12 @@ static inline void shadow_start_nonplaythrough(MoveGen *gen) {
       gen_cache_get_cross_score(gen, gen->current_left_col);
   const int this_word_multiplier = bonus_square >> 4;
   const int perpendicular_additional_score = cross_score * this_word_multiplier;
+  insert_movable_multipliers(gen, gen->current_left_col, 0, 0);
   gen->tiles_played++;
   if (!board_is_dir_vertical(gen->dir)) {
     // word_multiplier is always hard-coded as 0 since we are recording a
     // single tile
-    shadow_record(gen, gen->current_left_col, gen->current_right_col, 0,
-                  perpendicular_additional_score, 0);
+    shadow_record(gen, 0, perpendicular_additional_score, 0);
   }
   nonplaythrough_shadow_play_left(gen, 0, perpendicular_additional_score,
                                   this_word_multiplier,
@@ -782,8 +872,14 @@ void shadow_play_for_anchor(MoveGen *gen, int col) {
   gen->current_left_col = col;
   gen->current_right_col = col;
 
+  // set leftx/rightx
   gen->anchor_left_extension_set = gen_cache_get_left_extension_set(gen, col);
   gen->anchor_right_extension_set = gen_cache_get_right_extension_set(gen, col);
+
+  // reset movable multipliers
+  gen->num_movable_multipliers = 0;
+  memset(gen->descending_effective_letter_multipliers, 0,
+         sizeof(gen->descending_effective_letter_multipliers));
 
   // Reset shadow score
   gen->highest_shadow_equity = 0;

--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -52,7 +52,7 @@ typedef struct MoveGen {
   // Used to reset the arrays after finishing shadow_play_right, which may have
   // rearranged the ordering of the multipliiers used while shadowing left.
   MovableMultiplier desc_xw_muls_copy[WORD_ALIGNING_RACK_SIZE];
-  uint16_t desc_eff_lettter_muls_copy[WORD_ALIGNING_RACK_SIZE];
+  uint16_t desc_eff_letter_muls_copy[WORD_ALIGNING_RACK_SIZE];
 
   int last_anchor_col;
   int dir;
@@ -538,8 +538,9 @@ shadow_board_is_letter_allowed_in_cross_set(const MoveGen *gen, int col) {
   return (cross_set & gen->rack_cross_set) != 0;
 }
 
-void shadow_record(MoveGen *gen, int main_played_through_score,
-                   int perpendicular_additional_score, int word_multiplier) {
+static inline void shadow_record(MoveGen *gen, int main_played_through_score,
+                                 int perpendicular_additional_score,
+                                 int word_multiplier) {
   uint16_t tiles_played_score = 0;
   for (int i = 0; i < RACK_SIZE; i++) {
     tiles_played_score += gen->descending_tile_scores[i] *
@@ -654,7 +655,7 @@ static inline void shadow_play_right(MoveGen *gen,
   const int original_num_movable_multipliers = gen->num_movable_multipliers;
   memory_copy(gen->desc_xw_muls_copy, gen->descending_cross_word_multipliers,
               sizeof(gen->descending_cross_word_multipliers));
-  memory_copy(gen->desc_eff_lettter_muls_copy,
+  memory_copy(gen->desc_eff_letter_muls_copy,
               gen->descending_effective_letter_multipliers,
               sizeof(gen->descending_effective_letter_multipliers));
   const int original_current_right_col = gen->current_right_col;
@@ -707,7 +708,7 @@ static inline void shadow_play_right(MoveGen *gen,
   memory_copy(gen->descending_cross_word_multipliers, gen->desc_xw_muls_copy,
               sizeof(gen->descending_cross_word_multipliers));
   memory_copy(gen->descending_effective_letter_multipliers,
-              gen->desc_eff_lettter_muls_copy,
+              gen->desc_eff_letter_muls_copy,
               sizeof(gen->descending_effective_letter_multipliers));
   gen->current_right_col = original_current_right_col;
   gen->tiles_played = original_tiles_played;


### PR DESCRIPTION
Calculating and sorting effective multiplier squares in shadow_record took up a large amount of shadow time, and did a lot of redundant work. Instead let's have MoveGen own the list and update it before recording. When the word multiplier doesn't change, it is trivial to just insert a single square's multiplier into its place. When the word multiplier changes, we do have to do more work to recalculate and reorder the list, but it's still faster than starting from scratch every time in shadow_record.