### PR TITLE
don't read zeroth node in cross set code

### DIFF
--- a/src/ent/board.h
+++ b/src/ent/board.h
@@ -35,10 +35,6 @@ typedef struct Board {
   int number_of_row_anchors[BOARD_DIM * 2];
   int transposed;
   int tiles_played;
-  // Scratch pad for return values used by
-  // traverse backwards for score
-  uint32_t node_index;
-  bool path_is_valid;
 } Board;
 
 // Square: Letter
@@ -448,24 +444,6 @@ static inline int board_get_tiles_played(const Board *board) {
 static inline void board_increment_tiles_played(Board *board,
                                                 int tiles_played) {
   board->tiles_played += tiles_played;
-}
-
-// Board: traverse backwards return values
-
-static inline bool board_get_path_is_valid(const Board *board) {
-  return board->path_is_valid;
-}
-
-static inline void board_set_path_is_valid(Board *board, bool value) {
-  board->path_is_valid = value;
-}
-
-static inline uint32_t board_get_node_index(const Board *board) {
-  return board->node_index;
-}
-
-static inline void board_set_node_index(Board *board, uint32_t value) {
-  board->node_index = value;
 }
 
 // Board auxilllary functions

--- a/src/ent/game.c
+++ b/src/ent/game.c
@@ -9,13 +9,14 @@
 #include "../def/game_defs.h"
 #include "../def/letter_distribution_defs.h"
 #include "../def/players_data_defs.h"
-#include "assert.h"
+
 #include "bag.h"
 #include "board.h"
 #include "kwg.h"
 #include "player.h"
 #include "players_data.h"
 #include "rack.h"
+
 typedef struct MinimalGameBackup {
   Board *board;
   Bag *bag;

--- a/src/ent/game.c
+++ b/src/ent/game.c
@@ -135,6 +135,12 @@ int traverse_backwards_for_score(const Board *board,
 void traverse_backwards(const KWG *kwg, Board *board, int row, int col,
                         uint32_t node_index, bool check_letter_set,
                         int left_most_col) {
+  if (node_index == 0) {
+    board_set_node_index(board, node_index);
+    board_set_path_is_valid(board, false);
+    return;
+  }
+
   while (board_is_position_valid(row, col)) {
     uint8_t ml = board_get_letter(board, row, col);
     if (ml == ALPHABET_EMPTY_SQUARE_MARKER) {
@@ -216,7 +222,9 @@ void game_gen_cross_set(Game *game, int row, int col, int dir,
       kwg_get_letter_sets(kwg, lnode_index, &leftside_leftx_set);
       const uint32_t s_index =
           kwg_get_next_node_index(kwg, lnode_index, SEPARATION_MACHINE_LETTER);
-      back_hook_set = kwg_get_letter_sets(kwg, s_index, &leftside_rightx_set);
+      if (s_index != 0) {
+        back_hook_set = kwg_get_letter_sets(kwg, s_index, &leftside_rightx_set);
+      }
     }
     board_set_left_extension_set_with_blank(
         board, row, col - 1, through_dir, cross_set_index, leftside_leftx_set);
@@ -246,7 +254,9 @@ void game_gen_cross_set(Game *game, int row, int col, int dir,
           kwg_get_letter_sets(kwg, right_lnode_index, &rightside_leftx_set);
       const uint32_t s_index = kwg_get_next_node_index(
           kwg, right_lnode_index, SEPARATION_MACHINE_LETTER);
-      kwg_get_letter_sets(kwg, s_index, &rightside_rightx_set);
+      if (s_index != 0) {
+        kwg_get_letter_sets(kwg, s_index, &rightside_rightx_set);
+      }
     }
     board_set_left_extension_set_with_blank(board, row, right_col, through_dir,
                                             cross_set_index,

--- a/src/ent/game.c
+++ b/src/ent/game.c
@@ -9,14 +9,13 @@
 #include "../def/game_defs.h"
 #include "../def/letter_distribution_defs.h"
 #include "../def/players_data_defs.h"
+#include "assert.h"
 #include "bag.h"
 #include "board.h"
 #include "kwg.h"
 #include "player.h"
 #include "players_data.h"
 #include "rack.h"
-
-#include "assert.h"
 typedef struct MinimalGameBackup {
   Board *board;
   Bag *bag;
@@ -132,9 +131,10 @@ int traverse_backwards_for_score(const Board *board,
   return score;
 }
 
-static inline uint32_t traverse_backwards(const KWG *kwg, Board *board, int row, int col,
-                            uint32_t node_index, bool check_letter_set,
-                            int left_most_col) {
+static inline uint32_t traverse_backwards(const KWG *kwg, Board *board, int row,
+                                          int col, uint32_t node_index,
+                                          bool check_letter_set,
+                                          int left_most_col) {
   while (board_is_position_valid(row, col)) {
     uint8_t ml = board_get_letter(board, row, col);
     if (ml == ALPHABET_EMPTY_SQUARE_MARKER) {
@@ -149,13 +149,11 @@ static inline uint32_t traverse_backwards(const KWG *kwg, Board *board, int row,
       if (kwg_in_letter_set(kwg, ml, node_index)) {
         return node_index;
       }
-
       return 0;
     }
 
     node_index = kwg_get_next_node_index(kwg, node_index,
                                          get_unblanked_machine_letter(ml));
-
     col--;
   }
 
@@ -422,8 +420,9 @@ int draw_rack_from_bag(const LetterDistribution *ld, Bag *bag, Rack *rack,
   return number_of_letters_set;
 }
 
-cgp_parse_status_t parse_cgp_racks_with_string_splitter(
-    const StringSplitter *player_racks, Game *game) {
+cgp_parse_status_t
+parse_cgp_racks_with_string_splitter(const StringSplitter *player_racks,
+                                     Game *game) {
   cgp_parse_status_t cgp_parse_status = CGP_PARSE_STATUS_SUCCESS;
   int number_of_letters_added =
       draw_rack_from_bag(game->ld, game->bag, player_get_rack(game->players[0]),
@@ -475,8 +474,8 @@ cgp_parse_status_t parse_cgp_scores(Game *game, const char *cgp_scores) {
   return cgp_parse_status;
 }
 
-cgp_parse_status_t parse_cgp_consecutive_zeros(
-    Game *game, const char *cgp_consecutive_zeros) {
+cgp_parse_status_t
+parse_cgp_consecutive_zeros(Game *game, const char *cgp_consecutive_zeros) {
   if (!is_all_digits_or_empty(cgp_consecutive_zeros)) {
     return CGP_PARSE_STATUS_MALFORMED_CONSECUTIVE_ZEROS;
   }


### PR DESCRIPTION
Zero is a special value as a node index in the kwg format designating an empty subtrie. Zero is also the location of the node which is the pointer to the dawg root. Most places we check if node_index is zero and mark paths as invalid instead of looking up the kwg_node(kwg, 0) value but not here, and we only have the correct behavior because of a sort of accident of the kwg file (not required in the spec) where this node has the isEnd bit set so that it will act like an empty trie if read from like a trie.