### PR TITLE
subtract duplicated letters from rack instead of decrementing in loop

### DIFF
--- a/src/ent/rack.c
+++ b/src/ent/rack.c
@@ -14,7 +14,6 @@ void rack_reset(Rack *rack) {
   for (int i = 0; i < rack->dist_size; i++) {
     rack->array[i] = 0;
   }
-  rack->empty = true;
   rack->number_of_letters = 0;
 }
 
@@ -58,9 +57,6 @@ bool rack_subtract(Rack *rack_to_update, Rack *value_to_sub) {
     }
     rack_to_update->array[i] -= value_to_sub->array[i];
     rack_to_update->number_of_letters -= value_to_sub->array[i];
-    if (rack_to_update->number_of_letters == 0) {
-      rack_to_update->empty = true;
-    }
   }
   return true;
 }
@@ -81,8 +77,7 @@ bool racks_are_equal(const Rack *rack1, const Rack *rack2) {
   if (!rack1 && !rack2) {
     return true;
   }
-  if (!rack1 || !rack2 || rack1->dist_size != rack2->dist_size ||
-      rack1->empty != rack2->empty) {
+  if (!rack1 || !rack2 || rack1->dist_size != rack2->dist_size) {
     return false;
   }
   for (int i = 0; i < rack1->dist_size; i++) {

--- a/src/ent/rack.h
+++ b/src/ent/rack.h
@@ -5,15 +5,12 @@
 #include <stdint.h>
 
 #include "../def/rack_defs.h"
-
-#include "letter_distribution.h"
-
 #include "../util/string_util.h"
+#include "letter_distribution.h"
 
 typedef struct Rack {
   int dist_size;
   int array[MAX_ALPHABET_SIZE];
-  bool empty;
   int number_of_letters;
 } Rack;
 
@@ -25,7 +22,9 @@ static inline void rack_copy(Rack *dst, const Rack *src) {
 }
 void rack_reset(Rack *rack);
 
-static inline int rack_get_dist_size(const Rack *rack) { return rack->dist_size; }
+static inline int rack_get_dist_size(const Rack *rack) {
+  return rack->dist_size;
+}
 
 static inline int rack_get_letter(const Rack *rack, uint8_t machine_letter) {
   return rack->array[machine_letter];
@@ -35,7 +34,9 @@ static inline int rack_get_total_letters(const Rack *rack) {
   return rack->number_of_letters;
 }
 
-static inline bool rack_is_empty(const Rack *rack) { return rack->empty; }
+static inline bool rack_is_empty(const Rack *rack) {
+  return rack->number_of_letters == 0;
+}
 
 bool racks_are_equal(const Rack *rack1, const Rack *rack2);
 bool rack_subtract(Rack *rack, Rack *subrack);
@@ -43,17 +44,21 @@ bool rack_subtract(Rack *rack, Rack *subrack);
 static inline void rack_take_letter(Rack *rack, uint8_t letter) {
   rack->array[letter]--;
   rack->number_of_letters--;
-  if (rack->number_of_letters == 0) {
-    rack->empty = true;
-  }
+}
+
+static inline void rack_take_letters(Rack *rack, uint8_t letter, int count) {
+  rack->array[letter] -= count;
+  rack->number_of_letters -= count;
 }
 
 static inline void rack_add_letter(Rack *rack, uint8_t letter) {
   rack->array[letter]++;
   rack->number_of_letters++;
-  if (rack->empty == 1) {
-    rack->empty = false;
-  }
+}
+
+static inline void rack_add_letters(Rack *rack, uint8_t letter, int count) {
+  rack->array[letter] += count;
+  rack->number_of_letters += count;
 }
 
 int rack_set_to_string(const LetterDistribution *ld, Rack *rack,

--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -341,10 +341,6 @@ static inline void record_exchange(MoveGen *gen) {
 // lookup of leaves with common lexicographical "prefixes".
 void generate_exchange_moves(MoveGen *gen, Rack *leave, uint32_t node_index,
                              uint32_t word_index, uint8_t ml,
-                             bool add_exchange);
-
-void generate_exchange_moves(MoveGen *gen, Rack *leave, uint32_t node_index,
-                             uint32_t word_index, uint8_t ml,
                              bool add_exchange) {
   const uint32_t ld_size = ld_get_size(gen->ld);
   while (ml < ld_size && rack_get_letter(&gen->player_rack, ml) == 0) {
@@ -386,8 +382,8 @@ void generate_exchange_moves(MoveGen *gen, Rack *leave, uint32_t node_index,
                               add_exchange);
     }
 
+    rack_take_letters(leave, ml, num_this);
     for (int i = 0; i < num_this; i++) {
-      rack_take_letter(leave, ml);
       leave_map_add_letter_and_update_complement_index(&gen->leave_map,
                                                        &gen->player_rack, ml);
     }
@@ -446,7 +442,8 @@ void recursive_gen(MoveGen *gen, int col, uint32_t node_index, int leftstrip,
           (number_of_ml != 0 ||
            rack_get_letter(&gen->player_rack, BLANK_MACHINE_LETTER) != 0) &&
           board_is_letter_allowed_in_cross_set(possible_letters_here, ml)) {
-        const uint32_t next_node_index = kwg_node_arc_index_prefetch(node, gen->kwg);
+        const uint32_t next_node_index =
+            kwg_node_arc_index_prefetch(node, gen->kwg);
         bool accepts = kwg_node_accepts(node);
         if (number_of_ml > 0) {
           leave_map_take_letter_and_update_current_index(&gen->leave_map,
@@ -625,9 +622,8 @@ static inline void insert_unrestricted_cross_word_multiplier(MoveGen *gen,
   gen->descending_cross_word_multipliers[insert_index].column = col;
 }
 
-static inline void
-insert_unrestricted_effective_letter_multiplier(MoveGen *gen,
-                                                uint8_t multiplier) {
+static inline void insert_unrestricted_effective_letter_multiplier(
+    MoveGen *gen, uint8_t multiplier) {
   int insert_index = gen->num_unrestricted_multipliers;
   for (; insert_index > 0 &&
          gen->descending_effective_letter_multipliers[insert_index - 1] <

--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -622,8 +622,9 @@ static inline void insert_unrestricted_cross_word_multiplier(MoveGen *gen,
   gen->descending_cross_word_multipliers[insert_index].column = col;
 }
 
-static inline void insert_unrestricted_effective_letter_multiplier(
-    MoveGen *gen, uint8_t multiplier) {
+static inline void
+insert_unrestricted_effective_letter_multiplier(MoveGen *gen,
+                                                uint8_t multiplier) {
   int insert_index = gen->num_unrestricted_multipliers;
   for (; insert_index > 0 &&
          gen->descending_effective_letter_multipliers[insert_index - 1] <


### PR DESCRIPTION
Remove `empty` field from Rack as it not used in movegen and it is easy enough to check this with `number_of_letters` instead. Not worth updating this during movegen. Also add a function to remove multiples of a tile at once, used in generate_exchange_moves. Autoplay speedup of somewhere between 0.4% and 0.9%