### PR TITLE
fix fix for unfound leaves

### DIFF
--- a/src/ent/klv.h
+++ b/src/ent/klv.h
@@ -62,6 +62,7 @@ static inline uint32_t follow_arc(const KLV *klv, uint32_t node_index,
                                   uint32_t *next_word_index) {
   *next_word_index = word_index + 1;
   if (node_index == 0) {
+    *next_word_index = KLV_UNFOUND_INDEX;
     return 0;
   }
   const uint32_t node = kwg_node(klv->kwg, node_index);

--- a/src/ent/klv.h
+++ b/src/ent/klv.h
@@ -60,11 +60,11 @@ static inline uint32_t increment_node_to_ml(const KLV *klv, uint32_t node_index,
 static inline uint32_t follow_arc(const KLV *klv, uint32_t node_index,
                                   uint32_t word_index,
                                   uint32_t *next_word_index) {
-  *next_word_index = word_index + 1;
   if (node_index == 0) {
     *next_word_index = KLV_UNFOUND_INDEX;
     return 0;
   }
+  *next_word_index = word_index + 1;
   const uint32_t node = kwg_node(klv->kwg, node_index);
   return kwg_node_arc_index(node);
 }

--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -353,8 +353,8 @@ void generate_exchange_moves(MoveGen *gen, Rack *leave, uint32_t node_index,
       double value = 0.0;
       if (word_index != KLV_UNFOUND_INDEX) {
         value = klv_get_indexed_leave_value(gen->klv, word_index - 1);
-        leave_map_set_current_value(&gen->leave_map, value);
       }
+      leave_map_set_current_value(&gen->leave_map, value);
       if (value > gen->best_leaves[leave->number_of_letters]) {
         gen->best_leaves[leave->number_of_letters] = value;
       }


### PR DESCRIPTION
Discovered this while testing larger rack sizes. I found it hard to make a test for this but the previous fix for unfound leaves was very broken and the PIZZAQQ test was passing due to zeroes being in uninitialized memory. We must set 0.0 for unfound leaves, not just skip setting a value.