### PR TITLE
fixes for 8+ racks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,11 @@ ifndef BOARD_DIM
 BOARD_DIM = 15
 endif
 
-CFLAGS += -DBOARD_DIM=$(BOARD_DIM)
+ifndef RACK_SIZE
+RACK_SIZE = 7
+endif
+
+CFLAGS += -DBOARD_DIM=$(BOARD_DIM) -DRACK_SIZE=$(RACK_SIZE)
 
 LFLAGS := ${lflags.${BUILD}}
 LDFLAGS  := ${ldflags.${BUILD}}

--- a/src/def/move_defs.h
+++ b/src/def/move_defs.h
@@ -1,6 +1,12 @@
 #ifndef MOVE_DEFS_H
 #define MOVE_DEFS_H
 
+#include "board_defs.h"
+#include "rack_defs.h"
+
+// Passes and exchanges can exceed the board size when racks are bigger than the board dimension.
+#define MOVE_MAX_TILES ((BOARD_DIM) > (RACK_SIZE) ? (BOARD_DIM) : (RACK_SIZE))
+
 #define PASS_MOVE_EQUITY -10000
 #define INITIAL_TOP_MOVE_EQUITY -100000
 #define COMPARE_MOVES_EPSILON 1e-6

--- a/src/def/rack_defs.h
+++ b/src/def/rack_defs.h
@@ -1,7 +1,16 @@
 #ifndef RACK_DEFS_H
 #define RACK_DEFS_H
 
-#define RACK_SIZE 7
+#define DEFAULT_RACK_SIZE 7
+
+// This should be defined in the Makefile
+// but is conditionally defined here
+// as a fallback and so the IDE doesn't
+// complain about a missing definition.
+#ifndef RACK_SIZE
+#define RACK_SIZE DEFAULT_RACK_SIZE
+#endif
+
 #define ROUND_UP_TO_NEXT_MULTIPLE_OF_8(x) (((x) + 7) & ~7)
 #define WORD_ALIGNING_RACK_SIZE ROUND_UP_TO_NEXT_MULTIPLE_OF_8(RACK_SIZE)
 #define MAX_RACK_SIZE 10000

--- a/src/ent/move.h
+++ b/src/ent/move.h
@@ -22,7 +22,7 @@ typedef struct Move {
   int tiles_length;
   double equity;
   int dir;
-  uint8_t tiles[BOARD_DIM];
+  uint8_t tiles[MOVE_MAX_TILES];
 } Move;
 
 typedef struct MoveList {

--- a/src/ent/static_eval.h
+++ b/src/ent/static_eval.h
@@ -10,13 +10,13 @@
 #include "../ent/move.h"
 #include "../ent/rack.h"
 
-// The length of this array should match PEG_ADJUST_VALUES_LENGTH
-static const double peg_adjust_values[] = {0, 0, 0, 0, 0, 0, 0,
-                                           0, 0, 0, 0, 0, 0};
+static const double peg_adjust_values[PEG_ADJUST_VALUES_LENGTH] = {
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
 // These are quackle values, but we can probably come up with our
 // own at some point.
-// static const double peg_adjust_values[] = {0, -8, 0, -0.5, -2, -3.5, -2,
-//                                            2, 10, 7, 4, -1, -2};
+// static const double qpeg_adjust_values[PEG_ADJUST_VALUES_LENGTH] = {
+//    0, -8, 0, -0.5, -2, -3.5, -2, 2, 10, 7, 4, -1, -2};
 
 static inline double
 placement_adjustment(const LetterDistribution *ld, const Move *move,
@@ -82,12 +82,11 @@ static inline double shadow_endgame_adjustment(const LetterDistribution *ld,
   return endgame_outplay_adjustment(rack_get_score(ld, opp_rack));
 }
 
-static inline double
-static_eval_get_shadow_equity(const LetterDistribution *ld,
-                              const Rack *opp_rack, const double *best_leaves,
-                              const uint16_t *descending_tile_scores,
-                              int number_of_tiles_in_bag,
-                              int number_of_letters_on_rack, int tiles_played) {
+static inline double static_eval_get_shadow_equity(
+    const LetterDistribution *ld, const Rack *opp_rack,
+    const double *best_leaves, const uint16_t *descending_tile_scores,
+    int number_of_tiles_in_bag, int number_of_letters_on_rack,
+    int tiles_played) {
   double equity = 0;
   if (number_of_tiles_in_bag > 0) {
     // Bag is not empty: use leave values

--- a/src/ent/static_eval.h
+++ b/src/ent/static_eval.h
@@ -15,7 +15,7 @@ static const double peg_adjust_values[PEG_ADJUST_VALUES_LENGTH] = {
 
 // These are quackle values, but we can probably come up with our
 // own at some point.
-// static const double qpeg_adjust_values[PEG_ADJUST_VALUES_LENGTH] = {
+// static const double peg_adjust_values[PEG_ADJUST_VALUES_LENGTH] = {
 //    0, -8, 0, -0.5, -2, -3.5, -2, 2, 10, 7, 4, -1, -2};
 
 static inline double

--- a/src/ent/static_eval.h
+++ b/src/ent/static_eval.h
@@ -82,11 +82,12 @@ static inline double shadow_endgame_adjustment(const LetterDistribution *ld,
   return endgame_outplay_adjustment(rack_get_score(ld, opp_rack));
 }
 
-static inline double static_eval_get_shadow_equity(
-    const LetterDistribution *ld, const Rack *opp_rack,
-    const double *best_leaves, const uint16_t *descending_tile_scores,
-    int number_of_tiles_in_bag, int number_of_letters_on_rack,
-    int tiles_played) {
+static inline double
+static_eval_get_shadow_equity(const LetterDistribution *ld,
+                              const Rack *opp_rack, const double *best_leaves,
+                              const uint16_t *descending_tile_scores,
+                              int number_of_tiles_in_bag,
+                              int number_of_letters_on_rack, int tiles_played) {
   double equity = 0;
   if (number_of_tiles_in_bag > 0) {
     // Bag is not empty: use leave values

--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -66,8 +66,8 @@ typedef struct MoveGen {
 
   int bag_tiles_remaining;
 
-  uint8_t strip[(BOARD_DIM)];
-  uint8_t exchange_strip[(BOARD_DIM)];
+  uint8_t strip[(MOVE_MAX_TILES)];
+  uint8_t exchange_strip[(MOVE_MAX_TILES)];
   LeaveMap leave_map;
   // Shadow plays
   int current_left_col;


### PR DESCRIPTION
RACK_SIZE option in Makefile
peg array size
move->tiles and gen->strip sizes need to be max(RACK_SIZE, BOARD_DIM)

Works with up to 28 on my M2 mbp with 8GB ram but be aware that LeaveMap.values is sizeof(double)*2^RACK_SIZE (2GB for 28 tiles) and there's one of those per thread.