### PR TITLE
fix FormedWords crosses at edge of board

### DIFF
--- a/src/ent/words.c
+++ b/src/ent/words.c
@@ -86,6 +86,11 @@ FormedWords *formed_words_create(Board *board, Move *move) {
           break;
         }
       }
+
+      if (rend == BOARD_DIM) {
+        rend = BOARD_DIM - 1;
+      }
+
       int widx = 0;
       ws->words[formed_words_idx].word_length = rend - rbegin + 1;
       ws->words[formed_words_idx].valid = false; // we don't know validity yet.

--- a/test/tsrc/word_test.c
+++ b/test/tsrc/word_test.c
@@ -130,6 +130,30 @@ void test_words_played() {
 
   validated_moves_destroy(vms_spays);
 
+  // N1 ZA making ZE# and AN, testing crosswords at board edge
+  ValidatedMoves *vms_zo =
+      validated_moves_create(game, 0, "N1.ZA", false, true, false);
+  fw = validated_moves_get_formed_words(vms_zo, 0);
+  assert(formed_words_get_num_words(fw) == 3);
+
+  // ZE# (phony because lexicon is NWL)
+  assert(formed_words_get_word_length(fw, 0) == 2);
+  assert(formed_words_get_word_valid(fw, 0) == 0);
+  assert(memory_compare(formed_words_get_word(fw, 0), (uint8_t[]){26, 5}, 2) ==
+         0);
+  // AN
+  assert(formed_words_get_word_length(fw, 1) == 2);
+  assert(formed_words_get_word_valid(fw, 1) == 1);
+  assert(memory_compare(formed_words_get_word(fw, 1), (uint8_t[]){1, 14}, 2) ==
+         0);
+  // ZA
+  assert(formed_words_get_word_length(fw, 2) == 2);
+  assert(formed_words_get_word_valid(fw, 2) == 1);
+  assert(memory_compare(formed_words_get_word(fw, 2), (uint8_t[]){26, 1}, 2) ==
+         0);
+
+  validated_moves_destroy(vms_zo);
+
   game_destroy(game);
   config_destroy(config);
 }


### PR DESCRIPTION
```
   A B C D E F G H I J K L M N O   -> Player 1                           0
   ------------------------------     Player 2                           0
 1|=     '       =       '     E | --Tracking-----------------------------------
 2|  -       "       "       - N | AAAAAACCDDDEEFGIIIIIIIKLNOOOQRRRRSSTTTTUVVZ?  44
 3|    -       '   '       -   d |
 4|'     -       '       -     U |
 5|        G L O W S   -       R |
 6|  "       "     P E T     " E |
 7|    '       ' F A X I N G   R |
 8|=     '     J A Y   T E E M S |
 9|    B     B O Y '       N     |
10|  " L   D O E     "     U "   |
11|    A N E W         - P I     |
12|'   M O   L E U       O N   ' |
13|    E H     '   '     H E     |
14|  -       "       "       -   |
15|=     '       =       '     = |
   ------------------------------
   ```
   
FormedWords was getting the lengths of crosswords at the edge of the board off by one, adding a byte of uninitialized memory. For example in this position the lengths of the crosswords formed by N1 ZA were both 3 rather than 2.

Removing this code
```
      if (rend == BOARD_DIM) {
        rend = BOARD_DIM - 1;
      }
```

will cause some of the new assertions in word_test.c to fail
