### PR TITLE
slight change to leftx shadow code + remove unused field

### DIFF
--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -1279,9 +1279,6 @@ void shadow_play_for_anchor(MoveGen *gen, int col) {
   if (gen->max_tiles_to_play == 0) {
     return;
   }
-  // printf("shadow_play_for_anchor row: %d, col: %d, dir: %d "
-  //        "highest_shadow_equity: %f\n",
-  //        gen->current_row_index, col, gen->dir, gen->highest_shadow_equity);
 
   anchor_list_add_anchor(gen->anchor_list, gen->current_row_index, col,
                          gen->last_anchor_col, gen->dir,


### PR DESCRIPTION
Noticed this slow anchor when profiling wmp movegen
```
   A B C D E F G H I J K L M N O   -> Player 1                 EGLST??   85
   ------------------------------     Player 2                 BIPQRSS   123
 1|=     '       =       '     = | --Tracking-----------------------------------
 2|  -       "       "       -   | AAAAAABCDDEEEEEEEEEFFGHIIIIIIKLLLMNNNNOOOORRRRSTTTUUWYYZ  56
 3|    -       '   '       -     |
 4|'     -       '       -     ' |
 5|        -           -         |
 6|  "       "       "       "   |
 7|    '       ' J O W     '     |
 8|=     '     V O X   M U C O R |
 9|    '       ' T O U N   H     |
10|  "   D I V N A   G A T E D   |
11|        -           -   A     |
12|'     -       '       - P   ' |
13|    -       '   '       I     |
14|  -       "       "     E -   |
15|=     '       =       '     = |
   ------------------------------

wordmap_gen anchor col 9 row 10 dir 1 tiles 7 blocks 1 elapsed 2208ns
wordmap_gen anchor col 6 row 10 dir 0 tiles 7 blocks 1 elapsed 5541ns
wordmap_gen anchor col 7 row 10 dir 0 tiles 7 blocks 1 elapsed 1916ns
wordmap_gen anchor col 9 row 7 dir 1 tiles 5 blocks 1 elapsed 8916ns
wordmap_gen anchor col 7 row 13 dir 1 tiles 7 blocks 2 elapsed 2416ns
wordmap_gen anchor col 9 row 10 dir 1 tiles 5 blocks 1 elapsed 67958ns SLOWEST WMP ANCHOR
```
and investigated why a high equity gets recorded for this anchor. That double-doubles are not possible should be determinable in shadow using the hooks of JOW (L, S) and leftx of MNA (A, E, I, O, U, Y): "blank" matches each of those, but there is no letter the blank can be designated that would work for both.

This has no measurable impact on gaddag move generation speed as it doesn't come up all that often and recursive_gen will filter these possibilities immediately. However it is complementary to wordmap_gen, which doesn't do these checks, and I'm seeing about a 0.2% additional speedup adding this to my wordmap_gen branch.

This makes sense to me and imo can't hurt. It adds basically zero cost to shadow and ought to reduce the number of anchors processed in move finding.

I'll do some very thorough autoplay testing for correctness before merging