### PR TITLE
Fix tiles_length for passes, should be 0, not 1

### DIFF
--- a/src/ent/move.h
+++ b/src/ent/move.h
@@ -158,7 +158,9 @@ static inline void move_copy(Move *dest_move, const Move *src_move) {
 }
 
 static inline void move_set_as_pass(Move *move) {
-  move_set_all(move, NULL, 0, 0, 0, 0, 0, 0, 0, GAME_EVENT_PASS,
+  move_set_all(move, /*strip=*/NULL, /*leftstrip=*/0, /*rightstrip=*/-1,
+               /*score=*/0, /*row_start=*/0, /*col_start=*/0,
+               /*tiles_played=*/0, /*dir=*/0, GAME_EVENT_PASS,
                PASS_MOVE_EQUITY);
 }
 

--- a/test/tsrc/move_test.c
+++ b/test/tsrc/move_test.c
@@ -40,7 +40,6 @@ void test_move_resize(void) {
 }
 
 void test_move_compare(void) {
-
   MoveList *ml = move_list_create(1);
 
   int leftstrip = 2;
@@ -122,9 +121,29 @@ void test_move_compare(void) {
   move_destroy(m);
 }
 
+void test_move_set_as_pass(void) {
+  MoveList *ml = move_list_create(1);
+
+  Move *m = move_list_get_spare_move(ml);
+
+  move_set_as_pass(m);
+
+  assert(move_get_type(m) == GAME_EVENT_PASS);
+  assert(move_get_score(m) == 0);
+  assert(move_get_row_start(m) == 0);
+  assert(move_get_col_start(m) == 0);
+  assert(move_get_tiles_played(m) == 0);
+  assert(move_get_tiles_length(m) == 0);
+  assert(move_get_dir(m) == BOARD_HORIZONTAL_DIRECTION);
+  assert(move_get_equity(m) == PASS_MOVE_EQUITY);
+
+  move_list_destroy(ml);
+}
+
 void test_move(void) {
   // The majority of the move and move list functionalities
   // are tested in movegen tests.
   test_move_resize();
   test_move_compare();
+  test_move_set_as_pass();
 }

--- a/test/tsrc/move_test.c
+++ b/test/tsrc/move_test.c
@@ -122,10 +122,7 @@ void test_move_compare(void) {
 }
 
 void test_move_set_as_pass(void) {
-  MoveList *ml = move_list_create(1);
-
-  Move *m = move_list_get_spare_move(ml);
-
+  Move *m = move_create();
   move_set_as_pass(m);
 
   assert(move_get_type(m) == GAME_EVENT_PASS);
@@ -137,7 +134,7 @@ void test_move_set_as_pass(void) {
   assert(move_get_dir(m) == BOARD_HORIZONTAL_DIRECTION);
   assert(move_get_equity(m) == PASS_MOVE_EQUITY);
 
-  move_list_destroy(ml);
+  move_destroy(m);
 }
 
 void test_move(void) {


### PR DESCRIPTION
Ran into this bug while trying to do autoplay sims. Without this fix two pass moves have a risk of being seen as nonequal depending on the value of the first byte of move->tiles