### PR TITLE
Add an execute_command_sync_silent() function.

### DIFF
--- a/src/impl/config.c
+++ b/src/impl/config.c
@@ -1932,10 +1932,18 @@ void config_load_command(Config *config, const char *cmd,
   string_splitter_destroy(cmd_split_string);
 }
 
-void config_execute_command(Config *config, ErrorStack *error_stack) {
+bool config_execute_command_silent(Config *config, ErrorStack *error_stack) {
   if (config_exec_parg_is_set(config)) {
     config_get_parg_exec_func(config, config->exec_parg_token)(config,
                                                                error_stack);
+    return true;
+  } else {
+    return false;
+  }
+}
+
+void config_execute_command(Config *config, ErrorStack *error_stack) {
+  if (config_execute_command_silent(config, error_stack)) {
     char *finished_msg = get_status_finished_str(config);
     thread_control_print(config_get_thread_control(config), finished_msg);
     free(finished_msg);

--- a/src/impl/config.h
+++ b/src/impl/config.h
@@ -30,6 +30,7 @@ void config_destroy(Config *config);
 void config_load_command(Config *config, const char *cmd,
                          ErrorStack *error_stack);
 void config_execute_command(Config *config, ErrorStack *error_stack);
+bool config_execute_command_silent(Config *config, ErrorStack *error_stack);
 char *config_get_execute_status(Config *config);
 bool config_continue_on_coldstart(const Config *config);
 

--- a/src/impl/exec.h
+++ b/src/impl/exec.h
@@ -7,6 +7,8 @@
 
 void execute_command_sync(Config *config, ErrorStack *error_stack,
                           const char *command);
+bool execute_command_sync_silent(Config *config, ErrorStack *error_stack,
+                                 const char *command);
 void execute_command_async(Config *config, ErrorStack *error_stack,
                            const char *command);
 char *command_search_status(Config *config, bool should_exit);


### PR DESCRIPTION
Like `execute_command_sync()`, but does not print the `finished` message. Useful for API usage, since we don't want to mix the command output and the finished status message together.