### PR TITLE
cache score/equity cutoff + skip playthru subrack init when nonplaythru

### DIFF
--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -235,7 +235,6 @@ gen_insert_spare_move_within_x_equity_of_best(MoveGen *gen,
     // The current move is better than the best move, so update the best move to
     // the current move
     gen->best_move_equity_or_score = move_equity_or_score;
-
     // Update the cutoff now that the best possible equity or score has improved
     gen_update_cutoff_equity_or_score(gen);
     cutoff_equity_or_score = gen_get_cutoff_equity_or_score(gen);

--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -217,7 +217,6 @@ static inline void gen_update_cutoff_equity_or_score(MoveGen *gen) {
   }
 }
 
-// Returns true if best_move_equity_or_score was adjusted, false otherwise.
 static inline void
 gen_insert_spare_move_within_x_equity_of_best(MoveGen *gen,
                                               Equity move_equity_or_score) {
@@ -244,7 +243,6 @@ gen_insert_spare_move_within_x_equity_of_best(MoveGen *gen,
            move_list_peek_equity(gen->move_list) < cutoff_equity_or_score) {
       move_list_pop_move(gen->move_list);
     }
-    return;
   }
 }
 

--- a/src/impl/move_gen.h
+++ b/src/impl/move_gen.h
@@ -51,6 +51,8 @@ typedef struct MoveGen {
   Move best_move_and_current_move[2];
   int best_move_index;
   Equity current_anchor_highest_possible_score;
+  // Updated every time a play is recorded
+  Equity cutoff_equity_or_score;
   // This field is only used for the MOVE_RECORD_WITHIN_X_EQUITY_OF_BEST
   // record type
   Equity best_move_equity_or_score;

--- a/src/impl/wmp_move_gen.h
+++ b/src/impl/wmp_move_gen.h
@@ -130,6 +130,11 @@ wmp_move_gen_playthrough_subracks_init(WMPMoveGen *wmp_move_gen,
   const int subrack_size = anchor->tiles_to_play;
   wmp_move_gen->word_length = anchor->word_length;
   wmp_move_gen->num_tiles_played_through = anchor->word_length - subrack_size;
+  wmp_move_gen->tiles_to_play = subrack_size;
+  if (wmp_move_gen->num_tiles_played_through == 0) {
+    // We can use nonplaythrough subracks
+    return;
+  }
   const int offset = subracks_get_combination_offset(subrack_size);
   const int count = wmp_move_gen->count_by_size[subrack_size];
   for (int idx_for_size = 0; idx_for_size < count; idx_for_size++) {
@@ -141,7 +146,6 @@ wmp_move_gen_playthrough_subracks_init(WMPMoveGen *wmp_move_gen,
     bit_rack_add_bit_rack(&playthrough_subrack_info->subrack,
                           &wmp_move_gen->playthrough_bit_rack);
   }
-  wmp_move_gen->tiles_to_play = subrack_size;
 }
 
 static inline bool


### PR DESCRIPTION
Two unrelated speedups. 

- Skip most playthrough_subracks_init for nonplaythrough anchors (it was just adding zeroes and making copies we never looked at)
- Instead of recomputing in gen_get_cutoff_equity_or_score every time better_play_has_been_found is called, cache the value which can only be modified when a play is recorded. This value is read much more often than it's written to, especially in wordmap_gen.

Overall speedup looks like 0.15% for nonwmp and 1.2% for wmp.

profiling below, base on left, #394 on right
<img width="1592" height="794" alt="Screenshot 2025-09-20 at 3 50 50 PM" src="https://github.com/user-attachments/assets/4ed9ea2c-05cc-4b2a-af39-e87576e4fc9f" />


