### PR TITLE
Fix one-ply sim to use equity instead of score

### DIFF
--- a/src/impl/random_variable.c
+++ b/src/impl/random_variable.c
@@ -420,8 +420,8 @@ double rv_sim_sample(RandomVariables *rvs, const uint64_t play_index,
   Equity leftover = 0;
   game_set_backup_mode(game, BACKUP_MODE_SIMULATION);
   // For one-ply sims, we need to account for the candidate move's leave value
-  Rack candidate_rack;
   if (plies == 1) {
+    Rack candidate_rack;
     const Player *player_on_turn =
         game_get_player(game, simmer->initial_player);
     rack_copy(&candidate_rack, player_get_rack(player_on_turn));

--- a/src/impl/random_variable.c
+++ b/src/impl/random_variable.c
@@ -419,6 +419,16 @@ double rv_sim_sample(RandomVariables *rvs, const uint64_t play_index,
 
   Equity leftover = 0;
   game_set_backup_mode(game, BACKUP_MODE_SIMULATION);
+  // For one-ply sims, we need to account for the candidate move's leave value
+  Rack candidate_rack;
+  if (plies == 1) {
+    const Player *player_on_turn =
+        game_get_player(game, simmer->initial_player);
+    rack_copy(&candidate_rack, player_get_rack(player_on_turn));
+    leftover += get_leave_value_for_move(player_get_klv(player_on_turn),
+                                         simmed_play_get_move(simmed_play),
+                                         &candidate_rack);
+  }
   // play move
   play_move(simmed_play_get_move(simmed_play), game, NULL);
   sim_results_increment_node_count(sim_results);


### PR DESCRIPTION
In one-ply simulations, the candidate move's leave value was not being accounted for, causing the sim to prefer moves with higher scores over moves with better equity (score + leave value).

For example, JIBERS (46 points keeping R) was incorrectly preferred over JIBER (44 points keeping RS) in one-ply sims.

The fix adds a special case: when plies == 1, calculate and include the candidate move's leave value in the leftover equity before playing the move. This ensures one-ply sims correctly evaluate equity rather than just score.

Multi-ply sims are unaffected as they already correctly account for leave values on the last two plies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)