### PR TITLE
Fix autoplay percentage display and column alignment

### DIFF
--- a/src/ent/autoplay_results.c
+++ b/src/ent/autoplay_results.c
@@ -277,8 +277,8 @@ char *game_data_human_readable_str(const GameData *gd, bool divergent) {
 
   for (int i = 0; i < NUMBER_OF_GAME_END_REASONS; i++) {
     string_builder_add_formatted_string(
-        sb, "Game End Reason %-*s %d (%2.2f%%%%)\n", 10,
-        game_end_reason_strs[i], gd->game_end_reasons[i],
+        sb, "Game End Reason %-*s %d (%2.2f%%)\n", 10, game_end_reason_strs[i],
+        gd->game_end_reasons[i],
         100 * ((double)gd->game_end_reasons[i] / (double)gd->total_games));
   }
 

--- a/src/util/string_util.c
+++ b/src/util/string_util.c
@@ -88,9 +88,9 @@ void string_builder_add_space_padded_string(StringBuilder *string_builder,
                                             size_t total_length) {
   // string is a format string potentially containing escape sequences, but must
   // have no arguments.
-  string_builder_add_string(string_builder, string);
   char *formatted_string = get_formatted_string(string);
   const size_t printed_length = strlen(formatted_string);
+  string_builder_add_string(string_builder, formatted_string);
   const size_t number_of_spaces =
       total_length > printed_length ? total_length - printed_length : 0;
   string_builder_add_spaces(string_builder, (int)number_of_spaces);


### PR DESCRIPTION
This fixes two issues in human-readable autoplay output:
1. Double percent signs (e.g., "50.00%%" instead of "50.00%")
2. Misaligned table columns

Root Cause:
The bug was introduced in PR #336 (commit 9c89846f, June 2025) which added string_builder_add_table_row() and helper functions to improve table formatting. The implementation had these issues:

- Helper functions returned strings with escaped %% (e.g., "50.00%%")
- string_builder_add_space_padded_string() added the raw escaped string to output, then calculated padding based on the formatted version, causing misalignment

The bug was hidden until PR #400 (commit e6dd3f02, Oct 2025) which fixed thread_control_print() to stop treating content as a format string. This exposed the underlying issue.

Solution:
1. Keep helper functions returning strings with %% escapes so they can be processed as format strings
2. Change string_builder_add_space_padded_string() to format the string BEFORE adding it (not after), ensuring the output matches the padding calculations

This ensures both correct % display and proper column alignment.