### PR TITLE
Add optimized move generation for MOVE_RECORD_ALL_SMALL

### DIFF
--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -40,8 +40,6 @@
 
 #define INITIAL_LAST_ANCHOR_COL (BOARD_DIM)
 
-bool move_gen_use_optimized_record_all_small = true;
-
 // Cache move generators since destroying
 // and recreating a movegen for
 // every request to generate moves would
@@ -2227,8 +2225,7 @@ void gen_record_pass(MoveGen *gen) {
 void generate_moves(const MoveGenArgs *args) {
   MoveGen *gen = get_movegen(args->thread_index);
   gen_load_position(gen, args);
-  if (gen->move_record_type == MOVE_RECORD_ALL_SMALL &&
-      move_gen_use_optimized_record_all_small) {
+  if (gen->move_record_type == MOVE_RECORD_ALL_SMALL) {
     gen_record_scoring_plays_small(gen);
   } else {
     gen_look_up_leaves_and_record_exchanges(gen);


### PR DESCRIPTION
## Summary                                                                                                                            
                                                                                                                                        
  This PR adds a specialized fast path for move generation when using `MOVE_RECORD_ALL_SMALL`, which is used by the endgame solver. The 
  optimization bypasses leave tracking, shadow generation, and WMP checks since these are not needed when solving endgames.             
                                                                                                                                        
  ## Changes                                                                                                                            
                                                                                                                                        
  - Add `recursive_gen_small()` and `go_on_small()` - specialized move generation functions that skip leave_map operations and track    
  rack state directly                                                                                                                   
  - Add `gen_record_scoring_plays_small()` - optimized entry point for scoring play generation                                          
  - Modify `generate_moves()` to use the fast path when `move_record_type == MOVE_RECORD_ALL_SMALL`                                     
                                                                                                                                        
  ## Benchmark Results                                                                                                                  
                                                                                                                                        
  | Benchmark | With Optimization | Without Optimization | Speedup |                                                                    
  |-----------|-------------------|----------------------|---------|                                                                    
  | 200 games, 4-ply | 451.5s (2.26s/game) | 485.1s (2.43s/game) | 7.4% |                                                               
  | 10 games, 5-ply | 31.7s (3.17s/game) | 35.2s (3.52s/game) | 9.9% |                                                                  
                                                                                                                                        
  ## Correctness                                                                                                                        
                                                                                                                                        
  - 200 games at 4-ply: all endgame values match ✓                                                                                      
  - 10 games at 5-ply: all endgame values match ✓                                                                                       
                                                                                                                                        
  ## Test Plan                                                                                                                          
                                                                                                                                        
  - movegen tests pass                                                                                                                  
  - endgame tests pass                                                                                                                  
  - Benchmark correctness verified across 210 endgame positions  