### PR TITLE
Fix WASM file loading broken by circular dependency fix

### DIFF
--- a/src/util/io_util.c
+++ b/src/util/io_util.c
@@ -435,8 +435,11 @@ void fseek_or_die(FILE *stream, long offset, int whence) {
   }
 }
 
+// Forward declaration to avoid circular dependency with fileproxy.h
+FILE *stream_from_filename(const char *filename, ErrorStack *error_stack);
+
 char *get_string_from_file(const char *filename, ErrorStack *error_stack) {
-  FILE *file_handle = fopen_safe(filename, "r", error_stack);
+  FILE *file_handle = stream_from_filename(filename, error_stack);
   if (!error_stack_is_empty(error_stack)) {
     return NULL;
   }


### PR DESCRIPTION
Problem:
Commit 113b399 broke WASM functionality. In that commit, get_string_from_file was moved from fileproxy.c to io_util.c and changed to call fopen_safe directly instead of stream_from_filename. This bypassed the file cache that WASM relies on - files are precached from JavaScript via precache_file_data and accessed through stream_from_filename's cache lookup.

Without the cache lookup, all file reads in WASM failed, causing worker threads to hang with status 0.

Solution:
Use a forward declaration of stream_from_filename in io_util.c to avoid circular dependencies while restoring the cache lookup behavior. This ensures:
- WASM builds use the file cache when files are precached
- Non-WASM builds work normally (cache is empty, falls back to fopen_safe)
- No circular dependencies (verified by find_circ_deps.py)