### PR TITLE
Update test callbacks and add eldar_v to test suite

### DIFF
--- a/test/test.c
+++ b/test/test.c
@@ -115,6 +115,7 @@ static TestEntry test_table[] = {
     {"wmg", test_wmp_move_gen},
     {"winpct", test_win_pct},
     {"endgame", test_endgame},
+    {"eldar_v", test_eldar_v_stick},
     {"zobrist", test_zobrist},
     {"tt", test_transposition_table},
     {"load", test_load_gcg},
@@ -149,7 +150,6 @@ static TestEntry on_demand_test_table[] = {
     {"multipv", test_multi_pv},
     {"14domino", test_14domino},
     {"kue14domino", test_kue14domino},
-    {"eldar", test_eldar_v_stick},
     {"monsterq", test_monster_q},
     {NULL, NULL} // Sentinel value to mark end of array
 };


### PR DESCRIPTION
## Summary
- Silence ranked moves in `print_pv_callback` (void the params)
- Add `print_pv_and_ranked_callback` for tests that want ranked output
- Change `test_eldar_v_stick` from 9-ply to 5-ply
- Add `eldar_v` to always-run unit test table (runs with `./run u`, separate from `test_endgame`)
- Update `test_14domino` to use ranked callback with `num_top_moves = 10`
- Rename on-demand table key from `"eldar"` to `"eldar_v"`

## Test plan
- [x] `make clean && make magpie_test BUILD=release` compiles with no warnings
- [x] `./bin/magpie_test endgame` passes (exit 0)
- [x] `./bin/magpie_test eldar_v` passes (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)