### PR TITLE
Fix negamax_depth corruption in multi-threaded endgame search

### DIFF
--- a/repro_x86_endgame_bug.sh
+++ b/repro_x86_endgame_bug.sh
@@ -3,9 +3,10 @@
 # https://github.com/jvc56/MAGPIE/pull/512#issuecomment-4230988203
 #
 # Bug: Intermittent negamax_depth corruption in multi_pvs[0] with
-#      multi-threaded release builds. Reported on Apple Silicon (macOS,
-#      Apple clang, -O3 -flto). This script tests whether it reproduces
-#      on the current platform.
+#      multi-threaded release builds. Originally reported on Apple Silicon
+#      (macOS, Apple clang, -O3 -flto). Confirmed to also reproduce on
+#      x86_64 Linux with clang 18 -O3 -flto. Does NOT reproduce with GCC.
+#      This is a clang-specific issue, not ARM-specific.
 #
 # Prerequisites:
 #   - release binary: make magpie BUILD=release
@@ -26,7 +27,7 @@ ERRORS=0
 
 echo "=== negamax_depth corruption repro test ==="
 echo "Platform: $(uname -m) / $(uname -s)"
-echo "Compiler: $(gcc --version 2>&1 | head -1)"
+echo "Compiler: $(cc --version 2>&1 | head -1)"
 echo "Binary: $BINARY"
 echo "Runs: $RUNS, Threads: $THREADS"
 echo ""

--- a/repro_x86_endgame_bug.sh
+++ b/repro_x86_endgame_bug.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Reproduction script for PR #512 negamax_depth corruption bug
+# https://github.com/jvc56/MAGPIE/pull/512#issuecomment-4230988203
+#
+# Bug: Intermittent negamax_depth corruption in multi_pvs[0] with
+#      multi-threaded release builds. Reported on Apple Silicon (macOS,
+#      Apple clang, -O3 -flto). This script tests whether it reproduces
+#      on the current platform.
+#
+# Prerequisites:
+#   - release binary: make magpie BUILD=release
+#   - data files: ./download_data.sh && ./convert_lexica.sh
+#
+# Usage:
+#   ./repro_x86_endgame_bug.sh [num_runs] [threads]
+#   Default: 50 runs, 4 threads
+
+set -euo pipefail
+
+RUNS=${1:-50}
+THREADS=${2:-4}
+BINARY=./bin/magpie
+CORRUPT=0
+CORRECT=0
+ERRORS=0
+
+echo "=== negamax_depth corruption repro test ==="
+echo "Platform: $(uname -m) / $(uname -s)"
+echo "Compiler: $(gcc --version 2>&1 | head -1)"
+echo "Binary: $BINARY"
+echo "Runs: $RUNS, Threads: $THREADS"
+echo ""
+
+for i in $(seq 1 "$RUNS"); do
+    OUTPUT=$(echo "set -s1 score -s2 score -eplies 7 -etopk 5 -threads $THREADS -mode sync -savesettings false
+cgp GATELEGs1POGOED/R4MOOLI3X1/AA10U2/YU4BREDRIN2/1TITULE3E1IN1/1E4N3c1BOK/1C2O4CHARD1/QI1FLAWN2E1OE1/IS2E1HIN1A1W2/1MOTIVATE1T1S2/1S2N5S4/3PERJURY5/15/15/15 FV/AADIZ 442/388 0 -lex CSW21
+endgame
+shendgame 1" | timeout 120 "$BINARY" 2>&1)
+
+    PV_LINE=$(echo "$OUTPUT" | grep '^PV 1' || true)
+    DEPTH=$(echo "$PV_LINE" | grep -oP 'depth: \K[0-9]+' || true)
+
+    if [ -z "$DEPTH" ]; then
+        echo "Run $i: ERROR - no PV 1 line found"
+        ERRORS=$((ERRORS + 1))
+    elif [ "$DEPTH" -gt 100 ]; then
+        echo "Run $i: CORRUPT | $PV_LINE"
+        CORRUPT=$((CORRUPT + 1))
+    else
+        echo "Run $i: OK | $PV_LINE"
+        CORRECT=$((CORRECT + 1))
+    fi
+done
+
+echo ""
+echo "=== Results ==="
+echo "Correct: $CORRECT / $RUNS"
+echo "Corrupt: $CORRUPT / $RUNS"
+echo "Errors:  $ERRORS / $RUNS"
+
+if [ "$CORRUPT" -gt 0 ]; then
+    echo "VERDICT: BUG REPRODUCES on this platform"
+    exit 1
+else
+    echo "VERDICT: Bug did NOT reproduce in $RUNS runs"
+    exit 0
+fi

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -1780,12 +1780,14 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
       return negamax_greedy_leaf_playout(worker, node_key, on_turn_idx,
                                          on_turn_spread, pv, opp_stuck_frac);
     }
+    pv->negamax_depth = 0;
     return on_turn_spread;
   }
 
   PVLine child_pv;
   child_pv.game = worker->game_copy;
   child_pv.num_moves = 0;
+  child_pv.negamax_depth = 0;
 
   int nplays;
   bool arena_alloced = false;
@@ -2342,6 +2344,7 @@ void iterative_deepening(EndgameCtxWorker *worker, int plies) {
     PVLine pv;
     pv.game = worker->game_copy;
     pv.num_moves = 0;
+    pv.negamax_depth = 0;
 
     int32_t val;
 


### PR DESCRIPTION
## Summary
Fixes intermittent corruption of `negamax_depth` field in PV lines during multi-threaded endgame search with clang optimizations (-O3 -flto). The issue manifested as depth values exceeding 100 in multi_pvs[0], causing incorrect search results.

## Root Cause
PVLine structures were not being properly initialized before use. When PVLine objects were created on the stack or reused across iterations, the `negamax_depth` field could retain stale values from previous operations or uninitialized memory, leading to corruption in multi-threaded contexts where race conditions could expose these uninitialized values.

## Changes
- **abdada_negamax()**: Initialize `pv->negamax_depth = 0` before returning early on leaf nodes, and initialize `child_pv.negamax_depth = 0` when creating child PV structures
- **iterative_deepening()**: Initialize `pv.negamax_depth = 0` when creating PV structures for each depth iteration

## Testing
Added `repro_x86_endgame_bug.sh` - a reproduction script that:
- Runs endgame search with multi-threading on a specific position
- Detects corruption by checking if depth exceeds 100
- Confirms the fix works across multiple runs
- Works on both ARM (Apple Silicon) and x86_64 platforms with clang

The bug was clang-specific (not ARM-specific) and did not reproduce with GCC, suggesting it was related to compiler optimizations and memory initialization rather than platform-specific issues.

https://claude.ai/code/session_0197nDAY6SniaQxqeTp9psW3