### PR TITLE
Add opening-rack static-evaluation sweep (J exchange-1 investigation)

### DIFF
--- a/OPENING_RACKS_REPORT.md
+++ b/OPENING_RACKS_REPORT.md
@@ -1,0 +1,143 @@
+# Opening-rack static-evaluation sweep (CSW21, MAGPIE)
+
+Every distinct 7-tile opening rack is enumerated; the top static-eval move is recorded (score + superleave value + MAGPIE's opening placement adjustment), plus the equity of the next-best move and the best exchange-1 play that keeps the J in the leave (for J-containing racks).
+
+Equity is expressed in millipoints in the TSV; this report renders it in points.
+
+- Total distinct 7-tile opening racks: **3,199,724**
+- Top-move breakdown:
+  - `tile`: 2,456,013
+  - `exch1`: 522
+  - `exch`: 743,189
+  - `pass`: 0
+- Racks containing a J: **611,253**; of those, racks where the top static play is an exchange-1 keeping the J: **0**.
+
+## Letter coverage: 6-tile leaves that contain each letter
+
+For every letter, how many opening racks have a top static play that is an **exchange-1** whose resulting 6-tile leave contains that letter. The Discord claim under investigation is that the J is the only letter with zero such racks.
+
+| letter | racks where the letter is kept by the optimal exchange-1 | best margin (pts) | best rack | best leave |
+|---|---|---|---|---|
+| A | 208 | 12.585 | ACEHQRS | ACEHRS |
+| B | 36 | 3.676 | ABELQRS | ABELRS |
+| C | 133 | 12.585 | ACEHQRS | ACEHRS |
+| D | 143 | 5.889 | DEEPQRS | DEEPRS |
+| E | 447 | 12.585 | ACEHQRS | ACEHRS |
+| F | 10 | 5.310 | EFFQRS? | EFFRS? |
+| G | 38 | 4.879 | AEGLNQS | AEGLNS |
+| H | 74 | 12.585 | ACEHQRS | ACEHRS |
+| I | 67 | 5.942 | CEHIJRS | CEHIRS |
+| J | 0 |  |  |  |
+| K | 27 | 4.606 | AEKNQRS | AEKNRS |
+| L | 163 | 7.080 | ACELPQS | ACELPS |
+| M | 80 | 5.821 | ADEMNQS | ADEMNS |
+| N | 161 | 5.821 | ADEMNQS | ADEMNS |
+| O | 176 | 8.197 | EHOQRST | EHORST |
+| P | 121 | 7.080 | ACELPQS | ACELPS |
+| Q | 11 | 4.844 | CHQSTUV | CHQSTU |
+| R | 248 | 12.585 | ACEHQRS | ACEHRS |
+| S | 397 | 12.585 | ACEHQRS | ACEHRS |
+| T | 114 | 8.197 | EHOQRST | EHORST |
+| U | 16 | 4.844 | CHQSTUV | CHQSTU |
+| V | 10 | 5.716 | EEOQRSV | EEORSV |
+| W | 13 | 4.363 | DEOQRSW | DEORSW |
+| X | 13 | 6.374 | EEPQSX? | EEPSX? |
+| Y | 14 | 2.264 | LOPQRY? | LOPRY? |
+| Z | 8 | 3.030 | ABOQRSZ | ABORSZ |
+| ? | 153 | 6.374 | EEPQSX? | EEPSX? |
+
+## Top 6-tile leaves ranked by number of racks that pick them
+
+Each row is a 6-tile leave that is the optimal exchange-1 leave on at least one opening rack. `racks` is how many opening racks choose it. `margin` columns are the gap above the next-best static move.
+
+| leave (kept) | tile exchanged | racks | min margin (pts) | mean margin (pts) | max margin (pts) | rack achieving max margin |
+|---|---|---|---|---|---|---|
+| EORSST | T | 3 | 0.205 | 1.538 | 4.205 | EOQRSST |
+| AGINRS | S | 3 | 2.163 | 2.514 | 2.689 | AGINRSS |
+| AEILNT | T | 3 | 0.247 | 0.409 | 0.506 | AEILNNT |
+| AEILNS | N | 3 | 0.190 | 0.639 | 0.890 | AEIILNS |
+| AEGILN | O | 3 | 0.149 | 0.512 | 0.849 | AAEGILN |
+| EFFRS? | V | 3 | 0.295 | 2.679 | 5.310 | EFFQRS? |
+| EOPSST | Q | 2 | 1.185 | 3.324 | 5.463 | EOPQSST |
+| ENORSS | Q | 2 | 0.181 | 1.628 | 3.075 | ENOQRSS |
+| EIPRSS | J | 2 | 0.176 | 2.278 | 4.380 | EIJPRSS |
+| EERSST | U | 2 | 0.763 | 2.763 | 4.763 | EEQRSST |
+| EELRST | R | 2 | 0.376 | 0.376 | 0.376 | EELRRST |
+| CHQSTU | V | 2 | 1.255 | 3.050 | 4.844 | CHQSTUV |
+| AINRST | R | 2 | 0.682 | 0.682 | 0.682 | AINRRST |
+| AGINST | S | 2 | 0.178 | 0.796 | 1.414 | AGINSST |
+| AGILNS | O | 2 | 0.273 | 1.450 | 2.628 | AGILLNS |
+| AELRSS | Q | 2 | 0.925 | 1.948 | 2.971 | AELQRSS |
+| AEGINR | U | 2 | 2.798 | 3.188 | 3.578 | AEGINRU |
+| AEGINS | I | 2 | 0.190 | 0.232 | 0.274 | AEGIINS |
+| ADERST | U | 2 | 0.434 | 0.602 | 0.771 | ADERSTU |
+| ADENRS | Q | 2 | 0.297 | 0.634 | 0.970 | ADENQRS |
+| ADEINS | U | 2 | 0.312 | 1.234 | 2.155 | ADEINSU |
+| ABELMS | V | 2 | 0.849 | 2.105 | 3.361 | ABELMQS |
+| EIQSU? | W | 2 | 0.228 | 0.528 | 0.827 | EIJQSU? |
+| CEMPS? | V | 2 | 1.014 | 1.014 | 1.014 | CEMPSV? |
+| BELMS? | V | 2 | 0.211 | 1.391 | 2.571 | BELMQS? |
+| OPRSST | Q | 1 | 0.258 | 0.258 | 0.258 | OPQRSST |
+| GINORS | R | 1 | 0.158 | 0.158 | 0.158 | GINORRS |
+| GIILNS | I | 1 | 1.511 | 1.511 | 1.511 | GIIILNS |
+| GHILNS | V | 1 | 0.243 | 0.243 | 0.243 | GHILNSV |
+| EPRSST | Q | 1 | 1.520 | 1.520 | 1.520 | EPQRSST |
+| EOPSSS | Q | 1 | 0.033 | 0.033 | 0.033 | EOPQSSS |
+| EOPRST | Q | 1 | 6.406 | 6.406 | 6.406 | EOPQRST |
+| EOPRSS | Q | 1 | 6.207 | 6.207 | 6.207 | EOPQRSS |
+| EOPPRS | Q | 1 | 4.263 | 4.263 | 4.263 | EOPPQRS |
+| ENOSST | Q | 1 | 3.641 | 3.641 | 3.641 | ENOQSST |
+| ENORST | Q | 1 | 2.604 | 2.604 | 2.604 | ENOQRST |
+| ENOPST | Q | 1 | 0.191 | 0.191 | 0.191 | ENOPQST |
+| ENOPRS | Q | 1 | 1.575 | 1.575 | 1.575 | ENOPQRS |
+| EMOSST | Q | 1 | 2.592 | 2.592 | 2.592 | EMOQSST |
+| EMORST | Q | 1 | 3.261 | 3.261 | 3.261 | EMOQRST |
+| EMORSS | Q | 1 | 1.595 | 1.595 | 1.595 | EMOQRSS |
+| EMNOST | Q | 1 | 5.532 | 5.532 | 5.532 | EMNOQST |
+| EMNORS | Q | 1 | 3.071 | 3.071 | 3.071 | EMNOQRS |
+| ELOSST | Q | 1 | 2.359 | 2.359 | 2.359 | ELOQSST |
+| ELORSS | Q | 1 | 2.906 | 2.906 | 2.906 | ELOQRSS |
+| ELOPST | Q | 1 | 0.233 | 0.233 | 0.233 | ELOPQST |
+| ELOPSS | Q | 1 | 1.987 | 1.987 | 1.987 | ELOPQSS |
+| ELOPRS | Q | 1 | 1.381 | 1.381 | 1.381 | ELOPQRS |
+| ELOPPS | Q | 1 | 0.396 | 0.396 | 0.396 | ELOPPQS |
+| ELNOSS | Q | 1 | 0.551 | 0.551 | 0.551 | ELNOQSS |
+
+_(showing top 50 of 491 distinct leaves)_
+
+## J nearest miss
+
+Racks containing a J, sorted by the smallest equity gap between the top static play and the best **exchange-1** play that trades a non-J tile (keeping J in the 6-tile leave). Lower `miss` = closer the J-keeping exchange-1 comes to being optimal.
+
+| rack | top move | top eq (pts) | best exch1 keeping J | exch1 leave | exch1 eq (pts) | miss (pts) |
+|---|---|---|---|---|---|---|
+| CCEJR?? | (exch CJ) | 44.670 | (exch C) | CEJR?? | 43.517 | 1.153 |
+| CEJNOQ? | (exch JQ) | 35.358 | (exch Q) | CEJNO? | 34.133 | 1.225 |
+| CDEJQ?? | (exch JQ) | 44.760 | (exch Q) | CDEJ?? | 43.188 | 1.572 |
+| CCDEJ?? | (exch CJ) | 44.760 | (exch C) | CDEJ?? | 43.188 | 1.572 |
+| CJQRS?? | (exch JQ) | 43.578 | (exch Q) | CJRS?? | 41.840 | 1.738 |
+| CCJRS?? | (exch CJ) | 43.578 | (exch C) | CJRS?? | 41.840 | 1.738 |
+| CCIJR?? | (exch CJ) | 43.052 | (exch C) | CIJR?? | 41.230 | 1.822 |
+| FJQRS?? | (exch JQ) | 42.425 | (exch Q) | FJRS?? | 40.313 | 2.112 |
+| EJQTV?? | (exch JV) | 42.523 | (exch V) | EJQT?? | 40.354 | 2.169 |
+| CCJST?? | (exch CJT) | 43.273 | (exch C) | CJST?? | 41.035 | 2.238 |
+| CEJQY?? | 8E QuEY | 45.740 | (exch Q) | CEJY?? | 43.452 | 2.288 |
+| GJNQR?? | (exch GJNQ) | 37.753 | (exch Q) | GJNR?? | 35.456 | 2.297 |
+| CJMSV?? | (exch CJV) | 43.711 | (exch V) | CJMS?? | 41.328 | 2.383 |
+| CJSTV?? | 8D JiVeST | 43.521 | (exch V) | CJST?? | 41.035 | 2.486 |
+| CEJMQ?? | (exch JQ) | 43.356 | (exch Q) | CEJM?? | 40.789 | 2.567 |
+| CEJPQ?? | (exch JQ) | 44.003 | (exch Q) | CEJP?? | 41.405 | 2.598 |
+| EGJNQ?? | (exch GQ) | 42.110 | (exch Q) | EGJN?? | 39.500 | 2.610 |
+| CCEJS?? | 8D JuiCE | 47.935 | (exch C) | CEJS?? | 45.305 | 2.630 |
+| CEJQST? | 8D QuEST | 40.058 | (exch Q) | CEJST? | 37.424 | 2.634 |
+| CJQST?? | 8G QaT | 43.685 | (exch Q) | CJST?? | 41.035 | 2.650 |
+| FJSTV?? | (exch FTV) | 41.394 | (exch V) | FJST?? | 38.718 | 2.676 |
+| CJNSV?? | (exch JNV) | 43.273 | (exch V) | CJNS?? | 40.553 | 2.720 |
+| CFJNS?? | (exch FJN) | 43.273 | (exch F) | CJNS?? | 40.553 | 2.720 |
+| CFJRS?? | 8H SCaRF | 44.681 | (exch F) | CJRS?? | 41.840 | 2.841 |
+| DGJNQ?? | (exch GJNQ) | 37.693 | (exch Q) | DGJN?? | 34.851 | 2.842 |
+| JLQSY?? | (exch JLQ) | 44.278 | (exch Q) | JLSY?? | 41.267 | 3.011 |
+| EJMNQ?? | 8D QuEMe | 44.269 | (exch Q) | EJMN?? | 41.234 | 3.035 |
+| AJNQSX? | (exch JQX) | 34.766 | (exch Q) | AJNSX? | 31.710 | 3.056 |
+| JNOQSX? | (exch JQX) | 33.267 | (exch Q) | JNOSX? | 30.184 | 3.083 |
+| GJNQW?? | (exch GJNQW) | 37.559 | (exch Q) | GJNW?? | 34.460 | 3.099 |

--- a/test/opening_racks_test.c
+++ b/test/opening_racks_test.c
@@ -1,0 +1,351 @@
+#include "opening_racks_test.h"
+
+#include "../src/def/equity_defs.h"
+#include "../src/def/game_history_defs.h"
+#include "../src/def/letter_distribution_defs.h"
+#include "../src/def/move_defs.h"
+#include "../src/def/rack_defs.h"
+#include "../src/def/thread_control_defs.h"
+#include "../src/ent/equity.h"
+#include "../src/ent/game.h"
+#include "../src/ent/letter_distribution.h"
+#include "../src/ent/move.h"
+#include "../src/ent/rack.h"
+#include "../src/ent/thread_control.h"
+#include "../src/impl/config.h"
+#include "../src/impl/gameplay.h"
+#include "../src/impl/move_gen.h"
+#include "../src/str/letter_distribution_string.h"
+#include "../src/str/move_string.h"
+#include "../src/str/rack_string.h"
+#include "../src/util/io_util.h"
+#include "../src/util/string_util.h"
+#include "test_util.h"
+#include <assert.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static void exec_config_quiet(Config *config, const char *cmd) {
+  (void)fflush(stdout);
+  int saved_stdout = fcntl(STDOUT_FILENO, F_DUPFD_CLOEXEC, 0);
+  int devnull = open("/dev/null", O_WRONLY | O_CLOEXEC);
+  (void)dup2(devnull, STDOUT_FILENO);
+  close(devnull);
+
+  ErrorStack *error_stack = error_stack_create();
+  thread_control_set_status(config_get_thread_control(config),
+                            THREAD_CONTROL_STATUS_STARTED);
+  config_load_command(config, cmd, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  config_execute_command(config, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  error_stack_destroy(error_stack);
+  thread_control_set_status(config_get_thread_control(config),
+                            THREAD_CONTROL_STATUS_FINISHED);
+
+  (void)fflush(stdout);
+  (void)dup2(saved_stdout, STDOUT_FILENO);
+  close(saved_stdout);
+}
+
+typedef struct OpeningRackCtx {
+  Game *game;
+  MoveList *move_list;
+  const LetterDistribution *ld;
+  int ld_size;
+  MachineLetter j_ml;
+  FILE *fp;
+  uint64_t racks_processed;
+} OpeningRackCtx;
+
+static void rack_to_cstr(const Rack *rack, const LetterDistribution *ld,
+                         char *out, size_t out_size) {
+  StringBuilder *sb = string_builder_create();
+  string_builder_add_rack(sb, rack, ld, false);
+  const char *s = string_builder_peek(sb);
+  size_t len = strlen(s);
+  if (len >= out_size) {
+    len = out_size - 1;
+  }
+  memcpy(out, s, len);
+  out[len] = '\0';
+  string_builder_destroy(sb);
+}
+
+static void move_to_cstr(const Move *move, const Game *game, char *out,
+                         size_t out_size) {
+  StringBuilder *sb = string_builder_create();
+  string_builder_add_move(sb, game_get_board(game), move, game_get_ld(game),
+                          false);
+  const char *s = string_builder_peek(sb);
+  size_t len = strlen(s);
+  if (len >= out_size) {
+    len = out_size - 1;
+  }
+  memcpy(out, s, len);
+  out[len] = '\0';
+  string_builder_destroy(sb);
+}
+
+static void move_leave_to_cstr(const Rack *rack, const Move *move,
+                               const LetterDistribution *ld, char *out,
+                               size_t out_size) {
+  StringBuilder *sb = string_builder_create();
+  string_builder_add_move_leave(sb, rack, move, ld);
+  const char *s = string_builder_peek(sb);
+  size_t len = strlen(s);
+  if (len >= out_size) {
+    len = out_size - 1;
+  }
+  memcpy(out, s, len);
+  out[len] = '\0';
+  string_builder_destroy(sb);
+}
+
+// Classify top move.
+typedef enum {
+  OPENING_TOP_TILE_PLACEMENT,
+  OPENING_TOP_EXCH1,
+  OPENING_TOP_EXCH_MULTI,
+  OPENING_TOP_PASS,
+} opening_top_kind_t;
+
+static opening_top_kind_t classify_move(const Move *m) {
+  switch (move_get_type(m)) {
+  case GAME_EVENT_EXCHANGE:
+    return move_get_tiles_played(m) == 1 ? OPENING_TOP_EXCH1
+                                         : OPENING_TOP_EXCH_MULTI;
+  case GAME_EVENT_PASS:
+    return OPENING_TOP_PASS;
+  default:
+    return OPENING_TOP_TILE_PLACEMENT;
+  }
+}
+
+static const char *top_kind_str(opening_top_kind_t kind) {
+  switch (kind) {
+  case OPENING_TOP_TILE_PLACEMENT:
+    return "tile";
+  case OPENING_TOP_EXCH1:
+    return "exch1";
+  case OPENING_TOP_EXCH_MULTI:
+    return "exch";
+  case OPENING_TOP_PASS:
+    return "pass";
+  }
+  return "?";
+}
+
+// Returns the machine letter that an exchange-1 move trades.
+static MachineLetter exch1_tile(const Move *m) {
+  MachineLetter t = move_get_tile(m, 0);
+  if (get_is_blanked(t)) {
+    return BLANK_MACHINE_LETTER;
+  }
+  return t;
+}
+
+static void ml_to_cstr(const LetterDistribution *ld, MachineLetter ml,
+                       char *out, size_t out_size) {
+  StringBuilder *sb = string_builder_create();
+  string_builder_add_user_visible_letter(sb, ld, ml);
+  const char *s = string_builder_peek(sb);
+  size_t len = strlen(s);
+  if (len >= out_size) {
+    len = out_size - 1;
+  }
+  memcpy(out, s, len);
+  out[len] = '\0';
+  string_builder_destroy(sb);
+}
+
+static void process_opening_rack(OpeningRackCtx *ctx, const Rack *rack) {
+  Game *game = ctx->game;
+  MoveList *move_list = ctx->move_list;
+
+  draw_rack_from_bag(game, 0, rack);
+
+  const MoveGenArgs args = {.game = game,
+                            .move_list = move_list,
+                            .move_record_type = MOVE_RECORD_ALL,
+                            .move_sort_type = MOVE_SORT_EQUITY,
+                            .override_kwg = NULL,
+                            .thread_index = 0,
+                            .eq_margin_movegen = 0,
+                            .target_equity = EQUITY_MAX_VALUE,
+                            .target_leave_size_for_exchange_cutoff =
+                                UNSET_LEAVE_SIZE};
+  generate_moves(&args);
+  move_list_sort_moves(move_list);
+
+  const int count = move_list_get_count(move_list);
+  assert(count >= 1);
+
+  const Move *top = move_list_get_move(move_list, 0);
+  const Equity top_eq = move_get_equity(top);
+  const Equity next_eq = count >= 2
+                             ? move_get_equity(move_list_get_move(move_list, 1))
+                             : EQUITY_MIN_VALUE;
+
+  char rack_str[32];
+  char top_move_str[128];
+  char top_leave_str[32];
+  char top_exch_tile_str[8] = "";
+  rack_to_cstr(rack, ctx->ld, rack_str, sizeof(rack_str));
+  move_to_cstr(top, game, top_move_str, sizeof(top_move_str));
+  move_leave_to_cstr(rack, top, ctx->ld, top_leave_str, sizeof(top_leave_str));
+
+  const opening_top_kind_t top_kind = classify_move(top);
+  if (top_kind == OPENING_TOP_EXCH1) {
+    ml_to_cstr(ctx->ld, exch1_tile(top), top_exch_tile_str,
+               sizeof(top_exch_tile_str));
+  }
+
+  const bool rack_has_j = rack_get_letter(rack, ctx->j_ml) > 0;
+
+  // Among all exchange-1 moves whose exchanged tile is NOT J, find the best
+  // one (highest equity). Its leave keeps the J and is the 6-tile leave for
+  // the "nearest miss" computation.
+  Equity j_exch1_keep_eq = EQUITY_MIN_VALUE;
+  char j_exch1_keep_leave_str[32] = "";
+  char j_exch1_keep_tile_str[8] = "";
+  if (rack_has_j) {
+    for (int i = 0; i < count; i++) {
+      const Move *m = move_list_get_move(move_list, i);
+      if (classify_move(m) != OPENING_TOP_EXCH1) {
+        continue;
+      }
+      if (exch1_tile(m) == ctx->j_ml) {
+        continue;
+      }
+      j_exch1_keep_eq = move_get_equity(m);
+      move_leave_to_cstr(rack, m, ctx->ld, j_exch1_keep_leave_str,
+                         sizeof(j_exch1_keep_leave_str));
+      ml_to_cstr(ctx->ld, exch1_tile(m), j_exch1_keep_tile_str,
+                 sizeof(j_exch1_keep_tile_str));
+      break;
+    }
+  }
+
+  const int64_t top_eq_v = (int64_t)top_eq;
+  const int64_t next_eq_v = (int64_t)next_eq;
+  const int64_t margin_v = top_eq_v - next_eq_v;
+
+  // TSV columns:
+  //  1. rack
+  //  2. top_move
+  //  3. top_eq
+  //  4. top_kind (tile|exch1|exch|pass)
+  //  5. top_exch_tile (exchanged letter if exch1)
+  //  6. top_leave
+  //  7. next_eq
+  //  8. margin  (= top_eq - next_eq)
+  //  9. j_exch1_keep_eq  (empty if rack has no J or no valid move)
+  // 10. j_exch1_keep_tile
+  // 11. j_exch1_keep_leave
+  // 12. j_miss_margin  (= top_eq - j_exch1_keep_eq)
+  if (rack_has_j && j_exch1_keep_eq != EQUITY_MIN_VALUE) {
+    const int64_t j_eq_v = (int64_t)j_exch1_keep_eq;
+    const int64_t j_miss_v = top_eq_v - j_eq_v;
+    (void)fprintf(ctx->fp,
+                  "%s\t%s\t%" PRId64 "\t%s\t%s\t%s\t%" PRId64 "\t%" PRId64
+                  "\t%" PRId64 "\t%s\t%s\t%" PRId64 "\n",
+                  rack_str, top_move_str, top_eq_v, top_kind_str(top_kind),
+                  top_exch_tile_str, top_leave_str, next_eq_v, margin_v, j_eq_v,
+                  j_exch1_keep_tile_str, j_exch1_keep_leave_str, j_miss_v);
+  } else {
+    (void)fprintf(ctx->fp,
+                  "%s\t%s\t%" PRId64 "\t%s\t%s\t%s\t%" PRId64 "\t%" PRId64
+                  "\t\t\t\t\n",
+                  rack_str, top_move_str, top_eq_v, top_kind_str(top_kind),
+                  top_exch_tile_str, top_leave_str, next_eq_v, margin_v);
+  }
+
+  return_rack_to_bag(game, 0);
+  ctx->racks_processed++;
+  if (ctx->racks_processed % 100000 == 0) {
+    (void)fprintf(stderr, "  processed %" PRIu64 " racks\n",
+                  ctx->racks_processed);
+    (void)fflush(stderr);
+  }
+}
+
+static void enumerate_racks(OpeningRackCtx *ctx, Rack *rack, MachineLetter ml) {
+  while (ml < ctx->ld_size &&
+         ld_get_dist(ctx->ld, ml) - rack_get_letter(rack, ml) == 0) {
+    ml++;
+  }
+  const int total = rack_get_total_letters(rack);
+  if (ml == ctx->ld_size) {
+    if (total == (RACK_SIZE)) {
+      process_opening_rack(ctx, rack);
+    }
+    return;
+  }
+  // Option A: add no more of this letter; advance.
+  enumerate_racks(ctx, rack, ml + 1);
+
+  int max_add = ld_get_dist(ctx->ld, ml) - (int)rack_get_letter(rack, ml);
+  const int remaining_capacity = (RACK_SIZE)-total;
+  if (max_add > remaining_capacity) {
+    max_add = remaining_capacity;
+  }
+  for (int i = 0; i < max_add; i++) {
+    rack_add_letter(rack, ml);
+    enumerate_racks(ctx, rack, ml + 1);
+  }
+  rack_take_letters(rack, ml, max_add);
+}
+
+void test_opening_racks_static_eval(void) {
+  log_set_level(LOG_FATAL);
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -wmp true -s1 equity -s2 equity -r1 all -r2 all "
+      "-numplays 10000 -threads 1");
+
+  exec_config_quiet(config, "new");
+  Game *game = config_get_game(config);
+  const LetterDistribution *ld = game_get_ld(game);
+  const int ld_size = ld_get_size(ld);
+
+  MoveList *move_list = move_list_create(10000);
+
+  // Clear any randomly-drawn starting rack so the bag is full.
+  return_rack_to_bag(game, 0);
+  return_rack_to_bag(game, 1);
+
+  const char *outfile = "/tmp/opening_racks.tsv";
+  FILE *fp = fopen(outfile, "we");
+  assert(fp);
+  (void)fprintf(fp, "rack\ttop_move\ttop_eq\ttop_kind\ttop_exch_tile\ttop_leave"
+                    "\tnext_eq\tmargin"
+                    "\tj_exch1_keep_eq\tj_exch1_keep_tile\tj_exch1_keep_leave"
+                    "\tj_miss_margin\n");
+
+  OpeningRackCtx ctx = {.game = game,
+                        .move_list = move_list,
+                        .ld = ld,
+                        .ld_size = ld_size,
+                        .j_ml = ld_hl_to_ml(ld, "J"),
+                        .fp = fp,
+                        .racks_processed = 0};
+
+  Rack rack;
+  rack_set_dist_size_and_reset(&rack, ld_size);
+  enumerate_racks(&ctx, &rack, 0);
+
+  (void)fclose(fp);
+
+  (void)fprintf(stderr, "\nopening_racks: %" PRIu64 " racks written to %s\n",
+                ctx.racks_processed, outfile);
+  (void)fflush(stderr);
+
+  move_list_destroy(move_list);
+  config_destroy(config);
+}

--- a/test/opening_racks_test.h
+++ b/test/opening_racks_test.h
@@ -1,0 +1,6 @@
+#ifndef OPENING_RACKS_TEST_H
+#define OPENING_RACKS_TEST_H
+
+void test_opening_racks_static_eval(void);
+
+#endif

--- a/test/test.c
+++ b/test/test.c
@@ -37,6 +37,7 @@
 #include "math_util_test.h"
 #include "move_gen_test.h"
 #include "move_test.h"
+#include "opening_racks_test.h"
 #include "players_data_test.h"
 #include "rack_list_test.h"
 #include "rack_test.h"
@@ -136,6 +137,7 @@ static TestEntry on_demand_test_table[] = {
     {"multipv", test_multi_pv},
     {"kue", test_kue},
     {"monsterq", test_monster_q},
+    {"openracks", test_opening_racks_static_eval},
     {NULL, NULL} // Sentinel value to mark end of array
 };
 

--- a/tools/opening_racks_report.py
+++ b/tools/opening_racks_report.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""Build Markdown tables summarising the opening-rack static eval sweep.
+
+Reads /tmp/opening_racks.tsv (the TSV produced by
+`./bin/magpie_test openracks`) and writes OPENING_RACKS_REPORT.md.
+
+Equity is in millipoints (Equity units in MAGPIE). 42 points = 42000.
+This script renders millipoints as points (millipoints / 1000).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import mean
+from typing import Iterator
+
+
+@dataclass
+class Row:
+    rack: str
+    top_move: str
+    top_eq: int
+    top_kind: str
+    top_exch_tile: str
+    top_leave: str
+    next_eq: int
+    margin: int
+    j_exch1_keep_eq: int | None
+    j_exch1_keep_tile: str
+    j_exch1_keep_leave: str
+    j_miss_margin: int | None
+
+
+def mp_to_points(mp: int | None) -> str:
+    if mp is None:
+        return ""
+    return f"{mp / 1000:.3f}"
+
+
+def iter_rows(path: Path) -> Iterator[Row]:
+    with path.open() as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        for r in reader:
+            j_eq = r["j_exch1_keep_eq"]
+            j_miss = r["j_miss_margin"]
+            yield Row(
+                rack=r["rack"],
+                top_move=r["top_move"],
+                top_eq=int(r["top_eq"]),
+                top_kind=r["top_kind"],
+                top_exch_tile=r["top_exch_tile"],
+                top_leave=r["top_leave"],
+                next_eq=int(r["next_eq"]),
+                margin=int(r["margin"]),
+                j_exch1_keep_eq=int(j_eq) if j_eq else None,
+                j_exch1_keep_tile=r["j_exch1_keep_tile"],
+                j_exch1_keep_leave=r["j_exch1_keep_leave"],
+                j_miss_margin=int(j_miss) if j_miss else None,
+            )
+
+
+def build_leave_ranking(rows: list[Row]) -> list[dict]:
+    """For each 6-tile leave that is ever the optimal exchange-1 leave, compute
+    aggregates over the racks that select it."""
+    buckets: dict[str, dict] = defaultdict(
+        lambda: {
+            "racks": 0,
+            "margins": [],
+            "tile": "",
+            "example_rack": "",
+            "max_margin_rack": "",
+            "max_margin": -1,
+        }
+    )
+    for row in rows:
+        if row.top_kind != "exch1":
+            continue
+        leave = row.top_leave
+        b = buckets[leave]
+        b["racks"] += 1
+        b["margins"].append(row.margin)
+        if not b["tile"]:
+            b["tile"] = row.top_exch_tile
+            b["example_rack"] = row.rack
+        if row.margin > b["max_margin"]:
+            b["max_margin"] = row.margin
+            b["max_margin_rack"] = row.rack
+
+    out = []
+    for leave, b in buckets.items():
+        ms = b["margins"]
+        out.append(
+            {
+                "leave": leave,
+                "tile": b["tile"],
+                "racks": b["racks"],
+                "min_margin_mp": min(ms),
+                "max_margin_mp": max(ms),
+                "mean_margin_mp": int(round(mean(ms))),
+                "max_margin_rack": b["max_margin_rack"],
+            }
+        )
+    return out
+
+
+def kept_letters(leave: str) -> set[str]:
+    """Machine letters appearing in a leave string (one char per ml)."""
+    return set(leave)
+
+
+def build_letter_coverage(rows: list[Row]) -> list[dict]:
+    """For each letter A-Z + blank, count opening racks where the top move is
+    an exchange-1 that keeps that letter in its 6-tile leave."""
+    counts: dict[str, int] = defaultdict(int)
+    examples: dict[str, tuple[int, str, str]] = {}
+    for row in rows:
+        if row.top_kind != "exch1":
+            continue
+        for ch in kept_letters(row.top_leave):
+            counts[ch] += 1
+            cur = examples.get(ch)
+            if cur is None or row.margin > cur[0]:
+                examples[ch] = (row.margin, row.rack, row.top_leave)
+
+    alphabet = list("ABCDEFGHIJKLMNOPQRSTUVWXYZ") + ["?"]
+    out = []
+    for ch in alphabet:
+        ex = examples.get(ch, (0, "", ""))
+        out.append(
+            {
+                "letter": ch,
+                "racks_where_kept_as_optimal_exch1_leave": counts.get(ch, 0),
+                "best_margin_mp": ex[0] if ch in examples else None,
+                "best_rack": ex[1],
+                "best_leave": ex[2],
+            }
+        )
+    return out
+
+
+def build_j_nearest_miss(rows: list[Row], limit: int = 50) -> list[Row]:
+    """Racks with a J, sorted by how close the best J-keeping exchange-1 comes
+    to the top play (smaller miss = closer).
+
+    Excludes racks where the top play itself already keeps J on an exchange-1
+    (there the miss would be zero and the question doesn't apply)."""
+    candidates = [
+        r
+        for r in rows
+        if r.j_miss_margin is not None and r.j_miss_margin > 0
+    ]
+    candidates.sort(key=lambda r: r.j_miss_margin)
+    return candidates[:limit]
+
+
+def count_j_top_exch1_keeps(rows: list[Row]) -> tuple[int, int]:
+    """Sanity check: how many racks with J have the top play being an
+    exchange-1 that keeps J? Expected: 0 (the claim under investigation)."""
+    j_racks = 0
+    j_top_keeps = 0
+    for row in rows:
+        if row.j_exch1_keep_eq is None and "J" not in row.rack:
+            continue
+        if "J" in row.rack:
+            j_racks += 1
+            if row.top_kind == "exch1" and "J" in row.top_leave:
+                j_top_keeps += 1
+    return j_racks, j_top_keeps
+
+
+def markdown_table(headers: list[str], rows: list[list[str]]) -> str:
+    def cell(v):
+        if v is None:
+            return ""
+        return str(v)
+
+    out = [
+        "| " + " | ".join(headers) + " |",
+        "|" + "|".join("---" for _ in headers) + "|",
+    ]
+    for row in rows:
+        out.append("| " + " | ".join(cell(v) for v in row) + " |")
+    return "\n".join(out)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--tsv", type=Path, default=Path("/tmp/opening_racks.tsv")
+    )
+    parser.add_argument(
+        "--out", type=Path, default=Path("OPENING_RACKS_REPORT.md")
+    )
+    parser.add_argument("--near-miss-limit", type=int, default=50)
+    parser.add_argument("--leave-table-limit", type=int, default=50)
+    args = parser.parse_args()
+
+    if not args.tsv.exists():
+        print(f"missing input: {args.tsv}", file=sys.stderr)
+        return 2
+
+    rows = list(iter_rows(args.tsv))
+    total = len(rows)
+
+    # Top-level counts.
+    top_kind_counts: dict[str, int] = defaultdict(int)
+    for r in rows:
+        top_kind_counts[r.top_kind] += 1
+
+    j_racks, j_top_keeps = count_j_top_exch1_keeps(rows)
+
+    # Table: letter coverage.
+    letter_rows = build_letter_coverage(rows)
+
+    # Table: 6-tile leaves that are optimal exchange-1 leaves.
+    leave_ranking = build_leave_ranking(rows)
+    leave_ranking.sort(key=lambda d: d["racks"], reverse=True)
+
+    # Nearest-miss J table.
+    near_miss = build_j_nearest_miss(rows, limit=args.near_miss_limit)
+
+    lines: list[str] = []
+    lines.append("# Opening-rack static-evaluation sweep (CSW21, MAGPIE)")
+    lines.append("")
+    lines.append(
+        "Every distinct 7-tile opening rack is enumerated; the top static-eval "
+        "move is recorded (score + superleave value + MAGPIE's opening placement "
+        "adjustment), plus the equity of the next-best move and the best "
+        "exchange-1 play that keeps the J in the leave (for J-containing racks)."
+    )
+    lines.append("")
+    lines.append(
+        "Equity is expressed in millipoints in the TSV; this report renders it "
+        "in points."
+    )
+    lines.append("")
+    lines.append(f"- Total distinct 7-tile opening racks: **{total:,}**")
+    lines.append("- Top-move breakdown:")
+    for kind in ("tile", "exch1", "exch", "pass"):
+        n = top_kind_counts.get(kind, 0)
+        lines.append(f"  - `{kind}`: {n:,}")
+    lines.append(
+        f"- Racks containing a J: **{j_racks:,}**; of those, racks where the "
+        f"top static play is an exchange-1 keeping the J: **{j_top_keeps:,}**."
+    )
+    lines.append("")
+
+    # Section 1: letter coverage.
+    lines.append("## Letter coverage: 6-tile leaves that contain each letter")
+    lines.append("")
+    lines.append(
+        "For every letter, how many opening racks have a top static play that "
+        "is an **exchange-1** whose resulting 6-tile leave contains that letter. "
+        "The Discord claim under investigation is that the J is the only letter "
+        "with zero such racks."
+    )
+    lines.append("")
+    lines.append(
+        markdown_table(
+            [
+                "letter",
+                "racks where the letter is kept by the optimal exchange-1",
+                "best margin (pts)",
+                "best rack",
+                "best leave",
+            ],
+            [
+                [
+                    r["letter"],
+                    f"{r['racks_where_kept_as_optimal_exch1_leave']:,}",
+                    mp_to_points(r["best_margin_mp"]),
+                    r["best_rack"],
+                    r["best_leave"],
+                ]
+                for r in letter_rows
+            ],
+        )
+    )
+    lines.append("")
+
+    # Section 2: leave ranking.
+    lines.append("## Top 6-tile leaves ranked by number of racks that pick them")
+    lines.append("")
+    lines.append(
+        "Each row is a 6-tile leave that is the optimal exchange-1 leave on at "
+        "least one opening rack. `racks` is how many opening racks choose it. "
+        "`margin` columns are the gap above the next-best static move."
+    )
+    lines.append("")
+    k = args.leave_table_limit
+    top_k = leave_ranking[:k]
+    lines.append(
+        markdown_table(
+            [
+                "leave (kept)",
+                "tile exchanged",
+                "racks",
+                "min margin (pts)",
+                "mean margin (pts)",
+                "max margin (pts)",
+                "rack achieving max margin",
+            ],
+            [
+                [
+                    r["leave"],
+                    r["tile"],
+                    f"{r['racks']:,}",
+                    mp_to_points(r["min_margin_mp"]),
+                    mp_to_points(r["mean_margin_mp"]),
+                    mp_to_points(r["max_margin_mp"]),
+                    r["max_margin_rack"],
+                ]
+                for r in top_k
+            ],
+        )
+    )
+    lines.append("")
+    if len(leave_ranking) > k:
+        lines.append(
+            f"_(showing top {k} of {len(leave_ranking):,} distinct leaves)_"
+        )
+        lines.append("")
+
+    # Section 3: J nearest miss.
+    lines.append("## J nearest miss")
+    lines.append("")
+    lines.append(
+        "Racks containing a J, sorted by the smallest equity gap between the "
+        "top static play and the best **exchange-1** play that trades a "
+        "non-J tile (keeping J in the 6-tile leave). Lower `miss` = closer the "
+        "J-keeping exchange-1 comes to being optimal."
+    )
+    lines.append("")
+    lines.append(
+        markdown_table(
+            [
+                "rack",
+                "top move",
+                "top eq (pts)",
+                "best exch1 keeping J",
+                "exch1 leave",
+                "exch1 eq (pts)",
+                "miss (pts)",
+            ],
+            [
+                [
+                    r.rack,
+                    r.top_move,
+                    mp_to_points(r.top_eq),
+                    f"(exch {r.j_exch1_keep_tile})",
+                    r.j_exch1_keep_leave,
+                    mp_to_points(r.j_exch1_keep_eq),
+                    mp_to_points(r.j_miss_margin),
+                ]
+                for r in near_miss
+            ],
+        )
+    )
+    lines.append("")
+
+    args.out.write_text("\n".join(lines))
+    print(f"wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds an on-demand test `openracks` that enumerates every distinct 7-tile opening rack under CSW21 (3,199,724 racks) and records the top static-eval move for each, together with the 2nd-best equity and — for J-containing racks — the best exchange-1 play that keeps the J in the leave.

The motivation is the Discord observation that MAGPIE never picks an exchange-1 keeping the J as the top opening play, while every other tile has ≥1 rack where it does. This PR ships the measurement tooling and a full report.

## What's in this PR

- `test/opening_racks_test.{c,h}`: recursive rack enumeration + per-rack movegen, writes to `/tmp/opening_racks.tsv`. Registered in `on_demand_test_table[]` as `openracks`. Single-threaded release build takes ~9 min.
- `tools/opening_racks_report.py`: reads the TSV and produces three Markdown tables in `OPENING_RACKS_REPORT.md`:
  1. **Letter coverage** — for each letter, the number of opening racks whose top play is an exchange-1 whose 6-tile leave contains that letter. **J is the only letter with 0.**
  2. **Top 6-tile leaves** — the 491 distinct leaves that ever appear as the optimal exchange-1, with the margin each one has over the next-best play.
  3. **J nearest miss** — racks containing J sorted by how close the best J-keeping exchange-1 comes to being optimal. The closest miss is **1.153 pts** on `CCEJR??` (top play `(exch CJ)` at 44.670 pts vs `(exch C)` keeping J at 43.517 pts).
- `OPENING_RACKS_REPORT.md`: the rendered report.

## Reproduce

```bash
make magpie_test BUILD=release
./bin/magpie_test openracks          # ~9 min, writes /tmp/opening_racks.tsv
python3 tools/opening_racks_report.py
```

## Test plan

- [x] `make magpie_test BUILD=release` succeeds (no new warnings from this PR)
- [x] `clang-format` clean on new files
- [x] `clang-tidy-18` clean on new file under project's check set
- [x] `cppcheck.sh` passes
- [x] `python3 find_circ_deps.py` — "No cycles found"
- [x] `./bin/magpie_test openracks` runs to completion and writes all 3,199,724 rows
- [x] Sanity: 0 racks where the top play is an exchange-1 keeping J

https://claude.ai/code/session_01121nBCGJyPK7XpmBA6T3qA