### PR TITLE
Add bingoprobs command for opp-bingo and self-bingo probabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,40 @@ magpie> goto 3
 magpie> infer
 ```
 
+### Computing bingo probabilities
+
+The `bingoprobs` command reports two probabilities for a given position:
+
+1. **Opponent bingo**: probability the opponent (not on turn) holds a bingo-able rack, given that their actual rack is unknown to us and was drawn from the unseen pool (bag + opponent's rack).
+2. **Self bingo after opp pass + replenish**: if the opponent passes and we draw from the bag to refill our rack to 7, probability that the resulting rack can bingo.
+
+It requires a WMP-enabled lexicon. The first four arguments form a CGP; an optional fifth argument is a Monte Carlo sample count (`0` or omitted = exhaustive enumeration over every distinct multiset, weighted by the multinomial coefficient).
+
+For example, on an empty board with `SATINE` as our leave:
+
+```
+magpie> set -lex CSW21 -wmp true -threads 8
+magpie> bingoprobs 15/15/15/15/15/15/15/15/15/15/15/15/15/15/15 SATINE/ 0/0 0
+opp_bingo (drawn from bag + opp rack (unseen to us), 7 of 94 tiles drawn):
+  raw racks: 145644 bingo / 3050892 no-bingo (3196536 distinct)
+  weighted: 1500082267/10235867928 = 14.655%
+
+self_bingo (after opp pass, replenish from bag, 1 of 94 tiles drawn):
+  raw racks: 25 bingo / 2 no-bingo (27 distinct)
+  weighted: 91/94 = 96.809%
+```
+
+The same position with 50,000 Monte Carlo samples per scenario:
+
+```
+magpie> bingoprobs 15/15/15/15/15/15/15/15/15/15/15/15/15/15/15 SATINE/ 0/0 0 50000
+opp_bingo (drawn from bag + opp rack (unseen to us), 7 of 94 tiles drawn):
+  sampled: 7318 bingo / 50000 samples = 14.636%  (SE 0.158%)
+
+self_bingo (after opp pass, replenish from bag, 1 of 94 tiles drawn):
+  sampled: 48393 bingo / 50000 samples = 96.786%  (SE 0.079%)
+```
+
 ### Comparing lexica
 
 To play two lexica against each other to see which is stronger, you can create the required lexical data from text files and run the autoplay command. First, set the letter distribution:

--- a/src/impl/bingo_probs.c
+++ b/src/impl/bingo_probs.c
@@ -1,0 +1,620 @@
+// Computes opponent-bingo and self-bingo probabilities for a given
+// position. See bingo_probs.h for the user-facing semantics.
+
+#include "bingo_probs.h"
+
+#include "../compat/cpthread.h"
+#include "../def/cpthread_defs.h"
+#include "../def/equity_defs.h"
+#include "../def/letter_distribution_defs.h"
+#include "../def/move_defs.h"
+#include "../def/rack_defs.h"
+#include "../ent/bag.h"
+#include "../ent/game.h"
+#include "../ent/letter_distribution.h"
+#include "../ent/move.h"
+#include "../ent/player.h"
+#include "../ent/rack.h"
+#include "../ent/xoshiro.h"
+#include "../util/io_util.h"
+#include "../util/string_util.h"
+#include "move_gen.h"
+#include <inttypes.h>
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// ---------------------------------------------------------------------
+// Combinatorics
+// ---------------------------------------------------------------------
+
+// C(n, k). Returns 0 if k > n. Uses uint64; safe up to roughly C(80, 40)
+// or so before overflow becomes a concern. For our use case (k <=
+// RACK_SIZE = 7, n up to ~100), we're well within range.
+static uint64_t binomial_u64(uint32_t n, uint32_t k) {
+  if (k > n) {
+    return 0;
+  }
+  if (k > n - k) {
+    k = n - k;
+  }
+  uint64_t result = 1;
+  for (uint32_t i = 0; i < k; i++) {
+    result = result * (n - i) / (i + 1);
+  }
+  return result;
+}
+
+static uint64_t gcd_u64(uint64_t a, uint64_t b) {
+  while (b != 0) {
+    const uint64_t t = b;
+    b = a % b;
+    a = t;
+  }
+  return a;
+}
+
+// ---------------------------------------------------------------------
+// Tile pool — per-letter counts plus total
+// ---------------------------------------------------------------------
+
+typedef struct {
+  uint16_t counts[MAX_ALPHABET_SIZE];
+  int total;
+  int ld_size;
+} TilePool;
+
+static void pool_zero(TilePool *pool, int ld_size) {
+  memset(pool->counts, 0, sizeof(pool->counts));
+  pool->total = 0;
+  pool->ld_size = ld_size;
+}
+
+static void pool_add_rack(TilePool *pool, const Rack *rack) {
+  if (rack == NULL) {
+    return;
+  }
+  for (int ml = 0; ml < pool->ld_size; ml++) {
+    const int n = rack_get_letter(rack, ml);
+    pool->counts[ml] += (uint16_t)n;
+    pool->total += n;
+  }
+}
+
+static void pool_add_bag(TilePool *pool, const Bag *bag) {
+  for (int ml = 0; ml < pool->ld_size; ml++) {
+    const int n = bag_get_letter(bag, ml);
+    pool->counts[ml] += (uint16_t)n;
+    pool->total += n;
+  }
+}
+
+// ---------------------------------------------------------------------
+// Multiset enumeration into a flat list
+// ---------------------------------------------------------------------
+
+typedef struct {
+  // Packed per-rack data. Each entry is (ld_size) uint8_t counts followed
+  // by a uint64_t multinomial weight. Stride = entry_bytes.
+  uint8_t *data;
+  size_t entry_bytes;
+  size_t count;
+  size_t cap;
+  int ld_size;
+} RackList;
+
+static void rack_list_init(RackList *list, int ld_size) {
+  list->ld_size = ld_size;
+  list->entry_bytes = (size_t)ld_size + sizeof(uint64_t);
+  list->count = 0;
+  list->cap = 256;
+  list->data = malloc_or_die(list->cap * list->entry_bytes);
+}
+
+static void rack_list_destroy(RackList *list) { free(list->data); }
+
+static void rack_list_push(RackList *list, const uint8_t *counts,
+                           uint64_t weight) {
+  if (list->count == list->cap) {
+    list->cap *= 2;
+    list->data = realloc_or_die(list->data, list->cap * list->entry_bytes);
+  }
+  uint8_t *slot = list->data + (list->count * list->entry_bytes);
+  memcpy(slot, counts, (size_t)list->ld_size);
+  memcpy(slot + list->ld_size, &weight, sizeof(uint64_t));
+  list->count++;
+}
+
+static const uint8_t *rack_list_counts(const RackList *list, size_t i) {
+  return list->data + (i * list->entry_bytes);
+}
+
+static uint64_t rack_list_weight(const RackList *list, size_t i) {
+  uint64_t w;
+  memcpy(&w, list->data + (i * list->entry_bytes) + list->ld_size,
+         sizeof(uint64_t));
+  return w;
+}
+
+static void enumerate_recursive(const TilePool *pool, int draw_size,
+                                uint8_t *current, int ml, uint64_t weight,
+                                RackList *out) {
+  if (draw_size == 0) {
+    rack_list_push(out, current, weight);
+    return;
+  }
+  if (ml >= pool->ld_size) {
+    return;
+  }
+  int max_n = pool->counts[ml];
+  if (max_n > draw_size) {
+    max_n = draw_size;
+  }
+  for (int n = 0; n <= max_n; n++) {
+    current[ml] = (uint8_t)n;
+    const uint64_t w = weight * binomial_u64(pool->counts[ml], (uint32_t)n);
+    enumerate_recursive(pool, draw_size - n, current, ml + 1, w, out);
+  }
+  current[ml] = 0;
+}
+
+static void enumerate_multisets(const TilePool *pool, int draw_size,
+                                RackList *out) {
+  if (draw_size > pool->total) {
+    return;
+  }
+  uint8_t *current = calloc_or_die((size_t)pool->ld_size, sizeof(uint8_t));
+  enumerate_recursive(pool, draw_size, current, /*ml=*/0, /*weight=*/1, out);
+  free(current);
+}
+
+// ---------------------------------------------------------------------
+// Workers
+// ---------------------------------------------------------------------
+
+typedef struct {
+  // Inputs
+  const RackList *list;
+  size_t start_idx;
+  size_t end_idx;
+  Game *game; // per-thread game copy
+  MoveList *move_list; // per-thread scratch
+  const Rack *base_rack; // tiles already in our rack (NULL = empty)
+  int player_on_turn_index;
+  int thread_index;
+
+  // Outputs
+  uint64_t bingo_distinct;
+  uint64_t bingo_weight;
+} ExhaustiveWorker;
+
+static void apply_rack_counts(Rack *target, const Rack *base,
+                              const uint8_t *drawn_counts, int ld_size) {
+  rack_set_dist_size(target, ld_size);
+  rack_reset(target);
+  if (base != NULL) {
+    for (int ml = 0; ml < ld_size; ml++) {
+      const int n = rack_get_letter(base, ml);
+      if (n > 0) {
+        rack_add_letters(target, (MachineLetter)ml, n);
+      }
+    }
+  }
+  for (int ml = 0; ml < ld_size; ml++) {
+    if (drawn_counts[ml] > 0) {
+      rack_add_letters(target, (MachineLetter)ml, drawn_counts[ml]);
+    }
+  }
+}
+
+static void *exhaustive_worker_run(void *arg) {
+  ExhaustiveWorker *w = (ExhaustiveWorker *)arg;
+  const RackList *list = w->list;
+  const Player *player = game_get_player(w->game, w->player_on_turn_index);
+  Rack *player_rack = player_get_rack(player);
+  const int ld_size = list->ld_size;
+
+  const MoveGenArgs args = {
+      .game = w->game,
+      .move_list = w->move_list,
+      .move_record_type = MOVE_RECORD_BINGO_EXISTS,
+      .move_sort_type = MOVE_SORT_SCORE,
+      .thread_index = w->thread_index,
+      .eq_margin_movegen = 0,
+      .target_equity = EQUITY_MAX_VALUE,
+      .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+  };
+
+  for (size_t i = w->start_idx; i < w->end_idx; i++) {
+    const uint8_t *counts = rack_list_counts(list, i);
+    apply_rack_counts(player_rack, w->base_rack, counts, ld_size);
+    if (bingo_exists(&args)) {
+      w->bingo_distinct++;
+      w->bingo_weight += rack_list_weight(list, i);
+    }
+  }
+  return NULL;
+}
+
+typedef struct {
+  // Inputs
+  const TilePool *pool;
+  int draw_size;
+  Game *game;
+  MoveList *move_list;
+  const Rack *base_rack;
+  int player_on_turn_index;
+  int thread_index;
+  uint64_t samples;
+  uint64_t seed;
+
+  // Outputs
+  uint64_t bingo_count;
+  uint64_t total_count;
+} SampleWorker;
+
+// Draws `draw_size` tiles from the pool without replacement using the
+// given PRNG, writing the result counts into `out_counts`. Pool counts
+// are not modified (we replenish after the draw).
+static void sample_one(const TilePool *pool, int draw_size, XoshiroPRNG *prng,
+                       uint8_t *out_counts, uint16_t *scratch_pool) {
+  memcpy(scratch_pool, pool->counts, sizeof(pool->counts));
+  int remaining = pool->total;
+  memset(out_counts, 0, (size_t)pool->ld_size);
+  for (int i = 0; i < draw_size; i++) {
+    uint64_t pick = prng_get_random_number(prng, (uint64_t)remaining);
+    for (int ml = 0; ml < pool->ld_size; ml++) {
+      if (scratch_pool[ml] == 0) {
+        continue;
+      }
+      if (pick < scratch_pool[ml]) {
+        out_counts[ml]++;
+        scratch_pool[ml]--;
+        remaining--;
+        break;
+      }
+      pick -= scratch_pool[ml];
+    }
+  }
+}
+
+static void *sample_worker_run(void *arg) {
+  SampleWorker *w = (SampleWorker *)arg;
+  const Player *player = game_get_player(w->game, w->player_on_turn_index);
+  Rack *player_rack = player_get_rack(player);
+  const int ld_size = w->pool->ld_size;
+  XoshiroPRNG *prng = prng_create(w->seed);
+  uint8_t *drawn_counts = calloc_or_die((size_t)ld_size, sizeof(uint8_t));
+  uint16_t scratch_pool[MAX_ALPHABET_SIZE];
+
+  const MoveGenArgs args = {
+      .game = w->game,
+      .move_list = w->move_list,
+      .move_record_type = MOVE_RECORD_BINGO_EXISTS,
+      .move_sort_type = MOVE_SORT_SCORE,
+      .thread_index = w->thread_index,
+      .eq_margin_movegen = 0,
+      .target_equity = EQUITY_MAX_VALUE,
+      .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+  };
+
+  for (uint64_t s = 0; s < w->samples; s++) {
+    sample_one(w->pool, w->draw_size, prng, drawn_counts, scratch_pool);
+    apply_rack_counts(player_rack, w->base_rack, drawn_counts, ld_size);
+    if (bingo_exists(&args)) {
+      w->bingo_count++;
+    }
+    w->total_count++;
+  }
+
+  free(drawn_counts);
+  prng_destroy(prng);
+  return NULL;
+}
+
+// ---------------------------------------------------------------------
+// Scenario runners
+// ---------------------------------------------------------------------
+
+typedef struct {
+  uint64_t bingo_distinct;
+  uint64_t total_distinct;
+  uint64_t bingo_weight;
+  uint64_t total_weight;
+  uint64_t sample_bingo;
+  uint64_t sample_total;
+  bool sampled;
+} ScenarioResult;
+
+static void run_exhaustive(const Game *base_game, const TilePool *pool,
+                           int draw_size, const Rack *base_rack,
+                           int num_threads, ScenarioResult *out) {
+  RackList list;
+  rack_list_init(&list, pool->ld_size);
+  enumerate_multisets(pool, draw_size, &list);
+  out->total_distinct = list.count;
+  out->total_weight = binomial_u64((uint32_t)pool->total, (uint32_t)draw_size);
+  out->bingo_distinct = 0;
+  out->bingo_weight = 0;
+
+  if (list.count == 0) {
+    rack_list_destroy(&list);
+    return;
+  }
+
+  if (num_threads < 1) {
+    num_threads = 1;
+  }
+  if ((size_t)num_threads > list.count) {
+    num_threads = (int)list.count;
+  }
+
+  const int player_on_turn = game_get_player_on_turn_index(base_game);
+
+  ExhaustiveWorker *workers =
+      calloc_or_die((size_t)num_threads, sizeof(ExhaustiveWorker));
+  Game **games = calloc_or_die((size_t)num_threads, sizeof(Game *));
+  MoveList **move_lists =
+      calloc_or_die((size_t)num_threads, sizeof(MoveList *));
+  cpthread_t *threads = calloc_or_die((size_t)num_threads, sizeof(cpthread_t));
+
+  const size_t per = list.count / (size_t)num_threads;
+  const size_t rem = list.count % (size_t)num_threads;
+  size_t cursor = 0;
+  for (int t = 0; t < num_threads; t++) {
+    const size_t this_size = per + (size_t)(t < (int)rem ? 1 : 0);
+    games[t] = game_duplicate(base_game);
+    move_lists[t] = move_list_create(1);
+    workers[t].list = &list;
+    workers[t].start_idx = cursor;
+    workers[t].end_idx = cursor + this_size;
+    workers[t].game = games[t];
+    workers[t].move_list = move_lists[t];
+    workers[t].base_rack = base_rack;
+    workers[t].player_on_turn_index = player_on_turn;
+    workers[t].thread_index = t;
+    cursor += this_size;
+  }
+
+  for (int t = 0; t < num_threads; t++) {
+    cpthread_create(&threads[t], exhaustive_worker_run, &workers[t]);
+  }
+  for (int t = 0; t < num_threads; t++) {
+    cpthread_join(threads[t]);
+    out->bingo_distinct += workers[t].bingo_distinct;
+    out->bingo_weight += workers[t].bingo_weight;
+    move_list_destroy(move_lists[t]);
+    game_destroy(games[t]);
+  }
+
+  free(threads);
+  free(move_lists);
+  free(games);
+  free(workers);
+  rack_list_destroy(&list);
+}
+
+static void run_sampled(const Game *base_game, const TilePool *pool,
+                        int draw_size, const Rack *base_rack, int num_threads,
+                        uint64_t total_samples, ScenarioResult *out) {
+  out->total_distinct = 0;
+  out->bingo_distinct = 0;
+  out->total_weight = binomial_u64((uint32_t)pool->total, (uint32_t)draw_size);
+  out->bingo_weight = 0;
+  out->sampled = true;
+  out->sample_total = 0;
+  out->sample_bingo = 0;
+
+  if (num_threads < 1) {
+    num_threads = 1;
+  }
+  if ((uint64_t)num_threads > total_samples) {
+    num_threads = (int)total_samples;
+  }
+  if (num_threads < 1) {
+    return;
+  }
+
+  const int player_on_turn = game_get_player_on_turn_index(base_game);
+
+  SampleWorker *workers =
+      calloc_or_die((size_t)num_threads, sizeof(SampleWorker));
+  Game **games = calloc_or_die((size_t)num_threads, sizeof(Game *));
+  MoveList **move_lists =
+      calloc_or_die((size_t)num_threads, sizeof(MoveList *));
+  cpthread_t *threads = calloc_or_die((size_t)num_threads, sizeof(cpthread_t));
+
+  // Seed each worker with a distinct value derived from a fixed mix of
+  // the per-process clock and the worker index. We don't need
+  // cross-process reproducibility here.
+  const uint64_t base_seed =
+      (uint64_t)((uintptr_t)workers ^ 0x9E3779B97F4A7C15ULL);
+
+  const uint64_t per = total_samples / (uint64_t)num_threads;
+  const uint64_t rem = total_samples % (uint64_t)num_threads;
+  for (int t = 0; t < num_threads; t++) {
+    const uint64_t this_samples = per + (uint64_t)(t < (int)rem ? 1 : 0);
+    games[t] = game_duplicate(base_game);
+    move_lists[t] = move_list_create(1);
+    workers[t].pool = pool;
+    workers[t].draw_size = draw_size;
+    workers[t].game = games[t];
+    workers[t].move_list = move_lists[t];
+    workers[t].base_rack = base_rack;
+    workers[t].player_on_turn_index = player_on_turn;
+    workers[t].thread_index = t;
+    workers[t].samples = this_samples;
+    workers[t].seed = base_seed + (uint64_t)t * 0x9E3779B97F4A7C15ULL;
+  }
+
+  for (int t = 0; t < num_threads; t++) {
+    cpthread_create(&threads[t], sample_worker_run, &workers[t]);
+  }
+  for (int t = 0; t < num_threads; t++) {
+    cpthread_join(threads[t]);
+    out->sample_bingo += workers[t].bingo_count;
+    out->sample_total += workers[t].total_count;
+    move_list_destroy(move_lists[t]);
+    game_destroy(games[t]);
+  }
+
+  free(threads);
+  free(move_lists);
+  free(games);
+  free(workers);
+}
+
+// ---------------------------------------------------------------------
+// Output formatting
+// ---------------------------------------------------------------------
+
+static void format_scenario(StringBuilder *sb, const char *label,
+                            const char *desc, int pool_size, int draw_size,
+                            const ScenarioResult *r) {
+  string_builder_add_formatted_string(
+      sb, "%s (%s, %d of %d tiles drawn):\n", label, desc, draw_size,
+      pool_size);
+  if (r->sampled) {
+    const double pct =
+        r->sample_total == 0
+            ? 0.0
+            : 100.0 * (double)r->sample_bingo / (double)r->sample_total;
+    const double p = pct / 100.0;
+    const double se =
+        r->sample_total == 0
+            ? 0.0
+            : 100.0 * sqrt(p * (1.0 - p) / (double)r->sample_total);
+    string_builder_add_formatted_string(
+        sb, "  sampled: %" PRIu64 " bingo / %" PRIu64
+            " samples = %.3f%%  (SE %.3f%%)\n",
+        r->sample_bingo, r->sample_total, pct, se);
+    return;
+  }
+  const uint64_t no_bingo = r->total_distinct - r->bingo_distinct;
+  string_builder_add_formatted_string(
+      sb, "  raw racks: %" PRIu64 " bingo / %" PRIu64 " no-bingo (%" PRIu64
+          " distinct)\n",
+      r->bingo_distinct, no_bingo, r->total_distinct);
+  uint64_t num = r->bingo_weight;
+  uint64_t den = r->total_weight;
+  if (den == 0) {
+    string_builder_add_string(sb,
+                              "  weighted: 0/0 (pool too small for draw)\n");
+    return;
+  }
+  const double pct = 100.0 * (double)num / (double)den;
+  const uint64_t g = num == 0 ? den : gcd_u64(num, den);
+  string_builder_add_formatted_string(
+      sb, "  weighted: %" PRIu64 "/%" PRIu64 " = %.3f%%\n", num / g, den / g,
+      pct);
+}
+
+// ---------------------------------------------------------------------
+// Public entry
+// ---------------------------------------------------------------------
+
+char *bingo_probs_run(const Game *game, int num_threads, uint64_t sample_count,
+                      ErrorStack *error_stack) {
+  const int player_on_turn = game_get_player_on_turn_index(game);
+  const Player *us = game_get_player(game, player_on_turn);
+  const Player *opp = game_get_player(game, 1 - player_on_turn);
+
+  if (player_get_wmp(us) == NULL) {
+    error_stack_push(
+        error_stack, ERROR_STATUS_CONFIG_LOAD_GAME_DATA_MISSING,
+        string_duplicate(
+            "bingoprobs requires a WMP-enabled lexicon (use -wmp true)"));
+    return NULL;
+  }
+
+  const LetterDistribution *ld = game_get_ld(game);
+  const int ld_size = ld_get_size(ld);
+  const Bag *bag = game_get_bag(game);
+  const Rack *opp_rack = player_get_rack(opp);
+  const Rack *our_rack = player_get_rack(us);
+
+  // Scenario 1: opp's hidden rack is drawn from bag + opp's actual rack.
+  TilePool opp_pool;
+  pool_zero(&opp_pool, ld_size);
+  pool_add_bag(&opp_pool, bag);
+  pool_add_rack(&opp_pool, opp_rack);
+  const int opp_draw_size = RACK_SIZE;
+
+  ScenarioResult opp_result = {0};
+  if (sample_count > 0) {
+    run_sampled(game, &opp_pool, opp_draw_size, /*base_rack=*/NULL, num_threads,
+                sample_count, &opp_result);
+  } else {
+    run_exhaustive(game, &opp_pool, opp_draw_size, /*base_rack=*/NULL,
+                   num_threads, &opp_result);
+  }
+
+  // Scenario 2: opp passes, we draw from bag to refill our rack.
+  TilePool self_pool;
+  pool_zero(&self_pool, ld_size);
+  pool_add_bag(&self_pool, bag);
+  const int our_size = rack_get_total_letters(our_rack);
+  const int self_draw_size = RACK_SIZE - our_size;
+
+  ScenarioResult self_result = {0};
+  if (self_draw_size < 0) {
+    // Shouldn't happen for legal racks.
+    error_stack_push(
+        error_stack, ERROR_STATUS_CONFIG_LOAD_GAME_DATA_MISSING,
+        string_duplicate("on-turn player rack has more than RACK_SIZE tiles"));
+    return NULL;
+  }
+  if (self_draw_size == 0) {
+    // No replenish needed; one trivial outcome — check it directly.
+    self_result.total_distinct = 1;
+    self_result.total_weight = 1;
+    Game *gd = game_duplicate(game);
+    MoveList *ml = move_list_create(1);
+    const MoveGenArgs args = {
+        .game = gd,
+        .move_list = ml,
+        .move_record_type = MOVE_RECORD_BINGO_EXISTS,
+        .move_sort_type = MOVE_SORT_SCORE,
+        .thread_index = 0,
+        .eq_margin_movegen = 0,
+        .target_equity = EQUITY_MAX_VALUE,
+        .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+    };
+    if (bingo_exists(&args)) {
+      self_result.bingo_distinct = 1;
+      self_result.bingo_weight = 1;
+    }
+    move_list_destroy(ml);
+    game_destroy(gd);
+  } else if (sample_count > 0) {
+    run_sampled(game, &self_pool, self_draw_size, our_rack, num_threads,
+                sample_count, &self_result);
+  } else {
+    run_exhaustive(game, &self_pool, self_draw_size, our_rack, num_threads,
+                   &self_result);
+  }
+
+  // Format report.
+  StringBuilder *sb = string_builder_create();
+  format_scenario(sb, "opp_bingo",
+                  "drawn from bag + opp rack (unseen to us)", opp_pool.total,
+                  opp_draw_size, &opp_result);
+  string_builder_add_char(sb, '\n');
+  if (self_draw_size == 0) {
+    string_builder_add_formatted_string(
+        sb, "self_bingo (rack already full, no replenish needed):\n");
+    string_builder_add_formatted_string(
+        sb, "  bingo: %s\n",
+        self_result.bingo_distinct > 0 ? "yes" : "no");
+  } else {
+    format_scenario(sb, "self_bingo",
+                    "after opp pass, replenish from bag", self_pool.total,
+                    self_draw_size, &self_result);
+  }
+  char *result = string_builder_dump(sb, NULL);
+  string_builder_destroy(sb);
+  return result;
+}

--- a/src/impl/bingo_probs.h
+++ b/src/impl/bingo_probs.h
@@ -1,0 +1,27 @@
+#ifndef BINGO_PROBS_H
+#define BINGO_PROBS_H
+
+#include "../ent/game.h"
+#include "../util/io_util.h"
+#include <stdint.h>
+
+// Computes opponent-bingo and self-bingo probabilities for the current
+// game state and returns a formatted report (caller frees).
+//
+// Two scenarios reported:
+// 1. Opponent bingo: probability that the opponent (not on turn) holds
+//    a bingo-able rack, given that their actual rack is unknown to us
+//    and was drawn from the unseen pool (bag + opponent's rack).
+// 2. Self bingo after opp pass + replenish: if opponent passes (board
+//    unchanged) and we draw from the bag to refill our rack to
+//    RACK_SIZE, probability the resulting rack can bingo.
+//
+// If sample_count > 0, runs Monte Carlo with that many samples per
+// scenario. Otherwise enumerates every distinct multiset exhaustively.
+// num_threads >= 1 partitions the work.
+//
+// Requires a WMP-enabled lexicon (uses bingo_exists internally).
+char *bingo_probs_run(const Game *game, int num_threads, uint64_t sample_count,
+                      ErrorStack *error_stack);
+
+#endif

--- a/src/impl/config.c
+++ b/src/impl/config.c
@@ -52,6 +52,7 @@
 #include "../util/io_util.h"
 #include "../util/string_util.h"
 #include "autoplay.h"
+#include "bingo_probs.h"
 #include "cgp.h"
 #include "convert.h"
 #include "endgame.h"
@@ -92,6 +93,7 @@ typedef enum {
   ARG_TOKEN_INFER,
   ARG_TOKEN_ENDGAME,
   ARG_TOKEN_AUTOPLAY,
+  ARG_TOKEN_BINGOPROBS,
   ARG_TOKEN_CONVERT,
   ARG_TOKEN_P1_NAME,
   ARG_TOKEN_P2_NAME,
@@ -1030,6 +1032,22 @@ void add_help_arg_to_string_builder(const Config *config, int token,
       text = "Runs the autoplay command with the specified recorder(s). If the "
              "game pairs option is set to true, autoplay will run <num_games> "
              "game pairs resulting in a total of 2 * <num_games> games.";
+      break;
+    case ARG_TOKEN_BINGOPROBS:
+      usages[0] = "<board> <racks> <scores> <consecutive_zeros> [<samples>]";
+      examples[0] = "15/15/15/15/14V/14A/14N/6GUM5N/7PEW4E/9EF3R/9BEVELS/15/"
+                    "15/15/15 AEEIILZ/CDGKNOR 56/117 0";
+      examples[1] = "15/15/15/15/15/15/15/15/15/15/15/15/15/15/15 AILORRV/ "
+                    "0/0 0 100000";
+      text =
+          "Reports two bingo probabilities for the given CGP: opponent-bingo "
+          "(unseen rack drawn from bag + opp's tiles) and self-bingo (after "
+          "opponent passes and we replenish from the bag). With no <samples> "
+          "argument, enumerates all distinct multisets exactly and reports "
+          "the weighted probability as a reduced fraction. With <samples> > "
+          "0, runs Monte Carlo with that many samples per scenario and "
+          "reports the empirical estimate plus standard error. Uses "
+          "-threads workers in parallel. Requires -wmp true.";
       break;
     case ARG_TOKEN_CONVERT:
       usages[0] = "<type> <input_name_without_extension> "
@@ -2120,6 +2138,67 @@ void impl_load_cgp(Config *config, ErrorStack *error_stack) {
     config_reset_move_list_and_invalidate_sim_results(config);
   }
   string_builder_destroy(cgp_builder);
+}
+
+// Bingoprobs
+
+static char *impl_bingoprobs(Config *config, ErrorStack *error_stack) {
+  if (!config_has_game_data(config)) {
+    error_stack_push(
+        error_stack, ERROR_STATUS_CONFIG_LOAD_GAME_DATA_MISSING,
+        string_duplicate("cannot run bingoprobs without lexicon"));
+    return NULL;
+  }
+  config_init_game(config);
+
+  // Concatenate the four CGP components into a single string and load.
+  StringBuilder *cgp_builder = string_builder_create();
+  for (int i = 0; i < 4; i++) {
+    const char *cgp_component =
+        config_get_parg_value(config, ARG_TOKEN_BINGOPROBS, i);
+    if (!cgp_component) {
+      log_fatal("missing cgp component: %d", i);
+    }
+    string_builder_add_string(cgp_builder, cgp_component);
+    string_builder_add_char(cgp_builder, ' ');
+  }
+  const char *cgp = string_builder_peek(cgp_builder);
+  Game *game_dupe = game_duplicate(config->game);
+  game_load_cgp(game_dupe, cgp, error_stack);
+  game_destroy(game_dupe);
+  if (!error_stack_is_empty(error_stack)) {
+    string_builder_destroy(cgp_builder);
+    return NULL;
+  }
+  game_load_cgp(config->game, cgp, error_stack);
+  string_builder_destroy(cgp_builder);
+  if (!error_stack_is_empty(error_stack)) {
+    return NULL;
+  }
+  config_reset_move_list_and_invalidate_sim_results(config);
+
+  // Optional fifth argument: sample count (Monte Carlo). 0 means exact.
+  uint64_t sample_count = 0;
+  const int n_set =
+      config_get_parg_num_set_values(config, ARG_TOKEN_BINGOPROBS);
+  if (n_set >= 5) {
+    const char *samples_str =
+        config_get_parg_value(config, ARG_TOKEN_BINGOPROBS, 4);
+    char *endptr = NULL;
+    const unsigned long long parsed = strtoull(samples_str, &endptr, 10);
+    if (endptr == samples_str || *endptr != '\0') {
+      error_stack_push(error_stack, ERROR_STATUS_CONFIG_LOAD_MALFORMED_INT_ARG,
+                       get_formatted_string(
+                           "bingoprobs <samples> must be a non-negative "
+                           "integer, got '%s'",
+                           samples_str));
+      return NULL;
+    }
+    sample_count = (uint64_t)parsed;
+  }
+
+  return bingo_probs_run(config->game, config_get_num_threads(config),
+                         sample_count, error_stack);
 }
 
 // Adding moves
@@ -5392,6 +5471,8 @@ void string_builder_add_move_record_type(StringBuilder *sb,
   case MOVE_RECORD_ALL_SMALL:
   case MOVE_RECORD_TILES_PLAYED:
   case MOVE_RECORD_BEST_SMALL:
+  case MOVE_RECORD_BINGO_EXISTS:
+  case MOVE_RECORD_BINGO_EXISTS_APPROX:
     log_fatal("cannot serialize internal move record type: %d", record_type);
   }
 }
@@ -7032,6 +7113,22 @@ char *str_api_create_data(Config *config, ErrorStack *error_stack) {
   return empty_string();
 }
 
+void execute_bingoprobs(Config *config, ErrorStack *error_stack) {
+  char *result = impl_bingoprobs(config, error_stack);
+  if (error_stack_is_empty(error_stack) && result != NULL) {
+    thread_control_print(config->thread_control, result);
+  }
+  free(result);
+}
+
+char *str_api_bingoprobs(Config *config, ErrorStack *error_stack) {
+  char *result = impl_bingoprobs(config, error_stack);
+  if (result == NULL) {
+    return empty_string();
+  }
+  return result;
+}
+
 Config *config_create(const ConfigArgs *config_args, ErrorStack *error_stack) {
   Config *config = calloc_or_die(1, sizeof(Config));
   // Set the values specified by the args first
@@ -7108,6 +7205,7 @@ Config *config_create(const ConfigArgs *config_args, ErrorStack *error_stack) {
   cmd(ARG_TOKEN_INFER, "infer", 0, 5, infer, generic, false);
   cmd(ARG_TOKEN_ENDGAME, "endgame", 0, 0, endgame, endgame, false);
   cmd(ARG_TOKEN_AUTOPLAY, "autoplay", 2, 2, autoplay, autoplay, false);
+  cmd(ARG_TOKEN_BINGOPROBS, "bingoprobs", 4, 5, bingoprobs, generic, false);
   cmd(ARG_TOKEN_CONVERT, "convert", 2, 3, convert, generic, false);
   cmd(ARG_TOKEN_LEAVE_GEN, "leavegen", 2, 2, leave_gen, generic, false);
   cmd(ARG_TOKEN_CREATE_DATA, "createdata", 2, 3, create_data, generic, false);
@@ -7403,6 +7501,7 @@ void config_add_settings_to_string_builder(const Config *config,
     case ARG_TOKEN_INFER:
     case ARG_TOKEN_ENDGAME:
     case ARG_TOKEN_AUTOPLAY:
+    case ARG_TOKEN_BINGOPROBS:
     case ARG_TOKEN_CONVERT:
     case ARG_TOKEN_LEAVE_GEN:
     case ARG_TOKEN_CREATE_DATA:

--- a/test/bingo_probs_test.c
+++ b/test/bingo_probs_test.c
@@ -1,0 +1,100 @@
+// Tests for bingo_probs_run.
+//
+// All tests use an empty board so the result depends only on the
+// lexicon (CSW21) and rack composition, not on board state.
+
+#include "bingo_probs_test.h"
+
+#include "../src/ent/game.h"
+#include "../src/impl/bingo_probs.h"
+#include "../src/impl/config.h"
+#include "../src/util/io_util.h"
+#include "test_util.h"
+#include <assert.h>
+#include <ctype.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *EMPTY_BOARD_15X15 =
+    "15/15/15/15/15/15/15/15/15/15/15/15/15/15/15";
+
+// Returns the first percent value appearing after `substring`. Aborts
+// if the substring or the percent cannot be located. Specifically, for
+// exhaustive output the percent comes from the "weighted: a/b = X%"
+// line; for sampled output it comes from the "sampled: ... = X%" line.
+static double extract_percent_after(const char *output, const char *substring) {
+  const char *p = strstr(output, substring);
+  assert(p != NULL);
+  const char *pct = strchr(p, '%');
+  assert(pct != NULL);
+  const char *num_start = pct - 1;
+  while (num_start > p &&
+         (isdigit((unsigned char)*num_start) || *num_start == '.')) {
+    num_start--;
+  }
+  num_start++;
+  return strtod(num_start, NULL);
+}
+
+static char *run_bingo_probs_for_cgp(Config *config, const char *cgp,
+                                     uint64_t sample_count) {
+  load_and_exec_config_or_die(config, "set -lex CSW21 -wmp true -threads 4");
+  Game *game = config_game_create(config);
+  load_cgp_or_die(game, cgp);
+  ErrorStack *error_stack = error_stack_create();
+  char *result = bingo_probs_run(game, 4, sample_count, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(result != NULL);
+  error_stack_destroy(error_stack);
+  game_destroy(game);
+  return result;
+}
+
+// Empty board, our rack is SATINE. Replenishing 1 tile from the bag
+// gives a 7-letter bingo for 91 of 94 unseen tiles -> ~96.8%.
+static void test_bingo_probs_satine_exhaustive(void) {
+  Config *config = config_create_default_test();
+  char cgp[256];
+  snprintf(cgp, sizeof(cgp), "%s SATINE/ 0/0 0", EMPTY_BOARD_15X15);
+  char *output = run_bingo_probs_for_cgp(config, cgp, 0);
+  const double self_pct = extract_percent_after(output, "self_bingo");
+  assert(self_pct > 96.5 && self_pct < 97.0);
+  free(output);
+  config_destroy(config);
+}
+
+// Same setup but Monte Carlo. With 50k samples the standard error on a
+// ~97% probability is ~0.08%, so a tolerance of 0.5% is safely above
+// the 6-sigma band.
+static void test_bingo_probs_satine_sampled(void) {
+  Config *config = config_create_default_test();
+  char cgp[256];
+  snprintf(cgp, sizeof(cgp), "%s SATINE/ 0/0 0", EMPTY_BOARD_15X15);
+  char *output = run_bingo_probs_for_cgp(config, cgp, 50000);
+  const double self_pct = extract_percent_after(output, "self_bingo");
+  assert(self_pct > 96.3 && self_pct < 97.3);
+  free(output);
+  config_destroy(config);
+}
+
+// Empty board, our rack is MSUUUU - a notoriously bad leave. Only a
+// handful of tiles complete a 7-letter bingo, so self_bingo should be
+// in the low single digits.
+static void test_bingo_probs_msuuuu_exhaustive(void) {
+  Config *config = config_create_default_test();
+  char cgp[256];
+  snprintf(cgp, sizeof(cgp), "%s MSUUUU/ 0/0 0", EMPTY_BOARD_15X15);
+  char *output = run_bingo_probs_for_cgp(config, cgp, 0);
+  const double self_pct = extract_percent_after(output, "self_bingo");
+  assert(self_pct < 10.0);
+  free(output);
+  config_destroy(config);
+}
+
+void test_bingo_probs(void) {
+  test_bingo_probs_satine_exhaustive();
+  test_bingo_probs_satine_sampled();
+  test_bingo_probs_msuuuu_exhaustive();
+}

--- a/test/bingo_probs_test.h
+++ b/test/bingo_probs_test.h
@@ -1,0 +1,6 @@
+#ifndef BINGO_PROBS_TEST_H
+#define BINGO_PROBS_TEST_H
+
+void test_bingo_probs(void);
+
+#endif

--- a/test/test.c
+++ b/test/test.c
@@ -38,6 +38,7 @@
 #include "move_gen_test.h"
 #include "move_test.h"
 #include "bingo_exists_test.h"
+#include "bingo_probs_test.h"
 #include "players_data_test.h"
 #include "rack_info_table_test.h"
 #include "rack_list_test.h"
@@ -121,6 +122,7 @@ static TestEntry test_table[] = {
     {"zobrist", test_zobrist},
     {"tt", test_transposition_table},
     {"load", test_load_gcg},
+    {"bingoprobs", test_bingo_probs},
     {NULL, NULL} // Sentinel value to mark end of array
 };
 


### PR DESCRIPTION
## Summary

Adds a new `bingoprobs <board> <racks> <scores> <zeros> [samples]` command that reports two probabilities for a given CGP:

1. **Opponent bingo** — probability the opponent (not on turn) holds a bingo-able rack, given that their actual rack is unknown to us and was drawn from the unseen pool (bag + opp's rack).
2. **Self bingo after opp pass + replenish** — if the opponent passes and we draw from the bag to refill our rack to `RACK_SIZE`, probability the resulting rack can bingo.

With `sample_count = 0` (or omitted), enumerates every distinct multiset of the appropriate draw size and weights by the multinomial coefficient, reporting the exact reduced fraction in addition to the percentage. With `sample_count > 0`, runs Monte Carlo with that many samples per scenario plus a standard error.

Multi-threaded via the configured `-threads` count (each worker gets its own duplicated `Game` and `MoveList`). Requires a WMP-enabled lexicon, since the worker uses `MOVE_RECORD_BINGO_EXISTS` internally (introduced in #521, which this PR is stacked on).

Example, empty board, our leave is `SATINE`:

```
magpie> set -lex CSW21 -wmp true -threads 8
magpie> bingoprobs 15/15/15/15/15/15/15/15/15/15/15/15/15/15/15 SATINE/ 0/0 0
opp_bingo (drawn from bag + opp rack (unseen to us), 7 of 94 tiles drawn):
  raw racks: 145644 bingo / 3050892 no-bingo (3196536 distinct)
  weighted: 1500082267/10235867928 = 14.655%

self_bingo (after opp pass, replenish from bag, 1 of 94 tiles drawn):
  raw racks: 25 bingo / 2 no-bingo (27 distinct)
  weighted: 91/94 = 96.809%
```

This is one of the input features for the upcoming outcome_model (replacing the static win-pct lookup at sim leaves), but it's also useful as a standalone analysis tool.

## Test plan

New `bingoprobs` test (registered in `test_table[]`, runs as part of `magpie_test`) covers three empty-board cases:

- [x] **SATINE leave, exhaustive** — asserts self-bingo in `(96.5%, 97.0%)`. Actual: `91/94 = 96.809%`.
- [x] **SATINE leave, 50,000 samples** — asserts self-bingo in `(96.3%, 97.3%)` (well outside the 6σ band of ±0.5%). Actual: `~96.79%`.
- [x] **MSUUUU leave, exhaustive** — asserts self-bingo `< 10%` (bad leave). Actual: `3/94 = 3.191%`.

Also verified manually:
- [x] Midgame CGPs with non-empty opp racks (opp pool correctly includes opp's tiles).
- [x] Both scenarios short-circuit cleanly when self_bingo doesn't apply (rack already full).
- [x] `make magpie BUILD=release`, `make magpie_test BUILD=release` clean (modulo pre-existing `total_tokens` warning).
- [x] `./cppcheck.sh` clean.

## Stacking

Targets `bingo-exists-movegen` (#521). Once that lands, retarget to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)