### PR TITLE
Add single-tile play features (frac_playable, expected top-1/top-2 score)

### DIFF
--- a/src/impl/single_tile_play.c
+++ b/src/impl/single_tile_play.c
@@ -1,7 +1,7 @@
-// Computes per-letter best single-tile play scores by scanning cross_sets,
-// and per-rack expected single-tile-play features (fraction playable,
-// E[max score], E[2nd-max score]) for racks of the form
-// (known leave) + (random hypergeometric draw from a pool).
+// Per-square scan of single-tile play scores plus closed-form and
+// Monte-Carlo computation of expected top-1 / top-2 single-tile play
+// scores for racks of the form (known leave) + (random hypergeometric
+// draw from a pool).
 
 #include "single_tile_play.h"
 
@@ -13,6 +13,7 @@
 #include "../ent/bonus_square.h"
 #include "../ent/equity.h"
 #include "../ent/letter_distribution.h"
+#include "../ent/xoshiro.h"
 #include <stdint.h>
 #include <string.h>
 
@@ -21,12 +22,14 @@
 // ---------------------------------------------------------------------
 
 void single_tile_scan(const Game *game, SingleTileScan *scan) {
-  memset(scan, 0, sizeof(*scan));
+  scan->playable_set = 0;
+  scan->num_squares = 0;
+  memset(scan->best_score, 0, sizeof(scan->best_score));
 
   const Board *board = game_get_board(game);
-  const LetterDistribution *ld = game_get_ld(game);
   const int player_index = game_get_player_on_turn_index(game);
-  const bool kwgs_shared = game_get_data_is_shared(game, PLAYERS_DATA_TYPE_KWG);
+  const bool kwgs_shared =
+      game_get_data_is_shared(game, PLAYERS_DATA_TYPE_KWG);
   const int csi = board_get_cross_set_index(kwgs_shared, player_index);
 
   for (int row = 0; row < BOARD_DIM; row++) {
@@ -34,43 +37,41 @@ void single_tile_scan(const Game *game, SingleTileScan *scan) {
       if (!board_is_empty(board, row, col)) {
         continue;
       }
-      const uint64_t cs_h =
-          board_get_cross_set(board, row, col, BOARD_HORIZONTAL_DIRECTION, csi);
+      const uint64_t cs_h = board_get_cross_set(
+          board, row, col, BOARD_HORIZONTAL_DIRECTION, csi);
       const uint64_t cs_v =
           board_get_cross_set(board, row, col, BOARD_VERTICAL_DIRECTION, csi);
       const uint64_t playable = cs_h & cs_v;
-      // Stranded squares have both cross_sets == TRIVIAL, so playable ==
-      // TRIVIAL too. They aren't actually playable; skip them.
+      // Stranded squares have both cross_sets == TRIVIAL → playable ==
+      // TRIVIAL. They aren't actually playable; skip.
       if (playable == TRIVIAL_CROSS_SET || playable == 0) {
         continue;
       }
-      scan->playable_set |= playable;
 
       const BonusSquare bonus = board_get_bonus_square(board, row, col);
       const int letter_mult = bonus_square_get_letter_multiplier(bonus);
       const int word_mult = bonus_square_get_word_multiplier(bonus);
-      // cross_score[V] is the sum of horizontal-neighbor tile values;
-      // cross_score[H] is the sum of vertical-neighbor tile values.
-      const Equity h_run_score =
-          board_get_cross_score(board, row, col, BOARD_VERTICAL_DIRECTION, csi);
-      const Equity v_run_score = board_get_cross_score(
+      const Equity h_run = board_get_cross_score(
+          board, row, col, BOARD_VERTICAL_DIRECTION, csi);
+      const Equity v_run = board_get_cross_score(
           board, row, col, BOARD_HORIZONTAL_DIRECTION, csi);
-      const bool has_h_word = (cs_v != TRIVIAL_CROSS_SET);
-      const bool has_v_word = (cs_h != TRIVIAL_CROSS_SET);
+      const int has_h_word = (cs_v != TRIVIAL_CROSS_SET) ? 1 : 0;
+      const int has_v_word = (cs_h != TRIVIAL_CROSS_SET) ? 1 : 0;
 
+      SingleTileSquare *sq = &scan->squares[scan->num_squares++];
+      sq->playable_letters = playable;
+      sq->base = (h_run * has_h_word + v_run * has_v_word) * word_mult;
+      sq->coef = (Equity)(letter_mult * word_mult * (has_h_word + has_v_word));
+      scan->playable_set |= playable;
+
+      // Update per-letter best_score for use by closed-form top1.
+      const LetterDistribution *ld_for_face = game_get_ld(game);
       uint64_t bits = playable;
       while (bits != 0) {
         const int ml = __builtin_ctzll(bits);
         bits &= bits - 1;
-
-        const Equity face = ld_get_score(ld, (MachineLetter)ml);
-        Equity score = 0;
-        if (has_h_word) {
-          score += (h_run_score + face * letter_mult) * word_mult;
-        }
-        if (has_v_word) {
-          score += (v_run_score + face * letter_mult) * word_mult;
-        }
+        const Equity face = ld_get_score(ld_for_face, (MachineLetter)ml);
+        const Equity score = sq->base + face * sq->coef;
         if (score > scan->best_score[ml]) {
           scan->best_score[ml] = score;
         }
@@ -80,11 +81,9 @@ void single_tile_scan(const Game *game, SingleTileScan *scan) {
 }
 
 // ---------------------------------------------------------------------
-// Per-rack features
+// Combinatorics + per-square order stats
 // ---------------------------------------------------------------------
 
-// C(n, k) for k <= 7 fits comfortably in uint64 for any reasonable n.
-// Returns 0 if k > n.
 static uint64_t binomial_u64(int n, int k) {
   if (k < 0 || k > n) {
     return 0;
@@ -99,20 +98,115 @@ static uint64_t binomial_u64(int n, int k) {
   return result;
 }
 
-// Sorts the (score, leave_count, pool_count) triples by ascending score.
-// Insertion sort: K is small (<= MAX_ALPHABET_SIZE).
 typedef struct {
   Equity score;
   int leave_count;
   int pool_count;
 } ScoreBin;
 
-static int build_score_bins(const SingleTileScan *scan,
-                            const uint8_t *leave_counts,
-                            const uint8_t *pool_counts, ScoreBin *bins) {
-  // Group letters by their best_score. Letters with the same score share
-  // a bin. Always include score = 0 (covers non-playable letters and the
-  // baseline lower bound of the CDF).
+// Computes E[max_{L in rack} score(s, L)] for a single square s.
+// Non-playable letters at s implicitly score 0; we handle this by
+// including an implicit "score = 0" bin (which contributes nothing to
+// E[max] but shifts the CDF baseline from -inf to 0).
+static double e_max_at_square(const SingleTileSquare *sq,
+                              const LetterDistribution *ld,
+                              const uint8_t *leave_counts,
+                              const uint8_t *pool_counts, int pool_size,
+                              int draw_size, uint64_t denom_eff,
+                              int effective_d) {
+  ScoreBin bins[MAX_ALPHABET_SIZE];
+  int num_bins = 0;
+  int playable_leave = 0;
+  int playable_pool = 0;
+
+  uint64_t bits = sq->playable_letters;
+  while (bits != 0) {
+    const int ml = __builtin_ctzll(bits);
+    bits &= bits - 1;
+    const int lc = leave_counts[ml];
+    const int pc = pool_counts[ml];
+    if (lc + pc == 0) {
+      continue;
+    }
+    playable_leave += lc;
+    playable_pool += pc;
+    const Equity face = ld_get_score(ld, (MachineLetter)ml);
+    const Equity score = sq->base + face * sq->coef;
+    int found = -1;
+    for (int b = 0; b < num_bins; b++) {
+      if (bins[b].score == score) {
+        found = b;
+        break;
+      }
+    }
+    if (found >= 0) {
+      bins[found].leave_count += lc;
+      bins[found].pool_count += pc;
+    } else {
+      bins[num_bins].score = score;
+      bins[num_bins].leave_count = lc;
+      bins[num_bins].pool_count = pc;
+      num_bins++;
+    }
+  }
+
+  if (num_bins == 0) {
+    return 0.0;
+  }
+
+  // Insertion sort ascending.
+  for (int i = 1; i < num_bins; i++) {
+    ScoreBin tmp = bins[i];
+    int j = i - 1;
+    while (j >= 0 && bins[j].score > tmp.score) {
+      bins[j + 1] = bins[j];
+      j--;
+    }
+    bins[j + 1] = tmp;
+  }
+
+  // leave_above[i] / pool_above[i] = counts strictly above bins[i].
+  int leave_above[MAX_ALPHABET_SIZE];
+  int pool_above[MAX_ALPHABET_SIZE];
+  leave_above[num_bins - 1] = 0;
+  pool_above[num_bins - 1] = 0;
+  for (int i = num_bins - 2; i >= 0; i--) {
+    leave_above[i] = leave_above[i + 1] + bins[i + 1].leave_count;
+    pool_above[i] = pool_above[i + 1] + bins[i + 1].pool_count;
+  }
+
+  // Implicit P(max <= 0) — covers the case where the rack contains no
+  // tiles playable at this square. Counts "above 0" = playable counts.
+  double prev_p;
+  if (playable_leave > 0) {
+    prev_p = 0.0;
+  } else {
+    prev_p = (double)binomial_u64(pool_size - playable_pool, effective_d) /
+             (double)denom_eff;
+  }
+
+  double e_max = 0.0;
+  for (int i = 0; i < num_bins; i++) {
+    double p = 0.0;
+    if (leave_above[i] == 0) {
+      p = (double)binomial_u64(pool_size - pool_above[i], effective_d) /
+          (double)denom_eff;
+    }
+    e_max += (double)bins[i].score * (p - prev_p);
+    prev_p = p;
+  }
+  return e_max;
+}
+
+// ---------------------------------------------------------------------
+// Closed-form features
+// ---------------------------------------------------------------------
+
+// Build distinct-score bins from per-letter scores. Always includes a
+// score=0 bin for non-playable rack tiles. Returns num_bins.
+static int build_per_letter_bins(const Equity *score_per_letter,
+                                 const uint8_t *leave_counts,
+                                 const uint8_t *pool_counts, ScoreBin *bins) {
   int num_bins = 1;
   bins[0].score = 0;
   bins[0].leave_count = 0;
@@ -123,11 +217,11 @@ static int build_score_bins(const SingleTileScan *scan,
     if (lc == 0 && pc == 0) {
       continue;
     }
-    const Equity s = scan->best_score[ml];
+    const Equity s = score_per_letter[ml];
     int found = -1;
-    for (int i = 0; i < num_bins; i++) {
-      if (bins[i].score == s) {
-        found = i;
+    for (int b = 0; b < num_bins; b++) {
+      if (bins[b].score == s) {
+        found = b;
         break;
       }
     }
@@ -141,7 +235,6 @@ static int build_score_bins(const SingleTileScan *scan,
       num_bins++;
     }
   }
-  // Insertion sort by ascending score.
   for (int i = 1; i < num_bins; i++) {
     ScoreBin tmp = bins[i];
     int j = i - 1;
@@ -154,12 +247,46 @@ static int build_score_bins(const SingleTileScan *scan,
   return num_bins;
 }
 
+// E[max over rack of score_per_letter[L]] via standard per-letter
+// order statistics. Used for closed-form E[top1].
+static double e_max_per_letter(const Equity *score_per_letter,
+                               const uint8_t *leave_counts,
+                               const uint8_t *pool_counts, int pool_size,
+                               int draw_size, uint64_t denom_eff,
+                               int effective_d) {
+  ScoreBin bins[MAX_ALPHABET_SIZE + 1];
+  const int num_bins =
+      build_per_letter_bins(score_per_letter, leave_counts, pool_counts, bins);
+
+  int leave_above[MAX_ALPHABET_SIZE + 1];
+  int pool_above[MAX_ALPHABET_SIZE + 1];
+  leave_above[num_bins - 1] = 0;
+  pool_above[num_bins - 1] = 0;
+  for (int i = num_bins - 2; i >= 0; i--) {
+    leave_above[i] = leave_above[i + 1] + bins[i + 1].leave_count;
+    pool_above[i] = pool_above[i + 1] + bins[i + 1].pool_count;
+  }
+
+  double e_max = 0.0;
+  double prev_p = 0.0;
+  for (int i = 0; i < num_bins; i++) {
+    double p = 0.0;
+    if (leave_above[i] == 0) {
+      p = (double)binomial_u64(pool_size - pool_above[i], effective_d) /
+          (double)denom_eff;
+    }
+    e_max += (double)bins[i].score * (p - prev_p);
+    prev_p = p;
+  }
+  return e_max;
+}
+
 void single_tile_features(const SingleTileScan *scan,
+                          const LetterDistribution *ld,
                           const uint8_t *leave_counts,
                           const uint8_t *pool_counts, int pool_size,
                           int draw_size, int rack_size,
                           SingleTileFeatures *out) {
-  // Fraction playable: linearity of expectation.
   int leave_playable = 0;
   int pool_playable = 0;
   for (int ml = 0; ml < MAX_ALPHABET_SIZE; ml++) {
@@ -174,56 +301,152 @@ void single_tile_features(const SingleTileScan *scan,
       ((double)leave_playable + (double)draw_size * pool_frac) /
       (double)rack_size;
 
-  // Order statistics for E[max] and E[2nd_max].
-  ScoreBin bins[MAX_ALPHABET_SIZE + 1];
-  const int num_bins = build_score_bins(scan, leave_counts, pool_counts, bins);
-
   const uint64_t denom = binomial_u64(pool_size, draw_size);
-  const int d = (denom == 0) ? 0 : draw_size;
+  const int effective_d = (denom == 0) ? 0 : draw_size;
   const uint64_t denom_eff = (denom == 0) ? 1 : denom;
 
-  // Cumulative counts strictly above each bin: leave_above[i] is the
-  // number of leave tiles with score > bins[i].score (and similarly for
-  // the pool). Computed by walking descending once.
-  int leave_above[MAX_ALPHABET_SIZE + 1];
-  int pool_above[MAX_ALPHABET_SIZE + 1];
-  if (num_bins > 0) {
-    leave_above[num_bins - 1] = 0;
-    pool_above[num_bins - 1] = 0;
-    for (int i = num_bins - 2; i >= 0; i--) {
-      leave_above[i] = leave_above[i + 1] + bins[i + 1].leave_count;
-      pool_above[i] = pool_above[i + 1] + bins[i + 1].pool_count;
+  // E[top1] = E[max over rack of best_score[L]] — exact via per-letter
+  // order statistics.
+  out->e_top1 =
+      e_max_per_letter(scan->best_score, leave_counts, pool_counts, pool_size,
+                       draw_size, denom_eff, effective_d);
+
+  // E[top2] proxy: per-square E[max], then 2nd-largest across squares.
+  // This is a Jensen-biased approximation of E[2nd-largest per-square
+  // max across distinct squares].
+  double top2 = 0.0;
+  double bestseen = 0.0;
+  for (int i = 0; i < scan->num_squares; i++) {
+    const double e_max =
+        e_max_at_square(&scan->squares[i], ld, leave_counts, pool_counts,
+                        pool_size, draw_size, denom_eff, effective_d);
+    if (e_max > bestseen) {
+      top2 = bestseen;
+      bestseen = e_max;
+    } else if (e_max > top2) {
+      top2 = e_max;
     }
+  }
+  out->e_top2 = top2;
+}
+
+// ---------------------------------------------------------------------
+// Monte Carlo
+// ---------------------------------------------------------------------
+
+// Draws draw_size tiles from pool_counts (without replacement) into
+// drawn_counts. scratch_counts must be size MAX_ALPHABET_SIZE; gets
+// trashed.
+static void draw_random(XoshiroPRNG *prng, const uint8_t *pool_counts,
+                        int pool_size, int draw_size, uint8_t *drawn_counts,
+                        uint16_t *scratch_counts) {
+  for (int ml = 0; ml < MAX_ALPHABET_SIZE; ml++) {
+    scratch_counts[ml] = pool_counts[ml];
+    drawn_counts[ml] = 0;
+  }
+  int remaining = pool_size;
+  for (int i = 0; i < draw_size; i++) {
+    const uint64_t pick = prng_get_random_number(prng, (uint64_t)remaining);
+    uint64_t cum = 0;
+    for (int ml = 0; ml < MAX_ALPHABET_SIZE; ml++) {
+      cum += scratch_counts[ml];
+      if (pick < cum) {
+        drawn_counts[ml]++;
+        scratch_counts[ml]--;
+        remaining--;
+        break;
+      }
+    }
+  }
+}
+
+// Per-rack: for each square, find the max score over rack tiles at that
+// square. Returns (top1, top2) over distinct squares via the out args.
+static void per_rack_top12(const SingleTileScan *scan,
+                           const LetterDistribution *ld,
+                           const uint8_t *rack_counts, double *out_top1,
+                           double *out_top2) {
+  double top1 = 0.0;
+  double top2 = 0.0;
+  for (int i = 0; i < scan->num_squares; i++) {
+    const SingleTileSquare *sq = &scan->squares[i];
+    Equity best_at_sq = 0;
+    uint64_t bits = sq->playable_letters;
+    while (bits != 0) {
+      const int ml = __builtin_ctzll(bits);
+      bits &= bits - 1;
+      if (rack_counts[ml] == 0) {
+        continue;
+      }
+      const Equity face = ld_get_score(ld, (MachineLetter)ml);
+      const Equity score = sq->base + face * sq->coef;
+      if (score > best_at_sq) {
+        best_at_sq = score;
+      }
+    }
+    const double v = (double)best_at_sq;
+    if (v > top1) {
+      top2 = top1;
+      top1 = v;
+    } else if (v > top2) {
+      top2 = v;
+    }
+  }
+  *out_top1 = top1;
+  *out_top2 = top2;
+}
+
+void single_tile_features_mc(const SingleTileScan *scan,
+                             const LetterDistribution *ld,
+                             const uint8_t *leave_counts,
+                             const uint8_t *pool_counts, int pool_size,
+                             int draw_size, int rack_size, uint64_t samples,
+                             uint64_t seed, SingleTileFeatures *out) {
+  // frac_playable is exact via linearity; no MC needed.
+  int leave_playable = 0;
+  int pool_playable = 0;
+  for (int ml = 0; ml < MAX_ALPHABET_SIZE; ml++) {
+    if (((scan->playable_set >> ml) & 1) != 0) {
+      leave_playable += leave_counts[ml];
+      pool_playable += pool_counts[ml];
+    }
+  }
+  const double pool_frac =
+      (pool_size > 0) ? (double)pool_playable / (double)pool_size : 0.0;
+  out->frac_playable =
+      ((double)leave_playable + (double)draw_size * pool_frac) /
+      (double)rack_size;
+
+  if (samples == 0) {
+    out->e_top1 = 0.0;
+    out->e_top2 = 0.0;
+    return;
   }
 
-  // Walk bins ascending and accumulate E[X] = Σ s_i · (P(X≤s_i) −
-  // P(X≤s_{i−1})).
-  double e_max = 0.0;
-  double e_2nd_max = 0.0;
-  double prev_p_max = 0.0; // P(X <= -inf) = 0
-  double prev_p_2nd_max = 0.0;
-  for (int i = 0; i < num_bins; i++) {
-    double p_max = 0.0;
-    double p_2nd_max = 0.0;
-    if (leave_above[i] == 0) {
-      p_max = (double)binomial_u64(pool_size - pool_above[i], d) /
-              (double)denom_eff;
-      double term2 = 0.0;
-      if (d >= 1) {
-        term2 = (double)pool_above[i] *
-                (double)binomial_u64(pool_size - pool_above[i], d - 1) /
-                (double)denom_eff;
-      }
-      p_2nd_max = p_max + term2;
-    } else if (leave_above[i] == 1) {
-      p_2nd_max = (double)binomial_u64(pool_size - pool_above[i], d) /
-                  (double)denom_eff;
+  XoshiroPRNG *prng = prng_create(seed);
+  uint8_t drawn_counts[MAX_ALPHABET_SIZE];
+  uint16_t scratch_counts[MAX_ALPHABET_SIZE];
+  uint8_t rack_counts[MAX_ALPHABET_SIZE];
+
+  double sum_top1 = 0.0;
+  double sum_top2 = 0.0;
+  for (uint64_t s = 0; s < samples; s++) {
+    if (draw_size > 0 && pool_size >= draw_size) {
+      draw_random(prng, pool_counts, pool_size, draw_size, drawn_counts,
+                  scratch_counts);
+    } else {
+      memset(drawn_counts, 0, sizeof(drawn_counts));
     }
-    e_max += (double)bins[i].score * (p_max - prev_p_max);
-    e_2nd_max += (double)bins[i].score * (p_2nd_max - prev_p_2nd_max);
-    prev_p_max = p_max;
-    prev_p_2nd_max = p_2nd_max;
+    for (int ml = 0; ml < MAX_ALPHABET_SIZE; ml++) {
+      rack_counts[ml] = (uint8_t)(leave_counts[ml] + drawn_counts[ml]);
+    }
+    double top1;
+    double top2;
+    per_rack_top12(scan, ld, rack_counts, &top1, &top2);
+    sum_top1 += top1;
+    sum_top2 += top2;
   }
-  out->e_max_score = e_max;
-  out->e_2nd_max_score = e_2nd_max;
+  out->e_top1 = sum_top1 / (double)samples;
+  out->e_top2 = sum_top2 / (double)samples;
+  prng_destroy(prng);
 }

--- a/src/impl/single_tile_play.c
+++ b/src/impl/single_tile_play.c
@@ -1,0 +1,229 @@
+// Computes per-letter best single-tile play scores by scanning cross_sets,
+// and per-rack expected single-tile-play features (fraction playable,
+// E[max score], E[2nd-max score]) for racks of the form
+// (known leave) + (random hypergeometric draw from a pool).
+
+#include "single_tile_play.h"
+
+#include "../def/board_defs.h"
+#include "../def/cross_set_defs.h"
+#include "../def/letter_distribution_defs.h"
+#include "../def/players_data_defs.h"
+#include "../ent/board.h"
+#include "../ent/bonus_square.h"
+#include "../ent/equity.h"
+#include "../ent/letter_distribution.h"
+#include <stdint.h>
+#include <string.h>
+
+// ---------------------------------------------------------------------
+// Board scan
+// ---------------------------------------------------------------------
+
+void single_tile_scan(const Game *game, SingleTileScan *scan) {
+  memset(scan, 0, sizeof(*scan));
+
+  const Board *board = game_get_board(game);
+  const LetterDistribution *ld = game_get_ld(game);
+  const int player_index = game_get_player_on_turn_index(game);
+  const bool kwgs_shared = game_get_data_is_shared(game, PLAYERS_DATA_TYPE_KWG);
+  const int csi = board_get_cross_set_index(kwgs_shared, player_index);
+
+  for (int row = 0; row < BOARD_DIM; row++) {
+    for (int col = 0; col < BOARD_DIM; col++) {
+      if (!board_is_empty(board, row, col)) {
+        continue;
+      }
+      const uint64_t cs_h =
+          board_get_cross_set(board, row, col, BOARD_HORIZONTAL_DIRECTION, csi);
+      const uint64_t cs_v =
+          board_get_cross_set(board, row, col, BOARD_VERTICAL_DIRECTION, csi);
+      const uint64_t playable = cs_h & cs_v;
+      // Stranded squares have both cross_sets == TRIVIAL, so playable ==
+      // TRIVIAL too. They aren't actually playable; skip them.
+      if (playable == TRIVIAL_CROSS_SET || playable == 0) {
+        continue;
+      }
+      scan->playable_set |= playable;
+
+      const BonusSquare bonus = board_get_bonus_square(board, row, col);
+      const int letter_mult = bonus_square_get_letter_multiplier(bonus);
+      const int word_mult = bonus_square_get_word_multiplier(bonus);
+      // cross_score[V] is the sum of horizontal-neighbor tile values;
+      // cross_score[H] is the sum of vertical-neighbor tile values.
+      const Equity h_run_score =
+          board_get_cross_score(board, row, col, BOARD_VERTICAL_DIRECTION, csi);
+      const Equity v_run_score = board_get_cross_score(
+          board, row, col, BOARD_HORIZONTAL_DIRECTION, csi);
+      const bool has_h_word = (cs_v != TRIVIAL_CROSS_SET);
+      const bool has_v_word = (cs_h != TRIVIAL_CROSS_SET);
+
+      uint64_t bits = playable;
+      while (bits != 0) {
+        const int ml = __builtin_ctzll(bits);
+        bits &= bits - 1;
+
+        const Equity face = ld_get_score(ld, (MachineLetter)ml);
+        Equity score = 0;
+        if (has_h_word) {
+          score += (h_run_score + face * letter_mult) * word_mult;
+        }
+        if (has_v_word) {
+          score += (v_run_score + face * letter_mult) * word_mult;
+        }
+        if (score > scan->best_score[ml]) {
+          scan->best_score[ml] = score;
+        }
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------
+// Per-rack features
+// ---------------------------------------------------------------------
+
+// C(n, k) for k <= 7 fits comfortably in uint64 for any reasonable n.
+// Returns 0 if k > n.
+static uint64_t binomial_u64(int n, int k) {
+  if (k < 0 || k > n) {
+    return 0;
+  }
+  if (k > n - k) {
+    k = n - k;
+  }
+  uint64_t result = 1;
+  for (int i = 0; i < k; i++) {
+    result = result * (uint64_t)(n - i) / (uint64_t)(i + 1);
+  }
+  return result;
+}
+
+// Sorts the (score, leave_count, pool_count) triples by ascending score.
+// Insertion sort: K is small (<= MAX_ALPHABET_SIZE).
+typedef struct {
+  Equity score;
+  int leave_count;
+  int pool_count;
+} ScoreBin;
+
+static int build_score_bins(const SingleTileScan *scan,
+                            const uint8_t *leave_counts,
+                            const uint8_t *pool_counts, ScoreBin *bins) {
+  // Group letters by their best_score. Letters with the same score share
+  // a bin. Always include score = 0 (covers non-playable letters and the
+  // baseline lower bound of the CDF).
+  int num_bins = 1;
+  bins[0].score = 0;
+  bins[0].leave_count = 0;
+  bins[0].pool_count = 0;
+  for (int ml = 0; ml < MAX_ALPHABET_SIZE; ml++) {
+    const int lc = leave_counts[ml];
+    const int pc = pool_counts[ml];
+    if (lc == 0 && pc == 0) {
+      continue;
+    }
+    const Equity s = scan->best_score[ml];
+    int found = -1;
+    for (int i = 0; i < num_bins; i++) {
+      if (bins[i].score == s) {
+        found = i;
+        break;
+      }
+    }
+    if (found >= 0) {
+      bins[found].leave_count += lc;
+      bins[found].pool_count += pc;
+    } else {
+      bins[num_bins].score = s;
+      bins[num_bins].leave_count = lc;
+      bins[num_bins].pool_count = pc;
+      num_bins++;
+    }
+  }
+  // Insertion sort by ascending score.
+  for (int i = 1; i < num_bins; i++) {
+    ScoreBin tmp = bins[i];
+    int j = i - 1;
+    while (j >= 0 && bins[j].score > tmp.score) {
+      bins[j + 1] = bins[j];
+      j--;
+    }
+    bins[j + 1] = tmp;
+  }
+  return num_bins;
+}
+
+void single_tile_features(const SingleTileScan *scan,
+                          const uint8_t *leave_counts,
+                          const uint8_t *pool_counts, int pool_size,
+                          int draw_size, int rack_size,
+                          SingleTileFeatures *out) {
+  // Fraction playable: linearity of expectation.
+  int leave_playable = 0;
+  int pool_playable = 0;
+  for (int ml = 0; ml < MAX_ALPHABET_SIZE; ml++) {
+    if (((scan->playable_set >> ml) & 1) != 0) {
+      leave_playable += leave_counts[ml];
+      pool_playable += pool_counts[ml];
+    }
+  }
+  const double pool_frac =
+      (pool_size > 0) ? (double)pool_playable / (double)pool_size : 0.0;
+  out->frac_playable =
+      ((double)leave_playable + (double)draw_size * pool_frac) /
+      (double)rack_size;
+
+  // Order statistics for E[max] and E[2nd_max].
+  ScoreBin bins[MAX_ALPHABET_SIZE + 1];
+  const int num_bins = build_score_bins(scan, leave_counts, pool_counts, bins);
+
+  const uint64_t denom = binomial_u64(pool_size, draw_size);
+  const int d = (denom == 0) ? 0 : draw_size;
+  const uint64_t denom_eff = (denom == 0) ? 1 : denom;
+
+  // Cumulative counts strictly above each bin: leave_above[i] is the
+  // number of leave tiles with score > bins[i].score (and similarly for
+  // the pool). Computed by walking descending once.
+  int leave_above[MAX_ALPHABET_SIZE + 1];
+  int pool_above[MAX_ALPHABET_SIZE + 1];
+  if (num_bins > 0) {
+    leave_above[num_bins - 1] = 0;
+    pool_above[num_bins - 1] = 0;
+    for (int i = num_bins - 2; i >= 0; i--) {
+      leave_above[i] = leave_above[i + 1] + bins[i + 1].leave_count;
+      pool_above[i] = pool_above[i + 1] + bins[i + 1].pool_count;
+    }
+  }
+
+  // Walk bins ascending and accumulate E[X] = Σ s_i · (P(X≤s_i) −
+  // P(X≤s_{i−1})).
+  double e_max = 0.0;
+  double e_2nd_max = 0.0;
+  double prev_p_max = 0.0; // P(X <= -inf) = 0
+  double prev_p_2nd_max = 0.0;
+  for (int i = 0; i < num_bins; i++) {
+    double p_max = 0.0;
+    double p_2nd_max = 0.0;
+    if (leave_above[i] == 0) {
+      p_max = (double)binomial_u64(pool_size - pool_above[i], d) /
+              (double)denom_eff;
+      double term2 = 0.0;
+      if (d >= 1) {
+        term2 = (double)pool_above[i] *
+                (double)binomial_u64(pool_size - pool_above[i], d - 1) /
+                (double)denom_eff;
+      }
+      p_2nd_max = p_max + term2;
+    } else if (leave_above[i] == 1) {
+      p_2nd_max = (double)binomial_u64(pool_size - pool_above[i], d) /
+                  (double)denom_eff;
+    }
+    e_max += (double)bins[i].score * (p_max - prev_p_max);
+    e_2nd_max += (double)bins[i].score * (p_2nd_max - prev_p_2nd_max);
+    prev_p_max = p_max;
+    prev_p_2nd_max = p_2nd_max;
+  }
+  out->e_max_score = e_max;
+  out->e_2nd_max_score = e_2nd_max;
+}

--- a/src/impl/single_tile_play.h
+++ b/src/impl/single_tile_play.h
@@ -1,0 +1,56 @@
+#ifndef SINGLE_TILE_PLAY_H
+#define SINGLE_TILE_PLAY_H
+
+#include "../def/letter_distribution_defs.h"
+#include "../ent/equity.h"
+#include "../ent/game.h"
+#include <stdint.h>
+
+// Per-letter best single-tile play data, computed once per board state by
+// scanning the precomputed cross_sets and cross_scores. No KWG/WMP walks.
+//
+// best_score[L] is the maximum score achievable by placing letter L on any
+// single empty square, considering both the main and cross words formed.
+// 0 means L cannot be played as a single tile anywhere on the board.
+//
+// playable_set is the union over the board of letters that have any
+// single-tile play available. Bit 0 (the blank) is set whenever any other
+// letter is set (since the blank can stand for any letter).
+typedef struct {
+  Equity best_score[MAX_ALPHABET_SIZE];
+  uint64_t playable_set;
+} SingleTileScan;
+
+// Scans every empty, non-stranded square once and updates scan->best_score
+// and scan->playable_set. Caller must ensure cross_sets are valid (true
+// after every move in classic gameplay).
+void single_tile_scan(const Game *game, SingleTileScan *scan);
+
+// Features describing the distribution of a 7-tile rack composed of a known
+// leave plus a random draw without replacement from a pool, restricted to
+// single-tile plays:
+//
+//   E[fraction of rack tiles playable as single tiles]
+//   E[max single-tile play score across the rack]
+//   E[2nd-highest single-tile play score across the rack]
+//
+// Reduces to deterministic max/2nd-max when draw_size == 0 (full leave) and
+// to a pure 7-tile draw when leave is empty and draw_size == rack_size.
+typedef struct {
+  double frac_playable;
+  double e_max_score;     // equity units (millipoints)
+  double e_2nd_max_score; // equity units (millipoints)
+} SingleTileFeatures;
+
+// leave_counts and pool_counts are length-MAX_ALPHABET_SIZE arrays of
+// per-letter counts. pool_size = sum of pool_counts; rack_size is the total
+// rack size (leave_size + draw_size; typically RACK_SIZE = 7).
+//
+// If pool_size < draw_size the result is undefined (caller bug).
+void single_tile_features(const SingleTileScan *scan,
+                          const uint8_t *leave_counts,
+                          const uint8_t *pool_counts, int pool_size,
+                          int draw_size, int rack_size,
+                          SingleTileFeatures *out);
+
+#endif

--- a/src/impl/single_tile_play.h
+++ b/src/impl/single_tile_play.h
@@ -1,56 +1,86 @@
 #ifndef SINGLE_TILE_PLAY_H
 #define SINGLE_TILE_PLAY_H
 
-#include "../def/letter_distribution_defs.h"
+#include "../def/board_defs.h"
 #include "../ent/equity.h"
 #include "../ent/game.h"
+#include "../ent/letter_distribution.h"
 #include <stdint.h>
 
-// Per-letter best single-tile play data, computed once per board state by
-// scanning the precomputed cross_sets and cross_scores. No KWG/WMP walks.
+// Per-square data: playable letters and score parameters such that
+// score(square, letter L) = base + face_value(L) * coef.
 //
-// best_score[L] is the maximum score achievable by placing letter L on any
-// single empty square, considering both the main and cross words formed.
-// 0 means L cannot be played as a single tile anywhere on the board.
+// base = (h_run_score * has_h_word + v_run_score * has_v_word) * word_mult
+// coef = letter_mult * word_mult * (has_h_word + has_v_word)
 //
-// playable_set is the union over the board of letters that have any
-// single-tile play available. Bit 0 (the blank) is set whenever any other
-// letter is set (since the blank can stand for any letter).
+// playable_letters is cross_set[H] & cross_set[V] for the square (with
+// the blank bit set whenever any non-blank bit is set, per MAGPIE's
+// cross-set-with-blank convention).
 typedef struct {
+  uint64_t playable_letters;
+  Equity base;
+  Equity coef;
+} SingleTileSquare;
+
+// Result of one pass over the board. Caller-allocated (no heap).
+typedef struct {
+  uint64_t playable_set; // OR of playable_letters across all squares
+  // best_score[L] = max over all squares of score(square, L). Used for
+  // the closed-form E[top1] computation (which is exact via per-letter
+  // order statistics on this array).
   Equity best_score[MAX_ALPHABET_SIZE];
-  uint64_t playable_set;
+  int num_squares;
+  SingleTileSquare squares[BOARD_DIM * BOARD_DIM];
 } SingleTileScan;
 
-// Scans every empty, non-stranded square once and updates scan->best_score
-// and scan->playable_set. Caller must ensure cross_sets are valid (true
-// after every move in classic gameplay).
+// Scans every empty, non-stranded square once. Caller must ensure
+// cross_sets are valid (true after every move in classic gameplay).
 void single_tile_scan(const Game *game, SingleTileScan *scan);
 
-// Features describing the distribution of a 7-tile rack composed of a known
-// leave plus a random draw without replacement from a pool, restricted to
-// single-tile plays:
+// Features describing the distribution of single-tile-play scores for a
+// rack of the form (known leave) + (random hypergeometric draw of size
+// draw_size from a pool of size pool_size).
 //
-//   E[fraction of rack tiles playable as single tiles]
-//   E[max single-tile play score across the rack]
-//   E[2nd-highest single-tile play score across the rack]
+//   frac_playable: E[# tiles in rack that have ANY single-tile play
+//                    available somewhere on the board] / rack_size
+//   e_top1:        E[max single-tile play score over the whole rack]
+//   e_top2:        E[2nd-largest single-tile play score across DISTINCT
+//                    squares, where each square's contribution is the
+//                    best score achievable with any rack tile at that
+//                    square]
 //
-// Reduces to deterministic max/2nd-max when draw_size == 0 (full leave) and
-// to a pure 7-tile draw when leave is empty and draw_size == rack_size.
+// e_top2 is the "what's the next best play if my top play is blocked?"
+// notion — distinct from "2nd-best tile in my rack", which would
+// double-count tile copies playing the same square.
 typedef struct {
   double frac_playable;
-  double e_max_score;     // equity units (millipoints)
-  double e_2nd_max_score; // equity units (millipoints)
+  double e_top1;
+  double e_top2;
 } SingleTileFeatures;
 
-// leave_counts and pool_counts are length-MAX_ALPHABET_SIZE arrays of
-// per-letter counts. pool_size = sum of pool_counts; rack_size is the total
-// rack size (leave_size + draw_size; typically RACK_SIZE = 7).
-//
-// If pool_size < draw_size the result is undefined (caller bug).
+// Closed-form computation. Per square, computes E[max over rack of
+// score(s,L)] via the same hypergeometric order-stat machinery, then
+// takes top-2 across squares. Note: top-2 of the per-square E[max]
+// values is *not* identical to E[top-2 across squares] for random
+// racks (Jensen-biased upward); use single_tile_features_mc to
+// quantify the bias.
 void single_tile_features(const SingleTileScan *scan,
+                          const LetterDistribution *ld,
                           const uint8_t *leave_counts,
                           const uint8_t *pool_counts, int pool_size,
                           int draw_size, int rack_size,
                           SingleTileFeatures *out);
+
+// Monte Carlo: draws `samples` random racks (leave + draw_size random
+// tiles without replacement from pool), for each rack computes per-
+// square max and the per-rack top-2 across distinct squares, averages.
+// Slow (~hundreds of microseconds for thousands of samples) but exact
+// in the limit.
+void single_tile_features_mc(const SingleTileScan *scan,
+                             const LetterDistribution *ld,
+                             const uint8_t *leave_counts,
+                             const uint8_t *pool_counts, int pool_size,
+                             int draw_size, int rack_size, uint64_t samples,
+                             uint64_t seed, SingleTileFeatures *out);
 
 #endif

--- a/test/single_tile_play_test.c
+++ b/test/single_tile_play_test.c
@@ -1,0 +1,466 @@
+// Tests for single_tile_play (scan + features).
+//
+// Two correctness checks:
+// 1. The per-letter best_score from single_tile_scan agrees with what
+//    MAGPIE's existing move generator finds when run with a one-letter
+//    rack (filtered to single-tile plays).
+// 2. The per-rack features match a brute-force enumeration over all
+//    possible draws for a small pool, verifying the order-statistic
+//    formulas (E[max], E[2nd_max]) and the linearity formula for
+//    fraction playable.
+
+#include "single_tile_play_test.h"
+
+#include "../src/def/equity_defs.h"
+#include "../src/def/letter_distribution_defs.h"
+#include "../src/def/move_defs.h"
+#include "../src/def/rack_defs.h"
+#include "../src/ent/bag.h"
+#include "../src/ent/equity.h"
+#include "../src/ent/game.h"
+#include "../src/ent/letter_distribution.h"
+#include "../src/ent/move.h"
+#include "../src/ent/player.h"
+#include "../src/ent/rack.h"
+#include "../src/impl/config.h"
+#include "../src/impl/gameplay.h"
+#include "../src/impl/move_gen.h"
+#include "../src/impl/single_tile_play.h"
+#include "test_util.h"
+#include <assert.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+// A real mid-game position with plenty of tiles on the board, so most
+// letters have multiple potential single-tile plays with different scores.
+static const char *MIDGAME_CGP =
+    "WAgTAILS5K1/7P4QI1/3NEUTRINO1UN1/JOTA3I3BEDU/I2EFF1N2ZAS1N/"
+    "HM5G2AGO1R/AE4REP2G2E/D6SOOTY1TA/ID11EL/1AR10L1/1WO7UNBOX/"
+    "1TE10M1/1E11I1/1D10ICY/15 AILORRV/ 303/458 0";
+
+static void compute_brute_force_per_letter_max(Game *game,
+                                               Equity *expected_best) {
+  const LetterDistribution *ld = game_get_ld(game);
+  const int ld_size = ld_get_size(ld);
+  const int player_idx = game_get_player_on_turn_index(game);
+  Player *player = game_get_player(game, player_idx);
+  Rack *player_rack = player_get_rack(player);
+  MoveList *move_list = move_list_create(1024);
+
+  for (int ml = 0; ml < ld_size; ml++) {
+    expected_best[ml] = 0;
+    rack_reset(player_rack);
+    rack_set_dist_size(player_rack, ld_size);
+    rack_add_letter(player_rack, (MachineLetter)ml);
+
+    const MoveGenArgs args = {
+        .game = game,
+        .move_list = move_list,
+        .move_record_type = MOVE_RECORD_ALL,
+        .move_sort_type = MOVE_SORT_SCORE,
+        .thread_index = 0,
+        .eq_margin_movegen = 0,
+        .target_equity = EQUITY_MAX_VALUE,
+        .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+    };
+    generate_moves(&args);
+
+    const int n = move_list_get_count(move_list);
+    for (int i = 0; i < n; i++) {
+      const Move *m = move_list_get_move(move_list, i);
+      if (move_get_tiles_played(m) != 1) {
+        continue;
+      }
+      const Equity score = move_get_score(m);
+      if (score > expected_best[ml]) {
+        expected_best[ml] = score;
+      }
+    }
+  }
+  move_list_destroy(move_list);
+}
+
+static void test_scan_matches_movegen(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -wmp true -s1 equity -s2 equity -r1 all -r2 all "
+      "-numplays 1");
+  Game *game = config_game_create(config);
+  load_cgp_or_die(game, MIDGAME_CGP);
+
+  SingleTileScan scan;
+  single_tile_scan(game, &scan);
+
+  Equity expected[MAX_ALPHABET_SIZE] = {0};
+  compute_brute_force_per_letter_max(game, expected);
+
+  const LetterDistribution *ld = game_get_ld(game);
+  const int ld_size = ld_get_size(ld);
+  for (int ml = 0; ml < ld_size; ml++) {
+    if (scan.best_score[ml] != expected[ml]) {
+      printf("ml=%d expected=%d scan=%d\n", ml, equity_to_int(expected[ml]),
+             equity_to_int(scan.best_score[ml]));
+    }
+    assert(scan.best_score[ml] == expected[ml]);
+
+    // playable_set bit must be set iff best_score > 0 OR (blank-only case).
+    // For non-blank ml, best_score > 0 iff playable somewhere with non-zero
+    // face value. Blank may have best_score == 0 even when playable (if
+    // it can only play on a square with no scoring contribution), so handle
+    // it loosely.
+    if (ml != 0 && expected[ml] > 0) {
+      assert(((scan.playable_set >> ml) & 1) != 0);
+    }
+  }
+
+  game_destroy(game);
+  config_destroy(config);
+}
+
+// Brute-force enumeration of expected max/2nd-max/frac for a known
+// leave + small pool + small draw. Iterates every multiset draw, weights
+// by multinomial counts.
+typedef struct {
+  double e_max;
+  double e_2nd_max;
+  double e_frac;
+} BruteFeats;
+
+static uint64_t binom(int n, int k) {
+  if (k < 0 || k > n) {
+    return 0;
+  }
+  if (k > n - k) {
+    k = n - k;
+  }
+  uint64_t r = 1;
+  for (int i = 0; i < k; i++) {
+    r = r * (uint64_t)(n - i) / (uint64_t)(i + 1);
+  }
+  return r;
+}
+
+static void brute_recurse(const SingleTileScan *scan,
+                          const uint8_t *leave_counts,
+                          const uint8_t *pool_counts, int draw_size,
+                          uint8_t *current_draw, int ml, uint64_t weight,
+                          int rack_size, int ld_size, double total_denom,
+                          BruteFeats *out, double *check_total_weight) {
+  if (draw_size == 0) {
+    // Compute features for rack = leave + current_draw
+    int sorted[64];
+    int n_sorted = 0;
+    int playable_in_rack = 0;
+    for (int j = 0; j < ld_size; j++) {
+      const int n = leave_counts[j] + current_draw[j];
+      for (int k = 0; k < n; k++) {
+        sorted[n_sorted++] = (int)scan->best_score[j];
+        if (((scan->playable_set >> j) & 1) != 0) {
+          playable_in_rack++;
+        }
+      }
+    }
+    // Insertion sort descending
+    for (int i = 1; i < n_sorted; i++) {
+      int tmp = sorted[i];
+      int j = i - 1;
+      while (j >= 0 && sorted[j] < tmp) {
+        sorted[j + 1] = sorted[j];
+        j--;
+      }
+      sorted[j + 1] = tmp;
+    }
+    const double w = (double)weight / total_denom;
+    out->e_max += w * (double)sorted[0];
+    out->e_2nd_max += w * (n_sorted >= 2 ? (double)sorted[1] : 0.0);
+    out->e_frac += w * ((double)playable_in_rack / (double)rack_size);
+    *check_total_weight += w;
+    return;
+  }
+  if (ml >= ld_size) {
+    return;
+  }
+  const int max_take =
+      (pool_counts[ml] < draw_size) ? pool_counts[ml] : draw_size;
+  for (int take = 0; take <= max_take; take++) {
+    current_draw[ml] = (uint8_t)take;
+    const uint64_t w = weight * binom(pool_counts[ml], take);
+    brute_recurse(scan, leave_counts, pool_counts, draw_size - take,
+                  current_draw, ml + 1, w, rack_size, ld_size, total_denom, out,
+                  check_total_weight);
+  }
+  current_draw[ml] = 0;
+}
+
+static void test_features_against_enumeration(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -wmp true -s1 equity -s2 equity -r1 all -r2 all "
+      "-numplays 1");
+  Game *game = config_game_create(config);
+  load_cgp_or_die(game, MIDGAME_CGP);
+
+  SingleTileScan scan;
+  single_tile_scan(game, &scan);
+
+  const LetterDistribution *ld = game_get_ld(game);
+  const int ld_size = ld_get_size(ld);
+
+  // Construct a small pool with diverse letters (so different scores) and
+  // a fixed leave with 3 tiles. Draw 4 from a pool of ~12 tiles -> small
+  // enough for full enumeration.
+  uint8_t leave_counts[MAX_ALPHABET_SIZE] = {0};
+  uint8_t pool_counts[MAX_ALPHABET_SIZE] = {0};
+  // Use the actual on-turn rack as the leave (first 3 tiles).
+  const Player *player =
+      game_get_player(game, game_get_player_on_turn_index(game));
+  const Rack *real_rack = player_get_rack(player);
+  int placed = 0;
+  for (int ml = 0; ml < ld_size && placed < 3; ml++) {
+    const int c = rack_get_letter(real_rack, (MachineLetter)ml);
+    for (int i = 0; i < c && placed < 3; i++) {
+      leave_counts[ml]++;
+      placed++;
+    }
+  }
+  const int leave_size = 3;
+
+  // Build pool: pick 12 tiles, mix of low- and high-scoring letters.
+  // Use the first 12 letters with non-zero score that aren't entirely in
+  // the leave already.
+  int pool_total = 0;
+  for (int ml = 1; ml < ld_size && pool_total < 12; ml++) {
+    pool_counts[ml]++;
+    pool_total++;
+  }
+  const int draw_size = 4;
+  const int rack_size = leave_size + draw_size;
+
+  SingleTileFeatures feats;
+  single_tile_features(&scan, leave_counts, pool_counts, pool_total, draw_size,
+                       rack_size, &feats);
+
+  // Brute force
+  BruteFeats brute = {0};
+  uint8_t current_draw[MAX_ALPHABET_SIZE] = {0};
+  const double total_denom = (double)binom(pool_total, draw_size);
+  double check = 0.0;
+  brute_recurse(&scan, leave_counts, pool_counts, draw_size, current_draw, 0, 1,
+                rack_size, ld_size, total_denom, &brute, &check);
+
+  // The total weight should sum to 1.0 (within fp noise).
+  assert(fabs(check - 1.0) < 1e-9);
+
+  // Compare to formula (allow small fp tolerance).
+  if (fabs(feats.e_max_score - brute.e_max) > 1e-6) {
+    printf("e_max formula=%f brute=%f\n", feats.e_max_score, brute.e_max);
+  }
+  if (fabs(feats.e_2nd_max_score - brute.e_2nd_max) > 1e-6) {
+    printf("e_2nd_max formula=%f brute=%f\n", feats.e_2nd_max_score,
+           brute.e_2nd_max);
+  }
+  if (fabs(feats.frac_playable - brute.e_frac) > 1e-9) {
+    printf("frac_playable formula=%f brute=%f\n", feats.frac_playable,
+           brute.e_frac);
+  }
+  assert(fabs(feats.e_max_score - brute.e_max) < 1e-6);
+  assert(fabs(feats.e_2nd_max_score - brute.e_2nd_max) < 1e-6);
+  assert(fabs(feats.frac_playable - brute.e_frac) < 1e-9);
+
+  game_destroy(game);
+  config_destroy(config);
+}
+
+// Sanity check: when draw_size == 0, the features are deterministic in
+// the leave only and equal max / 2nd-max of leave letters' best_scores.
+static void test_features_deterministic(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -wmp true -s1 equity -s2 equity -r1 all -r2 all "
+      "-numplays 1");
+  Game *game = config_game_create(config);
+  load_cgp_or_die(game, MIDGAME_CGP);
+
+  SingleTileScan scan;
+  single_tile_scan(game, &scan);
+
+  const LetterDistribution *ld = game_get_ld(game);
+  const int ld_size = ld_get_size(ld);
+  const Player *player =
+      game_get_player(game, game_get_player_on_turn_index(game));
+  const Rack *real_rack = player_get_rack(player);
+
+  uint8_t leave_counts[MAX_ALPHABET_SIZE] = {0};
+  int leave_size = 0;
+  int playable = 0;
+  int sorted[16];
+  int n_sorted = 0;
+  for (int ml = 0; ml < ld_size; ml++) {
+    const int c = rack_get_letter(real_rack, (MachineLetter)ml);
+    leave_counts[ml] = (uint8_t)c;
+    leave_size += c;
+    for (int i = 0; i < c; i++) {
+      sorted[n_sorted++] = (int)scan.best_score[ml];
+      if (((scan.playable_set >> ml) & 1) != 0) {
+        playable++;
+      }
+    }
+  }
+  for (int i = 1; i < n_sorted; i++) {
+    int tmp = sorted[i];
+    int j = i - 1;
+    while (j >= 0 && sorted[j] < tmp) {
+      sorted[j + 1] = sorted[j];
+      j--;
+    }
+    sorted[j + 1] = tmp;
+  }
+
+  uint8_t pool_counts[MAX_ALPHABET_SIZE] = {0};
+  SingleTileFeatures feats;
+  single_tile_features(&scan, leave_counts, pool_counts, 0, 0, leave_size,
+                       &feats);
+
+  assert(fabs(feats.e_max_score - (double)sorted[0]) < 1e-9);
+  assert(fabs(feats.e_2nd_max_score -
+              (n_sorted >= 2 ? (double)sorted[1] : 0.0)) < 1e-9);
+  assert(fabs(feats.frac_playable - ((double)playable / (double)leave_size)) <
+         1e-9);
+
+  game_destroy(game);
+  config_destroy(config);
+}
+
+void test_single_tile_play(void) {
+  test_scan_matches_movegen();
+  test_features_deterministic();
+  test_features_against_enumeration();
+}
+
+// Throughput benchmark for single_tile_scan + single_tile_features.
+// Per iteration: redraw a fresh "us" rack from a fixed mid-game position,
+// build the unseen pool from the bag + opp's rack, then time
+//   1× single_tile_scan + 2× single_tile_features (us + opp).
+// "us" rack is treated as a leave with random size 1..6 (so there's a
+// non-trivial draw), while "opp" is a 7-tile draw with empty leave.
+//
+// Usage: ./bin/magpie_test singletilebench
+// Env vars:
+//   STBENCH_ITERS  iteration count (default 200000)
+//   STBENCH_SEED   bag PRNG seed (default 42)
+//   STBENCH_CGP    "midgame" / "empty" (default midgame)
+static const char *EMPTY_CGP =
+    "15/15/15/15/15/15/15/15/15/15/15/15/15/15/15 AILORRV/ 0/0 0";
+
+void test_single_tile_bench(void) {
+  const char *iters_env = getenv("STBENCH_ITERS");
+  const int iters =
+      (iters_env != NULL) ? (int)strtol(iters_env, NULL, 10) : 200000;
+  const char *seed_env = getenv("STBENCH_SEED");
+  const uint64_t seed =
+      (seed_env != NULL) ? (uint64_t)strtoull(seed_env, NULL, 10) : 42ULL;
+  const char *cgp_env = getenv("STBENCH_CGP");
+  const char *cgp_label = (cgp_env != NULL) ? cgp_env : "midgame";
+  const char *cgp_string = (cgp_env != NULL && strcmp(cgp_env, "empty") == 0)
+                               ? EMPTY_CGP
+                               : MIDGAME_CGP;
+
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -wmp true -s1 score -s2 score -r1 all -r2 all "
+      "-numplays 1");
+  Game *game = config_game_create(config);
+  load_cgp_or_die(game, cgp_string);
+  bag_seed(game_get_bag(game), seed);
+
+  const LetterDistribution *ld = game_get_ld(game);
+  const int ld_size = ld_get_size(ld);
+  const int us_idx = game_get_player_on_turn_index(game);
+  const int opp_idx = 1 - us_idx;
+  Player *us = game_get_player(game, us_idx);
+  Player *opp = game_get_player(game, opp_idx);
+  Rack *us_rack = player_get_rack(us);
+  Rack *opp_rack = player_get_rack(opp);
+  Bag *bag = game_get_bag(game);
+
+  uint8_t leave_us[MAX_ALPHABET_SIZE];
+  uint8_t leave_opp[MAX_ALPHABET_SIZE];
+  uint8_t pool_us[MAX_ALPHABET_SIZE];
+  uint8_t pool_opp[MAX_ALPHABET_SIZE];
+
+  // Warmup
+  return_rack_to_bag(game, us_idx);
+  draw_to_full_rack(game, us_idx);
+  SingleTileScan warmup_scan;
+  single_tile_scan(game, &warmup_scan);
+
+  struct timespec start;
+  struct timespec end;
+  clock_gettime(CLOCK_MONOTONIC, &start); // NOLINT(misc-include-cleaner)
+
+  double sink = 0.0;
+  for (int i = 0; i < iters; i++) {
+    // Re-draw "us" rack so the leave/draw composition varies. We also
+    // simulate a partial leave by leaving only the first (i % 6) + 1
+    // letters of the rack on the rack and returning the rest.
+    return_rack_to_bag(game, us_idx);
+    draw_to_full_rack(game, us_idx);
+    const int leave_size = (i % 6) + 1;
+    int dropped = 0;
+    for (int ml = 0; ml < ld_size && dropped < RACK_SIZE - leave_size; ml++) {
+      while (rack_get_letter(us_rack, (MachineLetter)ml) > 0 &&
+             dropped < RACK_SIZE - leave_size) {
+        rack_take_letter(us_rack, (MachineLetter)ml);
+        bag_add_letter(bag, (MachineLetter)ml, us_idx);
+        dropped++;
+      }
+    }
+
+    // Build per-letter counts.
+    memset(leave_us, 0, sizeof(leave_us));
+    memset(leave_opp, 0, sizeof(leave_opp));
+    memset(pool_us, 0, sizeof(pool_us));
+    memset(pool_opp, 0, sizeof(pool_opp));
+    int pool_us_size = 0;
+    int pool_opp_size = 0;
+    for (int ml = 0; ml < ld_size; ml++) {
+      const int n_us = rack_get_letter(us_rack, (MachineLetter)ml);
+      const int n_opp = rack_get_letter(opp_rack, (MachineLetter)ml);
+      const int n_bag = bag_get_letter(bag, (MachineLetter)ml);
+      leave_us[ml] = (uint8_t)n_us;
+      // "Us" pool: bag + opp's rack (everything we don't see).
+      pool_us[ml] = (uint8_t)(n_bag + n_opp);
+      pool_us_size += n_bag + n_opp;
+      // "Opp" pool: bag + opp's rack + our leave (everything not on board).
+      pool_opp[ml] = (uint8_t)(n_bag + n_opp + n_us);
+      pool_opp_size += n_bag + n_opp + n_us;
+    }
+
+    SingleTileScan scan;
+    single_tile_scan(game, &scan);
+
+    SingleTileFeatures feats_us;
+    single_tile_features(&scan, leave_us, pool_us, pool_us_size,
+                         RACK_SIZE - leave_size, RACK_SIZE, &feats_us);
+
+    SingleTileFeatures feats_opp;
+    single_tile_features(&scan, leave_opp, pool_opp, pool_opp_size, RACK_SIZE,
+                         RACK_SIZE, &feats_opp);
+
+    sink += feats_us.e_max_score + feats_opp.e_max_score +
+            feats_us.frac_playable + feats_opp.frac_playable;
+  }
+
+  clock_gettime(CLOCK_MONOTONIC, &end);
+  const double elapsed = (double)(end.tv_sec - start.tv_sec) +
+                         (double)(end.tv_nsec - start.tv_nsec) / 1e9;
+  const double calls_per_sec = (double)iters / elapsed;
+  const double us_per_call = elapsed * 1e6 / (double)iters;
+
+  printf("singletile bench cgp=%s iters=%d: %.3fs  %.0f calls/sec  "
+         "%.3f us/call  (sink=%.6f)\n",
+         cgp_label, iters, elapsed, calls_per_sec, us_per_call, sink);
+
+  game_destroy(game);
+  config_destroy(config);
+}

--- a/test/single_tile_play_test.c
+++ b/test/single_tile_play_test.c
@@ -420,10 +420,9 @@ void test_single_tile_play(void) {
 
 // Throughput benchmark for single_tile_scan + single_tile_features
 // (closed-form). One call = scan + features for "us" + features for
-// "opp".
-static const char *EMPTY_CGP =
-    "15/15/15/15/15/15/15/15/15/15/15/15/15/15/15 AILORRV/ 0/0 0";
-
+// "opp". Empty board is excluded — no single-tile play can ever be
+// legal there (no 1-letter words), so the scan does no work and the
+// timing isn't meaningful for this feature.
 void test_single_tile_bench(void) {
   const char *iters_env = getenv("STBENCH_ITERS");
   const int iters =
@@ -431,17 +430,12 @@ void test_single_tile_bench(void) {
   const char *seed_env = getenv("STBENCH_SEED");
   const uint64_t seed =
       (seed_env != NULL) ? (uint64_t)strtoull(seed_env, NULL, 10) : 42ULL;
-  const char *cgp_env = getenv("STBENCH_CGP");
-  const char *cgp_label = (cgp_env != NULL) ? cgp_env : "midgame";
-  const char *cgp_string = (cgp_env != NULL && strcmp(cgp_env, "empty") == 0)
-                               ? EMPTY_CGP
-                               : MIDGAME_CGP;
 
   Config *config = config_create_or_die(
       "set -lex CSW21 -wmp true -s1 score -s2 score -r1 all -r2 all "
       "-numplays 1");
   Game *game = config_game_create(config);
-  load_cgp_or_die(game, cgp_string);
+  load_cgp_or_die(game, MIDGAME_CGP);
   bag_seed(game_get_bag(game), seed);
 
   const LetterDistribution *ld = game_get_ld(game);
@@ -520,9 +514,9 @@ void test_single_tile_bench(void) {
   const double calls_per_sec = (double)iters / elapsed;
   const double us_per_call = elapsed * 1e6 / (double)iters;
 
-  printf("singletile bench cgp=%s iters=%d: %.3fs  %.0f calls/sec  "
+  printf("singletile bench iters=%d: %.3fs  %.0f calls/sec  "
          "%.3f us/call  (sink=%.6f)\n",
-         cgp_label, iters, elapsed, calls_per_sec, us_per_call, sink);
+         iters, elapsed, calls_per_sec, us_per_call, sink);
 
   game_destroy(game);
   config_destroy(config);

--- a/test/single_tile_play_test.c
+++ b/test/single_tile_play_test.c
@@ -1,13 +1,14 @@
-// Tests for single_tile_play (scan + features).
+// Tests for single_tile_play (per-square scan + closed-form + Monte Carlo).
 //
-// Two correctness checks:
-// 1. The per-letter best_score from single_tile_scan agrees with what
-//    MAGPIE's existing move generator finds when run with a one-letter
-//    rack (filtered to single-tile plays).
-// 2. The per-rack features match a brute-force enumeration over all
-//    possible draws for a small pool, verifying the order-statistic
-//    formulas (E[max], E[2nd_max]) and the linearity formula for
-//    fraction playable.
+// Correctness checks:
+// 1. Per-(square, letter) score from the scan agrees with MAGPIE's existing
+//    movegen for every single-tile play.
+// 2. PRETZEL/SSSS?? deterministic case: top1=57, top2=10. Demonstrates
+//    that per-square top-2 differs from naive per-letter top-2.
+// 3. PRETZEL with random draw: closed-form vs Monte Carlo. Documents
+//    the Jensen bias.
+// 4. Features against full multinomial enumeration: validates both
+//    closed-form and MC estimators.
 
 #include "single_tile_play_test.h"
 
@@ -35,12 +36,36 @@
 #include <string.h>
 #include <time.h>
 
-// A real mid-game position with plenty of tiles on the board, so most
-// letters have multiple potential single-tile plays with different scores.
 static const char *MIDGAME_CGP =
     "WAgTAILS5K1/7P4QI1/3NEUTRINO1UN1/JOTA3I3BEDU/I2EFF1N2ZAS1N/"
     "HM5G2AGO1R/AE4REP2G2E/D6SOOTY1TA/ID11EL/1AR10L1/1WO7UNBOX/"
     "1TE10M1/1E11I1/1D10ICY/15 AILORRV/ 303/458 0";
+
+// The trigraph "?\?/" avoids the "??/" trigraph warning while still
+// parsing as the literal string "SSSS??/" (the rack with two blanks).
+static const char *PRETZEL_CGP =
+    "15/15/15/15/15/15/15/7PRETZEL1/15/15/15/15/15/15/15 SSSS?\?/ 0/0 0";
+
+// Compute per-letter best score across the whole board by max-reducing
+// the per-square scores from the scan.
+static void scan_per_letter_best(const SingleTileScan *scan,
+                                 const LetterDistribution *ld,
+                                 Equity *out_best) {
+  memset(out_best, 0, MAX_ALPHABET_SIZE * sizeof(Equity));
+  for (int i = 0; i < scan->num_squares; i++) {
+    const SingleTileSquare *sq = &scan->squares[i];
+    uint64_t bits = sq->playable_letters;
+    while (bits != 0) {
+      const int ml = __builtin_ctzll(bits);
+      bits &= bits - 1;
+      const Equity face = ld_get_score(ld, (MachineLetter)ml);
+      const Equity score = sq->base + face * sq->coef;
+      if (score > out_best[ml]) {
+        out_best[ml] = score;
+      }
+    }
+  }
+}
 
 static void compute_brute_force_per_letter_max(Game *game,
                                                Equity *expected_best) {
@@ -97,20 +122,17 @@ static void test_scan_matches_movegen(void) {
   Equity expected[MAX_ALPHABET_SIZE] = {0};
   compute_brute_force_per_letter_max(game, expected);
 
+  Equity scan_best[MAX_ALPHABET_SIZE];
+  scan_per_letter_best(&scan, game_get_ld(game), scan_best);
+
   const LetterDistribution *ld = game_get_ld(game);
   const int ld_size = ld_get_size(ld);
   for (int ml = 0; ml < ld_size; ml++) {
-    if (scan.best_score[ml] != expected[ml]) {
+    if (scan_best[ml] != expected[ml]) {
       printf("ml=%d expected=%d scan=%d\n", ml, equity_to_int(expected[ml]),
-             equity_to_int(scan.best_score[ml]));
+             equity_to_int(scan_best[ml]));
     }
-    assert(scan.best_score[ml] == expected[ml]);
-
-    // playable_set bit must be set iff best_score > 0 OR (blank-only case).
-    // For non-blank ml, best_score > 0 iff playable somewhere with non-zero
-    // face value. Blank may have best_score == 0 even when playable (if
-    // it can only play on a square with no scoring contribution), so handle
-    // it loosely.
+    assert(scan_best[ml] == expected[ml]);
     if (ml != 0 && expected[ml] > 0) {
       assert(((scan.playable_set >> ml) & 1) != 0);
     }
@@ -120,12 +142,110 @@ static void test_scan_matches_movegen(void) {
   config_destroy(config);
 }
 
-// Brute-force enumeration of expected max/2nd-max/frac for a known
-// leave + small pool + small draw. Iterates every multiset draw, weights
-// by multinomial counts.
+// PRETZEL 8H + SSSS?? as deterministic full leave (no draw).
+// Verifies the per-square interpretation: top1=57 (S at O8 making
+// PRETZELS), top2=10 (blank at L9 making ZA/ZE/ZO with face 0).
+static void test_pretzel_deterministic(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -wmp true -s1 score -s2 score -r1 all -r2 all "
+      "-numplays 1");
+  Game *game = config_game_create(config);
+  load_cgp_or_die(game, PRETZEL_CGP);
+  const LetterDistribution *ld = game_get_ld(game);
+
+  SingleTileScan scan;
+  single_tile_scan(game, &scan);
+
+  uint8_t leave_counts[MAX_ALPHABET_SIZE] = {0};
+  MachineLetter mls[7];
+  const int n_mls = ld_str_to_mls(ld, "SSSS??", false, mls, 6);
+  for (int i = 0; i < n_mls; i++) {
+    leave_counts[mls[i]]++;
+  }
+  uint8_t pool_counts[MAX_ALPHABET_SIZE] = {0};
+
+  SingleTileFeatures feats;
+  single_tile_features(&scan, ld, leave_counts, pool_counts, /*pool_size=*/0,
+                       /*draw_size=*/0, /*rack_size=*/6, &feats);
+
+  // Equity is millipoints: 57 points = 57000.
+  if (fabs(feats.e_top1 - 57000.0) > 1e-6 ||
+      fabs(feats.e_top2 - 10000.0) > 1e-6) {
+    printf("PRETZEL det: top1=%.1f top2=%.1f frac=%.3f\n", feats.e_top1,
+           feats.e_top2, feats.frac_playable);
+  }
+  assert(fabs(feats.e_top1 - 57000.0) < 1e-6);
+  assert(fabs(feats.e_top2 - 10000.0) < 1e-6);
+
+  game_destroy(game);
+  config_destroy(config);
+}
+
+// PRETZEL 8H + SSSS?? leave + 1 draw from the actual bag (87 tiles).
+// Expected E[top2] is dominated by the blank's L9 hook (10 most of
+// the time), with small contributions from drawing a vowel (11 at L9)
+// or the X (17 at M7/M9 DLS through E). Compare closed-form vs MC.
+static void test_pretzel_with_draw(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -wmp true -s1 score -s2 score -r1 all -r2 all "
+      "-numplays 1");
+  Game *game = config_game_create(config);
+  load_cgp_or_die(game, PRETZEL_CGP);
+  const LetterDistribution *ld = game_get_ld(game);
+  const int ld_size = ld_get_size(ld);
+
+  SingleTileScan scan;
+  single_tile_scan(game, &scan);
+
+  uint8_t leave_counts[MAX_ALPHABET_SIZE] = {0};
+  MachineLetter mls[7];
+  const int n_mls = ld_str_to_mls(ld, "SSSS??", false, mls, 6);
+  for (int i = 0; i < n_mls; i++) {
+    leave_counts[mls[i]]++;
+  }
+
+  // Pool = bag (everything not on board, not in our leave).
+  uint8_t pool_counts[MAX_ALPHABET_SIZE] = {0};
+  int pool_size = 0;
+  const Bag *bag = game_get_bag(game);
+  for (int ml = 0; ml < ld_size; ml++) {
+    pool_counts[ml] = (uint8_t)bag_get_letter(bag, (MachineLetter)ml);
+    pool_size += pool_counts[ml];
+  }
+
+  SingleTileFeatures cf;
+  single_tile_features(&scan, ld, leave_counts, pool_counts, pool_size,
+                       /*draw_size=*/1, /*rack_size=*/7, &cf);
+  SingleTileFeatures mc;
+  single_tile_features_mc(&scan, ld, leave_counts, pool_counts, pool_size,
+                          /*draw_size=*/1, /*rack_size=*/7, /*samples=*/200000,
+                          /*seed=*/42, &mc);
+
+  // Convert to points for readability (Equity is millipoints).
+  printf("PRETZEL +1 draw: cf top1=%.4f top2=%.4f frac=%.4f | "
+         "mc top1=%.4f top2=%.4f frac=%.4f\n",
+         cf.e_top1 / 1000.0, cf.e_top2 / 1000.0, cf.frac_playable,
+         mc.e_top1 / 1000.0, mc.e_top2 / 1000.0, mc.frac_playable);
+
+  // top1 should agree across both modes (E[top1] is invariant) up to
+  // MC noise. Tolerance in millipoints.
+  assert(fabs(cf.e_top1 - mc.e_top1) < 500.0);
+  // top2 closed-form vs MC: both should be in the ~10–12 point range
+  // (10000–12000 millipoints) per the back-of-envelope ~10.4.
+  assert(cf.e_top2 > 10000.0 && cf.e_top2 < 12000.0);
+  assert(mc.e_top2 > 10000.0 && mc.e_top2 < 12000.0);
+  // frac is exact in both modes (linearity).
+  assert(fabs(cf.frac_playable - mc.frac_playable) < 1e-9);
+
+  game_destroy(game);
+  config_destroy(config);
+}
+
+// Brute-force enumeration of expected per-square top1/top2 for a known
+// leave + small pool + small draw.
 typedef struct {
-  double e_max;
-  double e_2nd_max;
+  double e_top1;
+  double e_top2;
   double e_frac;
 } BruteFeats;
 
@@ -143,39 +263,60 @@ static uint64_t binom(int n, int k) {
   return r;
 }
 
+static void brute_per_rack(const SingleTileScan *scan,
+                           const LetterDistribution *ld,
+                           const uint8_t *rack_counts, double *top1,
+                           double *top2) {
+  *top1 = 0;
+  *top2 = 0;
+  for (int i = 0; i < scan->num_squares; i++) {
+    const SingleTileSquare *sq = &scan->squares[i];
+    Equity best = 0;
+    uint64_t bits = sq->playable_letters;
+    while (bits != 0) {
+      const int ml = __builtin_ctzll(bits);
+      bits &= bits - 1;
+      if (rack_counts[ml] == 0) {
+        continue;
+      }
+      const Equity face = ld_get_score(ld, (MachineLetter)ml);
+      const Equity score = sq->base + face * sq->coef;
+      if (score > best) {
+        best = score;
+      }
+    }
+    const double v = (double)best;
+    if (v > *top1) {
+      *top2 = *top1;
+      *top1 = v;
+    } else if (v > *top2) {
+      *top2 = v;
+    }
+  }
+}
+
 static void brute_recurse(const SingleTileScan *scan,
+                          const LetterDistribution *ld,
                           const uint8_t *leave_counts,
                           const uint8_t *pool_counts, int draw_size,
                           uint8_t *current_draw, int ml, uint64_t weight,
                           int rack_size, int ld_size, double total_denom,
                           BruteFeats *out, double *check_total_weight) {
   if (draw_size == 0) {
-    // Compute features for rack = leave + current_draw
-    int sorted[64];
-    int n_sorted = 0;
+    uint8_t rack_counts[MAX_ALPHABET_SIZE] = {0};
     int playable_in_rack = 0;
     for (int j = 0; j < ld_size; j++) {
-      const int n = leave_counts[j] + current_draw[j];
-      for (int k = 0; k < n; k++) {
-        sorted[n_sorted++] = (int)scan->best_score[j];
-        if (((scan->playable_set >> j) & 1) != 0) {
-          playable_in_rack++;
-        }
+      rack_counts[j] = (uint8_t)(leave_counts[j] + current_draw[j]);
+      if (((scan->playable_set >> j) & 1) != 0) {
+        playable_in_rack += rack_counts[j];
       }
     }
-    // Insertion sort descending
-    for (int i = 1; i < n_sorted; i++) {
-      int tmp = sorted[i];
-      int j = i - 1;
-      while (j >= 0 && sorted[j] < tmp) {
-        sorted[j + 1] = sorted[j];
-        j--;
-      }
-      sorted[j + 1] = tmp;
-    }
+    double top1;
+    double top2;
+    brute_per_rack(scan, ld, rack_counts, &top1, &top2);
     const double w = (double)weight / total_denom;
-    out->e_max += w * (double)sorted[0];
-    out->e_2nd_max += w * (n_sorted >= 2 ? (double)sorted[1] : 0.0);
+    out->e_top1 += w * top1;
+    out->e_top2 += w * top2;
     out->e_frac += w * ((double)playable_in_rack / (double)rack_size);
     *check_total_weight += w;
     return;
@@ -188,7 +329,7 @@ static void brute_recurse(const SingleTileScan *scan,
   for (int take = 0; take <= max_take; take++) {
     current_draw[ml] = (uint8_t)take;
     const uint64_t w = weight * binom(pool_counts[ml], take);
-    brute_recurse(scan, leave_counts, pool_counts, draw_size - take,
+    brute_recurse(scan, ld, leave_counts, pool_counts, draw_size - take,
                   current_draw, ml + 1, w, rack_size, ld_size, total_denom, out,
                   check_total_weight);
   }
@@ -201,19 +342,14 @@ static void test_features_against_enumeration(void) {
       "-numplays 1");
   Game *game = config_game_create(config);
   load_cgp_or_die(game, MIDGAME_CGP);
+  const LetterDistribution *ld = game_get_ld(game);
+  const int ld_size = ld_get_size(ld);
 
   SingleTileScan scan;
   single_tile_scan(game, &scan);
 
-  const LetterDistribution *ld = game_get_ld(game);
-  const int ld_size = ld_get_size(ld);
-
-  // Construct a small pool with diverse letters (so different scores) and
-  // a fixed leave with 3 tiles. Draw 4 from a pool of ~12 tiles -> small
-  // enough for full enumeration.
   uint8_t leave_counts[MAX_ALPHABET_SIZE] = {0};
   uint8_t pool_counts[MAX_ALPHABET_SIZE] = {0};
-  // Use the actual on-turn rack as the leave (first 3 tiles).
   const Player *player =
       game_get_player(game, game_get_player_on_turn_index(game));
   const Rack *real_rack = player_get_rack(player);
@@ -225,108 +361,51 @@ static void test_features_against_enumeration(void) {
       placed++;
     }
   }
-  const int leave_size = 3;
 
-  // Build pool: pick 12 tiles, mix of low- and high-scoring letters.
-  // Use the first 12 letters with non-zero score that aren't entirely in
-  // the leave already.
   int pool_total = 0;
   for (int ml = 1; ml < ld_size && pool_total < 12; ml++) {
     pool_counts[ml]++;
     pool_total++;
   }
   const int draw_size = 4;
-  const int rack_size = leave_size + draw_size;
+  const int rack_size = 3 + draw_size;
 
-  SingleTileFeatures feats;
-  single_tile_features(&scan, leave_counts, pool_counts, pool_total, draw_size,
-                       rack_size, &feats);
+  SingleTileFeatures cf;
+  single_tile_features(&scan, ld, leave_counts, pool_counts, pool_total,
+                       draw_size, rack_size, &cf);
 
-  // Brute force
   BruteFeats brute = {0};
   uint8_t current_draw[MAX_ALPHABET_SIZE] = {0};
   const double total_denom = (double)binom(pool_total, draw_size);
   double check = 0.0;
-  brute_recurse(&scan, leave_counts, pool_counts, draw_size, current_draw, 0, 1,
-                rack_size, ld_size, total_denom, &brute, &check);
+  brute_recurse(&scan, ld, leave_counts, pool_counts, draw_size, current_draw,
+                0, 1, rack_size, ld_size, total_denom, &brute, &check);
 
-  // The total weight should sum to 1.0 (within fp noise).
   assert(fabs(check - 1.0) < 1e-9);
 
-  // Compare to formula (allow small fp tolerance).
-  if (fabs(feats.e_max_score - brute.e_max) > 1e-6) {
-    printf("e_max formula=%f brute=%f\n", feats.e_max_score, brute.e_max);
+  // top1 closed-form should match brute exactly (ignoring fp noise).
+  if (fabs(cf.e_top1 - brute.e_top1) > 1e-6) {
+    printf("e_top1 cf=%.6f brute=%.6f\n", cf.e_top1, brute.e_top1);
   }
-  if (fabs(feats.e_2nd_max_score - brute.e_2nd_max) > 1e-6) {
-    printf("e_2nd_max formula=%f brute=%f\n", feats.e_2nd_max_score,
-           brute.e_2nd_max);
-  }
-  if (fabs(feats.frac_playable - brute.e_frac) > 1e-9) {
-    printf("frac_playable formula=%f brute=%f\n", feats.frac_playable,
-           brute.e_frac);
-  }
-  assert(fabs(feats.e_max_score - brute.e_max) < 1e-6);
-  assert(fabs(feats.e_2nd_max_score - brute.e_2nd_max) < 1e-6);
-  assert(fabs(feats.frac_playable - brute.e_frac) < 1e-9);
+  assert(fabs(cf.e_top1 - brute.e_top1) < 1e-6);
+  // top2 closed-form is a Jensen-biased proxy for brute. Bias is
+  // bounded by some factor of the underlying scale; allow generous
+  // tolerance.
+  printf("e_top2 cf=%.6f brute=%.6f (bias=%.6f)\n", cf.e_top2, brute.e_top2,
+         cf.e_top2 - brute.e_top2);
+  // frac_playable should match exactly.
+  assert(fabs(cf.frac_playable - brute.e_frac) < 1e-9);
 
-  game_destroy(game);
-  config_destroy(config);
-}
-
-// Sanity check: when draw_size == 0, the features are deterministic in
-// the leave only and equal max / 2nd-max of leave letters' best_scores.
-static void test_features_deterministic(void) {
-  Config *config = config_create_or_die(
-      "set -lex CSW21 -wmp true -s1 equity -s2 equity -r1 all -r2 all "
-      "-numplays 1");
-  Game *game = config_game_create(config);
-  load_cgp_or_die(game, MIDGAME_CGP);
-
-  SingleTileScan scan;
-  single_tile_scan(game, &scan);
-
-  const LetterDistribution *ld = game_get_ld(game);
-  const int ld_size = ld_get_size(ld);
-  const Player *player =
-      game_get_player(game, game_get_player_on_turn_index(game));
-  const Rack *real_rack = player_get_rack(player);
-
-  uint8_t leave_counts[MAX_ALPHABET_SIZE] = {0};
-  int leave_size = 0;
-  int playable = 0;
-  int sorted[16];
-  int n_sorted = 0;
-  for (int ml = 0; ml < ld_size; ml++) {
-    const int c = rack_get_letter(real_rack, (MachineLetter)ml);
-    leave_counts[ml] = (uint8_t)c;
-    leave_size += c;
-    for (int i = 0; i < c; i++) {
-      sorted[n_sorted++] = (int)scan.best_score[ml];
-      if (((scan.playable_set >> ml) & 1) != 0) {
-        playable++;
-      }
-    }
-  }
-  for (int i = 1; i < n_sorted; i++) {
-    int tmp = sorted[i];
-    int j = i - 1;
-    while (j >= 0 && sorted[j] < tmp) {
-      sorted[j + 1] = sorted[j];
-      j--;
-    }
-    sorted[j + 1] = tmp;
-  }
-
-  uint8_t pool_counts[MAX_ALPHABET_SIZE] = {0};
-  SingleTileFeatures feats;
-  single_tile_features(&scan, leave_counts, pool_counts, 0, 0, leave_size,
-                       &feats);
-
-  assert(fabs(feats.e_max_score - (double)sorted[0]) < 1e-9);
-  assert(fabs(feats.e_2nd_max_score -
-              (n_sorted >= 2 ? (double)sorted[1] : 0.0)) < 1e-9);
-  assert(fabs(feats.frac_playable - ((double)playable / (double)leave_size)) <
-         1e-9);
+  // MC should converge to brute.
+  SingleTileFeatures mc;
+  single_tile_features_mc(&scan, ld, leave_counts, pool_counts, pool_total,
+                          draw_size, rack_size, /*samples=*/100000,
+                          /*seed=*/42, &mc);
+  printf("e_top2 mc=%.6f vs brute=%.6f (err=%.6f)\n", mc.e_top2, brute.e_top2,
+         mc.e_top2 - brute.e_top2);
+  // Tolerances in millipoints: ~100 points scale, MC noise on 100k samples.
+  assert(fabs(mc.e_top1 - brute.e_top1) < 200.0);
+  assert(fabs(mc.e_top2 - brute.e_top2) < 500.0);
 
   game_destroy(game);
   config_destroy(config);
@@ -334,22 +413,14 @@ static void test_features_deterministic(void) {
 
 void test_single_tile_play(void) {
   test_scan_matches_movegen();
-  test_features_deterministic();
+  test_pretzel_deterministic();
+  test_pretzel_with_draw();
   test_features_against_enumeration();
 }
 
-// Throughput benchmark for single_tile_scan + single_tile_features.
-// Per iteration: redraw a fresh "us" rack from a fixed mid-game position,
-// build the unseen pool from the bag + opp's rack, then time
-//   1× single_tile_scan + 2× single_tile_features (us + opp).
-// "us" rack is treated as a leave with random size 1..6 (so there's a
-// non-trivial draw), while "opp" is a 7-tile draw with empty leave.
-//
-// Usage: ./bin/magpie_test singletilebench
-// Env vars:
-//   STBENCH_ITERS  iteration count (default 200000)
-//   STBENCH_SEED   bag PRNG seed (default 42)
-//   STBENCH_CGP    "midgame" / "empty" (default midgame)
+// Throughput benchmark for single_tile_scan + single_tile_features
+// (closed-form). One call = scan + features for "us" + features for
+// "opp".
 static const char *EMPTY_CGP =
     "15/15/15/15/15/15/15/15/15/15/15/15/15/15/15 AILORRV/ 0/0 0";
 
@@ -388,7 +459,6 @@ void test_single_tile_bench(void) {
   uint8_t pool_us[MAX_ALPHABET_SIZE];
   uint8_t pool_opp[MAX_ALPHABET_SIZE];
 
-  // Warmup
   return_rack_to_bag(game, us_idx);
   draw_to_full_rack(game, us_idx);
   SingleTileScan warmup_scan;
@@ -400,9 +470,6 @@ void test_single_tile_bench(void) {
 
   double sink = 0.0;
   for (int i = 0; i < iters; i++) {
-    // Re-draw "us" rack so the leave/draw composition varies. We also
-    // simulate a partial leave by leaving only the first (i % 6) + 1
-    // letters of the rack on the rack and returning the rest.
     return_rack_to_bag(game, us_idx);
     draw_to_full_rack(game, us_idx);
     const int leave_size = (i % 6) + 1;
@@ -416,7 +483,6 @@ void test_single_tile_bench(void) {
       }
     }
 
-    // Build per-letter counts.
     memset(leave_us, 0, sizeof(leave_us));
     memset(leave_opp, 0, sizeof(leave_opp));
     memset(pool_us, 0, sizeof(pool_us));
@@ -428,10 +494,8 @@ void test_single_tile_bench(void) {
       const int n_opp = rack_get_letter(opp_rack, (MachineLetter)ml);
       const int n_bag = bag_get_letter(bag, (MachineLetter)ml);
       leave_us[ml] = (uint8_t)n_us;
-      // "Us" pool: bag + opp's rack (everything we don't see).
       pool_us[ml] = (uint8_t)(n_bag + n_opp);
       pool_us_size += n_bag + n_opp;
-      // "Opp" pool: bag + opp's rack + our leave (everything not on board).
       pool_opp[ml] = (uint8_t)(n_bag + n_opp + n_us);
       pool_opp_size += n_bag + n_opp + n_us;
     }
@@ -440,15 +504,14 @@ void test_single_tile_bench(void) {
     single_tile_scan(game, &scan);
 
     SingleTileFeatures feats_us;
-    single_tile_features(&scan, leave_us, pool_us, pool_us_size,
+    single_tile_features(&scan, ld, leave_us, pool_us, pool_us_size,
                          RACK_SIZE - leave_size, RACK_SIZE, &feats_us);
-
     SingleTileFeatures feats_opp;
-    single_tile_features(&scan, leave_opp, pool_opp, pool_opp_size, RACK_SIZE,
-                         RACK_SIZE, &feats_opp);
+    single_tile_features(&scan, ld, leave_opp, pool_opp, pool_opp_size,
+                         RACK_SIZE, RACK_SIZE, &feats_opp);
 
-    sink += feats_us.e_max_score + feats_opp.e_max_score +
-            feats_us.frac_playable + feats_opp.frac_playable;
+    sink += feats_us.e_top1 + feats_opp.e_top1 + feats_us.e_top2 +
+            feats_opp.e_top2 + feats_us.frac_playable + feats_opp.frac_playable;
   }
 
   clock_gettime(CLOCK_MONOTONIC, &end);

--- a/test/single_tile_play_test.h
+++ b/test/single_tile_play_test.h
@@ -1,0 +1,7 @@
+#ifndef SINGLE_TILE_PLAY_TEST_H
+#define SINGLE_TILE_PLAY_TEST_H
+
+void test_single_tile_play(void);
+void test_single_tile_bench(void);
+
+#endif

--- a/test/test.c
+++ b/test/test.c
@@ -47,6 +47,7 @@
 #include "shadow_test.h"
 #include "sim_benchmark_test.h"
 #include "sim_test.h"
+#include "single_tile_play_test.h"
 #include "stats_test.h"
 #include "string_util_test.h"
 #include "transposition_table_test.h"
@@ -123,6 +124,7 @@ static TestEntry test_table[] = {
     {"tt", test_transposition_table},
     {"load", test_load_gcg},
     {"bingoprobs", test_bingo_probs},
+    {"singletile", test_single_tile_play},
     {NULL, NULL} // Sentinel value to mark end of array
 };
 
@@ -148,6 +150,7 @@ static TestEntry on_demand_test_table[] = {
     {"bingoscorrect", test_bingo_exists_correctness},
     {"bingosvsstatic", test_bingo_exists_vs_static_bench},
     {"bingosapprox", test_bingo_exists_approx_miss_rate},
+    {"singletilebench", test_single_tile_bench},
     {NULL, NULL} // Sentinel value to mark end of array
 };
 


### PR DESCRIPTION
## Summary

Second PR in the outcome_model effort (stacked on #521). Adds the first batch of position features for the model: a fast cross-set scan plus closed-form expected single-tile-play features for both us (leave + future bag draw) and opp (full random rack from the unseen pool).

Three features per side:

- **frac_playable** — E[fraction of rack tiles with any single-tile play available somewhere on the board]. Closed-form by linearity of expectation.
- **e_top1** — E[max single-tile play score over the rack]. Closed-form via per-letter hypergeometric order statistics. Exact.
- **e_top2** — E[2nd-largest single-tile play score across **distinct squares**]. The per-square framing matters: with `SSSS??` on a board that has PRETZEL at 8H, naive per-letter top-2 would say 57 (a second S also makes PRETZELS), but only one S can actually play O8. The right answer is 10 (a blank at L9 making `?Z` = ZA/ZE/ZO with face value 0). Closed-form is a Jensen-biased proxy (top-2 of per-square `E[max]`); MC mode is provided for verification.

## Implementation

`src/impl/single_tile_play.{h,c}`:

- `single_tile_scan(game)` — single pass over empty squares. For each non-stranded square, intersects `cross_set[H] & cross_set[V]` to get the playable letters; precomputes `(base, coef)` such that `score(s, L) = base + face(L) · coef` (factoring out the bonus-square multipliers). Also fills per-letter `best_score[L]` for the closed-form top1 path. ~5 KB total per scan.
- `single_tile_features(...)` — closed-form. top1 via per-letter order stats; top2 via per-square order stats (Jensen-biased proxy for E[top-2 across distinct squares]).
- `single_tile_features_mc(samples, seed, ...)` — Monte Carlo. Draws random racks, computes per-rack per-square max + per-rack top-2, averages. Slow but exact.

The two modes return the same `SingleTileFeatures` struct so they're directly comparable.

## Tests (registered as `singletile`, on-demand bench `singletilebench`)

- `test_scan_matches_movegen` — for every letter independently, runs MAGPIE's existing movegen with `rack=[L]`, filters to 1-tile plays, and asserts `scan.best_score[L]` matches the movegen-derived max.
- `test_pretzel_deterministic` — PRETZEL 8H + SSSS?? leave (no draw): asserts `top1=57, top2=10`. Demonstrates the per-square interpretation in isolation.
- `test_pretzel_with_draw` — PRETZEL + SSSS?? leave + 1 bag draw: closed-form `top2=10.31`, MC `top2=10.39`. The X-draw bumps the expectation slightly above the deterministic 10 (X at M7/M9 DLS makes (E)X for 17).
- `test_features_against_enumeration` — small fixture (12-tile pool, 4-draw) where full multinomial enumeration is feasible. Validates closed-form top1 exactly, MC top2 within tolerance, and documents the closed-form top2 bias (~3.8% in the fixture).

## Performance

`./bin/magpie_test singletilebench` (midgame fixture, scan + features for both us + opp per call):

| | µs/call | calls/sec |
|---|---:|---:|
| midgame | 3.12 | 320k |

For comparison, `bingo_exists` is ~7 µs. So all six single-tile features cost less than half of one bingo-prob feature.

## Notes

- Empty board: `num_squares=0` (every square stranded), all features return 0. Empty-board handling is left to the model layer (1-letter words don't exist, so single-tile plays are never possible there).
- The MC mode is for validation, not production. The closed-form top2 is biased upward by Jensen's inequality (small in practice; ~3-4% in the test fixture). If the bias proves to matter for model accuracy we can swap in MC, but the closed-form is ~thousands of times faster.

## Stacking

Targets `bingo-exists-movegen` (#521). Once that lands, retarget to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)