### PR TITLE
Outcome-model training data: -tdump CSV emission from autoplay

### DIFF
--- a/src/impl/autoplay.c
+++ b/src/impl/autoplay.c
@@ -906,8 +906,8 @@ void play_autoplay_game_or_game_pair(AutoplayWorker *autoplay_worker,
   if (autoplay_worker->shared_data->outcome_recorder != NULL) {
     const Player *p0 = game_get_player(game_runner1->game, 0);
     const Player *p1 = game_get_player(game_runner1->game, 1);
-    const int p0_score = (int)player_get_score(p0);
-    const int p1_score = (int)player_get_score(p1);
+    const int p0_score = equity_to_int(player_get_score(p0));
+    const int p1_score = equity_to_int(player_get_score(p1));
     outcome_game_buffer_flush(autoplay_worker->outcome_buffer,
                               autoplay_worker->shared_data->outcome_recorder,
                               p0_score, p1_score);

--- a/src/impl/autoplay.c
+++ b/src/impl/autoplay.c
@@ -35,6 +35,8 @@
 #include "../util/io_util.h"
 #include "../util/string_util.h"
 #include "gameplay.h"
+#include "outcome_features.h"
+#include "outcome_recorder.h"
 #include "rack_list.h"
 #include "simmer.h"
 #include <stdatomic.h>
@@ -102,6 +104,8 @@ typedef struct AutoplaySharedData {
   cpthread_mutex_t iter_completed_mutex;
   ThreadControl *thread_control;
   LeavegenSharedData *leavegen_shared_data;
+  // Outcome-model training data recorder. NULL when -tdump isn't set.
+  OutcomeRecorder *outcome_recorder;
 } AutoplaySharedData;
 
 typedef struct AutoplayIterOutput {
@@ -297,6 +301,10 @@ typedef struct AutoplayWorker {
   Rack nontarget_known_rack;
   Rack target_known_rack;
   MoveList *move_lists[2];
+  // Per-worker outcome buffer + PRNG. Allocated only when shared_data
+  // ->outcome_recorder is non-NULL.
+  OutcomeGameBuffer *outcome_buffer;
+  XoshiroPRNG *outcome_prng;
 } AutoplayWorker;
 
 AutoplayWorker *autoplay_worker_create(const AutoplayArgs *args,
@@ -335,6 +343,14 @@ AutoplayWorker *autoplay_worker_create(const AutoplayArgs *args,
   autoplay_worker->inference_results = NULL;
   autoplay_worker->error_stack = NULL;
 
+  autoplay_worker->outcome_buffer = NULL;
+  autoplay_worker->outcome_prng = NULL;
+  if (shared_data->outcome_recorder != NULL) {
+    autoplay_worker->outcome_buffer = outcome_game_buffer_create();
+    autoplay_worker->outcome_prng = prng_create(
+        args->seed + 0x9E3779B97F4A7C15ULL * (uint64_t)worker_index);
+  }
+
   // Only allocate sim structs if at least one of the players running a sim.
   if (ap_args->p1_sim_args.num_plies > 0 ||
       ap_args->p2_sim_args.num_plies > 0) {
@@ -364,6 +380,8 @@ void autoplay_worker_destroy(AutoplayWorker *autoplay_worker) {
   error_stack_destroy(autoplay_worker->error_stack);
   move_list_destroy(autoplay_worker->move_lists[0]);
   move_list_destroy(autoplay_worker->move_lists[1]);
+  outcome_game_buffer_destroy(autoplay_worker->outcome_buffer);
+  prng_destroy(autoplay_worker->outcome_prng);
   free(autoplay_worker);
 }
 
@@ -417,6 +435,11 @@ autoplay_shared_data_create(const AutoplayArgs *args, int num_autoplay_threads,
         args->data_paths, klv, num_autoplay_threads, num_gens,
         min_rack_targets);
   }
+  shared_data->outcome_recorder = NULL;
+  if (args->outcome_dump_path != NULL && args->outcome_dump_path[0] != '\0') {
+    shared_data->outcome_recorder =
+        outcome_recorder_create(args->outcome_dump_path);
+  }
   return shared_data;
 }
 
@@ -436,6 +459,7 @@ void autoplay_shared_data_destroy(AutoplaySharedData *shared_data) {
   }
   prng_destroy(shared_data->prng);
   leavegen_shared_data_destroy(shared_data->leavegen_shared_data);
+  outcome_recorder_destroy(shared_data->outcome_recorder);
   free(shared_data);
 }
 
@@ -713,6 +737,50 @@ const Move *game_runner_play_move(AutoplayWorker *autoplay_worker,
     play_move(&game_runner->previous_move, game_runner->game_one_move_behind,
               NULL);
   }
+
+  // Outcome-model training-data recording. Skip non-tile-placement
+  // moves (passes/exchanges); model is trained on tile-placement
+  // positions only. Skip the second game in a game pair.
+  if (autoplay_worker->shared_data->outcome_recorder != NULL &&
+      game_runner->pair_game_number != 2 &&
+      move_get_type(move) == GAME_EVENT_TILE_PLACEMENT_MOVE) {
+    // Reconstruct the pre-draw unseen pool from us's POV.
+    // After play_move: us_rack = leave + drawn, bag = post-draw,
+    //   opp_rack = unchanged. So pre-draw bag = bag + drawn.
+    //   pool_pre_draw[L] = bag[L] + (us_rack[L] - leave[L]) + opp_rack[L].
+    const LetterDistribution *ld = game_get_ld(game);
+    const int ld_size = ld_get_size(ld);
+    const Player *us_player = game_get_player(game, player_on_turn_index);
+    const Player *opp_player = game_get_player(game, 1 - player_on_turn_index);
+    const Rack *us_rack_full = player_get_rack(us_player);
+    const Rack *opp_rack_full = player_get_rack(opp_player);
+    const Bag *bag = game_get_bag(game);
+
+    uint8_t pool_counts[MAX_ALPHABET_SIZE] = {0};
+    int pool_size = 0;
+    for (int ml = 0; ml < ld_size; ml++) {
+      const int n_bag = bag_get_letter(bag, (MachineLetter)ml);
+      const int n_us = rack_get_letter(us_rack_full, (MachineLetter)ml);
+      const int n_leave =
+          rack_get_letter(&rare_rack_or_move_leave, (MachineLetter)ml);
+      const int n_opp = rack_get_letter(opp_rack_full, (MachineLetter)ml);
+      pool_counts[ml] = (uint8_t)(n_bag + (n_us - n_leave) + n_opp);
+      pool_size += n_bag + (n_us - n_leave) + n_opp;
+    }
+
+    OutcomeFeatures features;
+    const int bingo_samples = autoplay_worker->args.outcome_bingo_samples > 0
+                                  ? autoplay_worker->args.outcome_bingo_samples
+                                  : 14;
+    outcome_features_compute(
+        game, autoplay_worker->move_lists[player_on_turn_index],
+        autoplay_worker->worker_index, player_on_turn_index,
+        &rare_rack_or_move_leave, pool_counts, pool_size, bingo_samples,
+        autoplay_worker->outcome_prng, &features);
+    outcome_game_buffer_add(autoplay_worker->outcome_buffer, &features,
+                            player_on_turn_index);
+  }
+
   move_copy(&game_runner->previous_move, move);
   game_runner->turn_number++;
   return move;
@@ -830,6 +898,19 @@ void play_autoplay_game_or_game_pair(AutoplayWorker *autoplay_worker,
     // does not use game pairs and therefore does not have a second
     // game runner.
     autoplay_add_game(autoplay_worker, game_runner2, games_are_divergent);
+  }
+
+  // Flush the per-worker outcome buffer with final scores. The buffer
+  // only contains rows from game_runner1 (we skip recording for the
+  // paired second game above).
+  if (autoplay_worker->shared_data->outcome_recorder != NULL) {
+    const Player *p0 = game_get_player(game_runner1->game, 0);
+    const Player *p1 = game_get_player(game_runner1->game, 1);
+    const int p0_score = (int)player_get_score(p0);
+    const int p1_score = (int)player_get_score(p1);
+    outcome_game_buffer_flush(autoplay_worker->outcome_buffer,
+                              autoplay_worker->shared_data->outcome_recorder,
+                              p0_score, p1_score);
   }
 }
 

--- a/src/impl/autoplay.h
+++ b/src/impl/autoplay.h
@@ -29,6 +29,11 @@ typedef struct AutoplayArgs {
   double cutoff;
   SimArgs p1_sim_args;
   SimArgs p2_sim_args;
+  // outcome_model training-data dump. NULL if disabled. When non-NULL,
+  // every tile-placement move emits one CSV row of (features, eventual
+  // win/spread) at recording-moment on-turn POV. See outcome_recorder.h.
+  const char *outcome_dump_path;
+  int outcome_bingo_samples; // bingo_prob sample count per side (default 14)
 } AutoplayArgs;
 
 void autoplay(const AutoplayArgs *args, AutoplayResults *autoplay_results,

--- a/src/impl/bingo_prob.c
+++ b/src/impl/bingo_prob.c
@@ -1,0 +1,93 @@
+// Sample-based bingo probability for outcome_model feature extraction.
+
+#include "bingo_prob.h"
+
+#include "../def/equity_defs.h"
+#include "../def/letter_distribution_defs.h"
+#include "../def/move_defs.h"
+#include "../ent/letter_distribution.h"
+#include "../ent/player.h"
+#include "../ent/rack.h"
+#include "move_gen.h"
+#include <stdint.h>
+#include <string.h>
+
+static void sample_one_rack(XoshiroPRNG *prng, const uint8_t *pool_counts,
+                            int pool_size, int draw_size, uint8_t *drawn,
+                            uint16_t *scratch) {
+  for (int ml = 0; ml < MAX_ALPHABET_SIZE; ml++) {
+    scratch[ml] = pool_counts[ml];
+    drawn[ml] = 0;
+  }
+  int remaining = pool_size;
+  for (int i = 0; i < draw_size; i++) {
+    const uint64_t pick = prng_get_random_number(prng, (uint64_t)remaining);
+    uint64_t cum = 0;
+    for (int ml = 0; ml < MAX_ALPHABET_SIZE; ml++) {
+      cum += scratch[ml];
+      if (pick < cum) {
+        drawn[ml]++;
+        scratch[ml]--;
+        remaining--;
+        break;
+      }
+    }
+  }
+}
+
+double bingo_prob_sampled(Game *game, MoveList *mv_list, int thread_index,
+                          const uint8_t *leave_counts,
+                          const uint8_t *pool_counts, int pool_size,
+                          int draw_size, int num_samples, XoshiroPRNG *prng) {
+  if (num_samples <= 0) {
+    return 0.0;
+  }
+  if (draw_size > 0 && pool_size < draw_size) {
+    return 0.0;
+  }
+
+  const int player_idx = game_get_player_on_turn_index(game);
+  Player *player = game_get_player(game, player_idx);
+  Rack *rack = player_get_rack(player);
+  const int ld_size = ld_get_size(game_get_ld(game));
+
+  Rack saved_rack;
+  rack_set_dist_size(&saved_rack, ld_size);
+  rack_copy(&saved_rack, rack);
+
+  uint8_t drawn[MAX_ALPHABET_SIZE];
+  uint16_t scratch[MAX_ALPHABET_SIZE];
+
+  const MoveGenArgs args = {
+      .game = game,
+      .move_list = mv_list,
+      .move_record_type = MOVE_RECORD_BINGO_EXISTS,
+      .move_sort_type = MOVE_SORT_SCORE,
+      .thread_index = thread_index,
+      .eq_margin_movegen = 0,
+      .target_equity = EQUITY_MAX_VALUE,
+      .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+  };
+
+  int bingo_count = 0;
+  for (int s = 0; s < num_samples; s++) {
+    if (draw_size > 0) {
+      sample_one_rack(prng, pool_counts, pool_size, draw_size, drawn, scratch);
+    } else {
+      memset(drawn, 0, sizeof(drawn));
+    }
+    rack_reset(rack);
+    for (int ml = 0; ml < ld_size; ml++) {
+      const int n = (int)leave_counts[ml] + (int)drawn[ml];
+      if (n > 0) {
+        rack_add_letters(rack, (MachineLetter)ml, n);
+      }
+    }
+    if (bingo_exists(&args)) {
+      bingo_count++;
+    }
+  }
+
+  rack_copy(rack, &saved_rack);
+  return (double)bingo_count / (double)num_samples;
+}

--- a/src/impl/bingo_prob.h
+++ b/src/impl/bingo_prob.h
@@ -1,0 +1,24 @@
+#ifndef BINGO_PROB_H
+#define BINGO_PROB_H
+
+#include "../ent/game.h"
+#include "../ent/move.h"
+#include "../ent/xoshiro.h"
+#include <stdint.h>
+
+// Sample-based estimate of the probability that a rack of the form
+//   leave + (random hypergeometric draw of draw_size from pool)
+// can play a bingo on the current board.
+//
+// Uses bingo_exists internally. Temporarily mutates and restores the
+// on-turn player's rack. Caller is responsible for setting on-turn to
+// the player whose perspective we're computing for (cross_set_index
+// follows on-turn when KWGs aren't shared).
+//
+// Returns 0.0 if num_samples <= 0 or draw_size > pool_size.
+double bingo_prob_sampled(Game *game, MoveList *mv_list, int thread_index,
+                          const uint8_t *leave_counts,
+                          const uint8_t *pool_counts, int pool_size,
+                          int draw_size, int num_samples, XoshiroPRNG *prng);
+
+#endif

--- a/src/impl/config.c
+++ b/src/impl/config.c
@@ -1817,7 +1817,8 @@ void add_help_arg_to_string_builder(const Config *config, int token,
       text = "Outcome-model training dump path. When set, autoplay writes "
              "one CSV row per tile-placement move with position features "
              "(single-tile, bingo prob, blanks, etc.) and the eventual "
-             "win/spread for that position's on-turn player.";
+             "win/spread for that position's on-turn player. Requires "
+             "-wmp true (the bingo-prob feature uses bingo_exists).";
       break;
     case ARG_TOKEN_OUTCOME_BINGO_SAMPLES:
       usages[0] = "<n>";
@@ -2960,7 +2961,8 @@ void config_fill_autoplay_args(const Config *config,
                                AutoplayArgs *autoplay_args,
                                autoplay_t autoplay_type,
                                const char *num_games_or_min_rack_targets,
-                               int games_before_force_draw_start) {
+                               int games_before_force_draw_start,
+                               ErrorStack *error_stack) {
   autoplay_args->type = autoplay_type;
   autoplay_args->num_games_or_min_rack_targets = num_games_or_min_rack_targets;
   autoplay_args->games_before_force_draw_start = games_before_force_draw_start;
@@ -2977,14 +2979,31 @@ void config_fill_autoplay_args(const Config *config,
   autoplay_args->cutoff = config->cutoff;
   autoplay_args->outcome_dump_path =
       config_get_parg_value(config, ARG_TOKEN_OUTCOME_DUMP, 0);
+  if (autoplay_args->outcome_dump_path != NULL) {
+    // -tdump features include bingo_prob, which requires WMP. Fail fast
+    // here rather than crashing mid-run inside bingo_exists.
+    for (int player_idx = 0; player_idx < 2; player_idx++) {
+      if (players_data_get_wmp(config->players_data, player_idx) == NULL) {
+        error_stack_push(
+            error_stack, ERROR_STATUS_AUTOPLAY_INVALID_OPTIONS,
+            get_formatted_string(
+                "the -tdump option requires WMP loaded for both players "
+                "(player %d has no WMP); pass -wmp true",
+                player_idx + 1));
+        return;
+      }
+    }
+  }
   autoplay_args->outcome_bingo_samples = 14;
   const char *bs_str =
       config_get_parg_value(config, ARG_TOKEN_OUTCOME_BINGO_SAMPLES, 0);
   if (bs_str != NULL) {
-    char *end = NULL;
-    long parsed = strtol(bs_str, &end, 10);
-    if (end != bs_str && *end == '\0' && parsed > 0 && parsed < 1000000) {
-      autoplay_args->outcome_bingo_samples = (int)parsed;
+    string_to_int_or_push_error("tbingosamples", bs_str, 1, 999999,
+                                ERROR_STATUS_CONFIG_LOAD_MALFORMED_INT_ARG,
+                                &autoplay_args->outcome_bingo_samples,
+                                error_stack);
+    if (!error_stack_is_empty(error_stack)) {
+      return;
     }
   }
 
@@ -3071,7 +3090,10 @@ void config_autoplay(const Config *config, AutoplayResults *autoplay_results,
   args.game_args = &game_args;
   config_fill_autoplay_args(config, &args, autoplay_type,
                             num_games_or_min_rack_targets,
-                            games_before_force_draw_start);
+                            games_before_force_draw_start, error_stack);
+  if (!error_stack_is_empty(error_stack)) {
+    return;
+  }
   autoplay(&args, autoplay_results, error_stack);
 }
 

--- a/src/impl/config.c
+++ b/src/impl/config.c
@@ -205,6 +205,8 @@ typedef enum {
   ARG_TOKEN_P1_INFERENCE_MARGIN,
   ARG_TOKEN_P2_INFERENCE_MARGIN,
   ARG_TOKEN_MULTI_THREADING_MODE,
+  ARG_TOKEN_OUTCOME_DUMP,          // -tdump <path>
+  ARG_TOKEN_OUTCOME_BINGO_SAMPLES, // -tbingosamples <int>
   // This must always be the last
   // token for the count to be accurate
   NUMBER_OF_ARG_TOKENS
@@ -1809,6 +1811,20 @@ void add_help_arg_to_string_builder(const Config *config, int token,
              "(default). " MULTI_THREADING_MODE_INTRA_GAME_PARALLELISM_STRING
              " runs one game at a time using all threads for simulation.";
       break;
+    case ARG_TOKEN_OUTCOME_DUMP:
+      usages[0] = "<csv_path>";
+      examples[0] = "training.csv";
+      text = "Outcome-model training dump path. When set, autoplay writes "
+             "one CSV row per tile-placement move with position features "
+             "(single-tile, bingo prob, blanks, etc.) and the eventual "
+             "win/spread for that position's on-turn player.";
+      break;
+    case ARG_TOKEN_OUTCOME_BINGO_SAMPLES:
+      usages[0] = "<n>";
+      examples[0] = "14";
+      text = "Number of random racks per side used to sample bingo "
+             "probability for outcome-model training rows. Default 14.";
+      break;
     case NUMBER_OF_ARG_TOKENS:
       log_fatal("encountered invalid arg token in help command");
       break;
@@ -2959,6 +2975,18 @@ void config_fill_autoplay_args(const Config *config,
   config_fill_game_args(config, autoplay_args->game_args);
   autoplay_args->multi_threading_mode = config->multi_threading_mode;
   autoplay_args->cutoff = config->cutoff;
+  autoplay_args->outcome_dump_path =
+      config_get_parg_value(config, ARG_TOKEN_OUTCOME_DUMP, 0);
+  autoplay_args->outcome_bingo_samples = 14;
+  const char *bs_str =
+      config_get_parg_value(config, ARG_TOKEN_OUTCOME_BINGO_SAMPLES, 0);
+  if (bs_str != NULL) {
+    char *end = NULL;
+    long parsed = strtol(bs_str, &end, 10);
+    if (end != bs_str && *end == '\0' && parsed > 0 && parsed < 1000000) {
+      autoplay_args->outcome_bingo_samples = (int)parsed;
+    }
+  }
 
   autoplay_args->num_threads = config->num_threads;
   int num_worker_threads_per_sim = 1;
@@ -7288,6 +7316,8 @@ Config *config_create(const ConfigArgs *config_args, ErrorStack *error_stack) {
   arg(ARG_TOKEN_P1_INFERENCE_MARGIN, "im1", 1, 1);
   arg(ARG_TOKEN_P2_INFERENCE_MARGIN, "im2", 1, 1);
   arg(ARG_TOKEN_MULTI_THREADING_MODE, "mtmode", 1, 1);
+  arg(ARG_TOKEN_OUTCOME_DUMP, "tdump", 1, 1);
+  arg(ARG_TOKEN_OUTCOME_BINGO_SAMPLES, "tbingosamples", 1, 1);
   arg(ARG_TOKEN_PRINT_BOARDS, "printboards", 1, 1);
   arg(ARG_TOKEN_BOARD_COLOR, "boardcolor", 1, 1);
   arg(ARG_TOKEN_BOARD_TILE_GLYPHS, "boardtiles", 1, 1);
@@ -7526,6 +7556,10 @@ void config_add_settings_to_string_builder(const Config *config,
     case ARG_TOKEN_NOTE:
     case ARG_TOKEN_P1_NAME:
     case ARG_TOKEN_P2_NAME:
+    case ARG_TOKEN_OUTCOME_DUMP:
+    case ARG_TOKEN_OUTCOME_BINGO_SAMPLES:
+      // outcome dump options are not persisted as settings; they are
+      // per-autoplay-invocation flags.
       break;
     case ARG_TOKEN_MULTI_THREADING_MODE:
       string_builder_add_formatted_string(sb, " -%s ",

--- a/src/impl/outcome_features.c
+++ b/src/impl/outcome_features.c
@@ -7,6 +7,7 @@
 
 #include "../def/letter_distribution_defs.h"
 #include "../def/rack_defs.h"
+#include "../ent/klv.h"
 #include "../ent/letter_distribution.h"
 #include "../ent/player.h"
 #include "../ent/rack.h"
@@ -75,4 +76,8 @@ void outcome_features_compute(Game *game, MoveList *mv_list, int thread_index,
   const Player *opp_player = game_get_player(game, opp_idx);
   out->score_diff =
       (int)player_get_score(us_player) - (int)player_get_score(opp_player);
+  // KLV value of us's leave (Equity millipoints). 0 if leave is empty
+  // (full bingo) or no KLV is loaded for us.
+  const KLV *us_klv = player_get_klv(us_player);
+  out->us_leave_value = (int)klv_get_leave_value(us_klv, us_leave);
 }

--- a/src/impl/outcome_features.c
+++ b/src/impl/outcome_features.c
@@ -7,6 +7,7 @@
 
 #include "../def/letter_distribution_defs.h"
 #include "../def/rack_defs.h"
+#include "../ent/equity.h"
 #include "../ent/klv.h"
 #include "../ent/letter_distribution.h"
 #include "../ent/player.h"
@@ -74,8 +75,8 @@ void outcome_features_compute(Game *game, MoveList *mv_list, int thread_index,
   out->tiles_unseen = pool_size;
   const Player *us_player = game_get_player(game, us_idx);
   const Player *opp_player = game_get_player(game, opp_idx);
-  out->score_diff =
-      (int)player_get_score(us_player) - (int)player_get_score(opp_player);
+  out->score_diff = equity_to_int(player_get_score(us_player)) -
+                    equity_to_int(player_get_score(opp_player));
   // KLV value of us's leave (Equity millipoints). 0 if leave is empty
   // (full bingo) or no KLV is loaded for us.
   const KLV *us_klv = player_get_klv(us_player);

--- a/src/impl/outcome_features.c
+++ b/src/impl/outcome_features.c
@@ -1,0 +1,78 @@
+// Aggregator: computes the full set of position features for the
+// outcome_model. Decoupled from the game's bag — caller passes a
+// reconstructed pre-draw pool so the function can be invoked at any
+// point in autoplay's per-move loop.
+
+#include "outcome_features.h"
+
+#include "../def/letter_distribution_defs.h"
+#include "../def/rack_defs.h"
+#include "../ent/letter_distribution.h"
+#include "../ent/player.h"
+#include "../ent/rack.h"
+#include "bingo_prob.h"
+#include "single_tile_play.h"
+#include <stdint.h>
+#include <string.h>
+
+void outcome_features_compute(Game *game, MoveList *mv_list, int thread_index,
+                              int us_player_index, const Rack *us_leave,
+                              const uint8_t *pool_counts, int pool_size,
+                              int bingo_samples, XoshiroPRNG *prng,
+                              OutcomeFeatures *out) {
+  const LetterDistribution *ld = game_get_ld(game);
+  const int ld_size = ld_get_size(ld);
+  const int us_idx = us_player_index;
+  const int opp_idx = 1 - us_idx;
+
+  uint8_t us_leave_counts[MAX_ALPHABET_SIZE] = {0};
+  int us_leave_size = 0;
+  for (int ml = 0; ml < ld_size; ml++) {
+    const int n = rack_get_letter(us_leave, (MachineLetter)ml);
+    us_leave_counts[ml] = (uint8_t)n;
+    us_leave_size += n;
+  }
+  const int us_draw_size = RACK_SIZE - us_leave_size;
+  uint8_t empty_leave[MAX_ALPHABET_SIZE] = {0};
+
+  const int saved_on_turn = game_get_player_on_turn_index(game);
+
+  // ---- us features ----
+  game_set_player_on_turn_index(game, us_idx);
+  SingleTileScan scan_us;
+  single_tile_scan(game, &scan_us);
+  SingleTileFeatures st_us;
+  single_tile_features(&scan_us, ld, us_leave_counts, pool_counts, pool_size,
+                       us_draw_size, RACK_SIZE, &st_us);
+  out->us_st_frac_playable = st_us.frac_playable;
+  out->us_st_top1 = st_us.e_top1;
+  out->us_st_top2 = st_us.e_top2;
+  // bingo_prob_sampled saves and restores us's rack; we just need
+  // on-turn = us so cross_set_index follows us's KWG when not shared.
+  out->us_bingo_prob = bingo_prob_sampled(
+      game, mv_list, thread_index, us_leave_counts, pool_counts, pool_size,
+      us_draw_size, bingo_samples, prng);
+
+  // ---- opp features ----
+  game_set_player_on_turn_index(game, opp_idx);
+  SingleTileScan scan_opp;
+  single_tile_scan(game, &scan_opp);
+  SingleTileFeatures st_opp;
+  single_tile_features(&scan_opp, ld, empty_leave, pool_counts, pool_size,
+                       RACK_SIZE, RACK_SIZE, &st_opp);
+  out->opp_st_frac_playable = st_opp.frac_playable;
+  out->opp_st_top1 = st_opp.e_top1;
+  out->opp_st_top2 = st_opp.e_top2;
+  out->opp_bingo_prob =
+      bingo_prob_sampled(game, mv_list, thread_index, empty_leave, pool_counts,
+                         pool_size, RACK_SIZE, bingo_samples, prng);
+
+  game_set_player_on_turn_index(game, saved_on_turn);
+
+  out->unplayed_blanks = pool_counts[BLANK_MACHINE_LETTER];
+  out->tiles_unseen = pool_size;
+  const Player *us_player = game_get_player(game, us_idx);
+  const Player *opp_player = game_get_player(game, opp_idx);
+  out->score_diff =
+      (int)player_get_score(us_player) - (int)player_get_score(opp_player);
+}

--- a/src/impl/outcome_features.h
+++ b/src/impl/outcome_features.h
@@ -1,0 +1,54 @@
+#ifndef OUTCOME_FEATURES_H
+#define OUTCOME_FEATURES_H
+
+#include "../ent/game.h"
+#include "../ent/move.h"
+#include "../ent/rack.h"
+#include "../ent/xoshiro.h"
+#include <stdint.h>
+
+// Features computed at the post-move-pre-draw moment from us's
+// perspective.
+typedef struct {
+  // single-tile features (us + opp)
+  double us_st_frac_playable;
+  double us_st_top1;
+  double us_st_top2;
+  double opp_st_frac_playable;
+  double opp_st_top1;
+  double opp_st_top2;
+  // bingo prob features (sampled)
+  double us_bingo_prob;
+  double opp_bingo_prob;
+  // misc scalars
+  int unplayed_blanks; // count of blanks in the unseen pool
+  int tiles_unseen;    // total tiles in unseen pool (bag + opp rack)
+  int score_diff;      // us_score - opp_score (signed) at this position
+} OutcomeFeatures;
+
+// Computes all features for the recorded position.
+//
+// Caller responsibilities:
+// - The game's board is already in its post-move state with
+//   cross_sets updated (true after play_move).
+// - us_player_index is the player who just played (whose features and
+//   eventual outcome we're recording).
+// - us_leave is the actual leave from the move (size 0..6).
+// - pool_counts is the reconstructed pre-draw unseen pool from us's
+//   POV: bag (post-draw, current) + tiles drawn during play_move +
+//   opp's rack. Length MAX_ALPHABET_SIZE; pool_size = sum.
+// - Scores at us_player_index already include the played move (true
+//   after play_move).
+//
+// Mutates and restores game's on-turn-index and both players' racks.
+//
+// thread_index, prng: per-thread state for bingo_exists / sampling.
+// bingo_samples: number of random racks per side for bingo prob (the
+//                project notes settled on 14).
+void outcome_features_compute(Game *game, MoveList *mv_list, int thread_index,
+                              int us_player_index, const Rack *us_leave,
+                              const uint8_t *pool_counts, int pool_size,
+                              int bingo_samples, XoshiroPRNG *prng,
+                              OutcomeFeatures *out);
+
+#endif

--- a/src/impl/outcome_features.h
+++ b/src/impl/outcome_features.h
@@ -24,6 +24,7 @@ typedef struct {
   int unplayed_blanks; // count of blanks in the unseen pool
   int tiles_unseen;    // total tiles in unseen pool (bag + opp rack)
   int score_diff;      // us_score - opp_score (signed) at this position
+  int us_leave_value;  // KLV leave value for us's leave (Equity millipoints)
 } OutcomeFeatures;
 
 // Computes all features for the recorded position.

--- a/src/impl/outcome_recorder.c
+++ b/src/impl/outcome_recorder.c
@@ -1,0 +1,112 @@
+// Per-game in-memory buffer + thread-safe CSV writer for outcome_model
+// training data.
+
+#include "outcome_recorder.h"
+
+#include "../compat/cpthread.h"
+#include "../def/cpthread_defs.h"
+#include "../util/io_util.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct OutcomeRecorder {
+  FILE *fp;
+  cpthread_mutex_t mutex;
+};
+
+typedef struct {
+  OutcomeFeatures features;
+  int us_player_index;
+} BufferedRow;
+
+struct OutcomeGameBuffer {
+  BufferedRow *rows;
+  int count;
+  int cap;
+};
+
+OutcomeRecorder *outcome_recorder_create(const char *path) {
+  OutcomeRecorder *rec = malloc_or_die(sizeof(OutcomeRecorder));
+  rec->fp = fopen(path, "w");
+  if (rec->fp == NULL) {
+    log_fatal("could not open outcome recorder file '%s'", path);
+  }
+  cpthread_mutex_init(&rec->mutex);
+  // Header row.
+  fprintf(rec->fp, "us_st_frac_playable,us_st_top1,us_st_top2,"
+                   "opp_st_frac_playable,opp_st_top1,opp_st_top2,"
+                   "us_bingo_prob,opp_bingo_prob,"
+                   "unplayed_blanks,tiles_unseen,score_diff,"
+                   "win,final_spread\n");
+  return rec;
+}
+
+void outcome_recorder_destroy(OutcomeRecorder *rec) {
+  if (rec == NULL) {
+    return;
+  }
+  if (rec->fp != NULL) {
+    fclose(rec->fp);
+  }
+  free(rec);
+}
+
+OutcomeGameBuffer *outcome_game_buffer_create(void) {
+  OutcomeGameBuffer *buf = malloc_or_die(sizeof(OutcomeGameBuffer));
+  buf->cap = 64;
+  buf->count = 0;
+  buf->rows = malloc_or_die((size_t)buf->cap * sizeof(BufferedRow));
+  return buf;
+}
+
+void outcome_game_buffer_destroy(OutcomeGameBuffer *buf) {
+  if (buf == NULL) {
+    return;
+  }
+  free(buf->rows);
+  free(buf);
+}
+
+void outcome_game_buffer_reset(OutcomeGameBuffer *buf) { buf->count = 0; }
+
+void outcome_game_buffer_add(OutcomeGameBuffer *buf,
+                             const OutcomeFeatures *features,
+                             int us_player_index) {
+  if (buf->count == buf->cap) {
+    buf->cap *= 2;
+    buf->rows =
+        realloc_or_die(buf->rows, (size_t)buf->cap * sizeof(BufferedRow));
+  }
+  buf->rows[buf->count].features = *features;
+  buf->rows[buf->count].us_player_index = us_player_index;
+  buf->count++;
+}
+
+void outcome_game_buffer_flush(OutcomeGameBuffer *buf, OutcomeRecorder *rec,
+                               int p0_final_score, int p1_final_score) {
+  if (rec == NULL || buf->count == 0) {
+    outcome_game_buffer_reset(buf);
+    return;
+  }
+  cpthread_mutex_lock(&rec->mutex);
+  for (int i = 0; i < buf->count; i++) {
+    const BufferedRow *row = &buf->rows[i];
+    const int us_score =
+        (row->us_player_index == 0) ? p0_final_score : p1_final_score;
+    const int opp_score =
+        (row->us_player_index == 0) ? p1_final_score : p0_final_score;
+    const int spread = us_score - opp_score;
+    const double win = (spread > 0) ? 1.0 : (spread < 0) ? 0.0 : 0.5;
+    const OutcomeFeatures *f = &row->features;
+    fprintf(rec->fp,
+            "%.6f,%.3f,%.3f,%.6f,%.3f,%.3f,%.6f,%.6f,%d,%d,%d,%.1f,%d\n",
+            f->us_st_frac_playable, f->us_st_top1, f->us_st_top2,
+            f->opp_st_frac_playable, f->opp_st_top1, f->opp_st_top2,
+            f->us_bingo_prob, f->opp_bingo_prob, f->unplayed_blanks,
+            f->tiles_unseen, f->score_diff, win, spread);
+  }
+  cpthread_mutex_unlock(&rec->mutex);
+  outcome_game_buffer_reset(buf);
+}

--- a/src/impl/outcome_recorder.c
+++ b/src/impl/outcome_recorder.c
@@ -39,6 +39,7 @@ OutcomeRecorder *outcome_recorder_create(const char *path) {
                    "opp_st_frac_playable,opp_st_top1,opp_st_top2,"
                    "us_bingo_prob,opp_bingo_prob,"
                    "unplayed_blanks,tiles_unseen,score_diff,"
+                   "us_leave_value,"
                    "win,final_spread\n");
   return rec;
 }
@@ -101,11 +102,11 @@ void outcome_game_buffer_flush(OutcomeGameBuffer *buf, OutcomeRecorder *rec,
     const double win = (spread > 0) ? 1.0 : (spread < 0) ? 0.0 : 0.5;
     const OutcomeFeatures *f = &row->features;
     fprintf(rec->fp,
-            "%.6f,%.3f,%.3f,%.6f,%.3f,%.3f,%.6f,%.6f,%d,%d,%d,%.1f,%d\n",
+            "%.6f,%.3f,%.3f,%.6f,%.3f,%.3f,%.6f,%.6f,%d,%d,%d,%d,%.1f,%d\n",
             f->us_st_frac_playable, f->us_st_top1, f->us_st_top2,
             f->opp_st_frac_playable, f->opp_st_top1, f->opp_st_top2,
             f->us_bingo_prob, f->opp_bingo_prob, f->unplayed_blanks,
-            f->tiles_unseen, f->score_diff, win, spread);
+            f->tiles_unseen, f->score_diff, f->us_leave_value, win, spread);
   }
   cpthread_mutex_unlock(&rec->mutex);
   outcome_game_buffer_reset(buf);

--- a/src/impl/outcome_recorder.h
+++ b/src/impl/outcome_recorder.h
@@ -1,0 +1,49 @@
+#ifndef OUTCOME_RECORDER_H
+#define OUTCOME_RECORDER_H
+
+#include "../compat/cpthread.h"
+#include "outcome_features.h"
+#include <stdint.h>
+#include <stdio.h>
+
+// Thread-safe CSV writer for outcome_model training rows. Each thread
+// owns a buffer of features captured during a single game; on game end
+// the thread fills in the win/spread targets (looked up from final
+// game scores) and flushes the buffer to the shared CSV file under a
+// mutex.
+//
+// CSV columns:
+//   us_st_frac_playable, us_st_top1, us_st_top2,
+//   opp_st_frac_playable, opp_st_top1, opp_st_top2,
+//   us_bingo_prob, opp_bingo_prob,
+//   unplayed_blanks, tiles_unseen, score_diff,
+//   win, final_spread
+//
+// "win" is 0 / 0.5 / 1 from the recording-moment on-turn player's POV.
+// "final_spread" is signed, also from that POV.
+
+typedef struct OutcomeRecorder OutcomeRecorder;
+
+OutcomeRecorder *outcome_recorder_create(const char *path);
+void outcome_recorder_destroy(OutcomeRecorder *rec);
+
+// Per-game buffer. Each worker (or each game-runner) gets its own.
+typedef struct OutcomeGameBuffer OutcomeGameBuffer;
+
+OutcomeGameBuffer *outcome_game_buffer_create(void);
+void outcome_game_buffer_destroy(OutcomeGameBuffer *buf);
+void outcome_game_buffer_reset(OutcomeGameBuffer *buf);
+
+// Append one row's features. The recording-moment on-turn player index
+// is captured so we can flip win/spread to that POV at flush time.
+void outcome_game_buffer_add(OutcomeGameBuffer *buf,
+                             const OutcomeFeatures *features,
+                             int us_player_index);
+
+// Flush the buffer to the recorder, computing win/spread for each row
+// from the final scores. Acquires the recorder's mutex once for the
+// whole flush. Resets the buffer.
+void outcome_game_buffer_flush(OutcomeGameBuffer *buf, OutcomeRecorder *rec,
+                               int p0_final_score, int p1_final_score);
+
+#endif

--- a/src/impl/outcome_recorder.h
+++ b/src/impl/outcome_recorder.h
@@ -16,7 +16,7 @@
 //   us_st_frac_playable, us_st_top1, us_st_top2,
 //   opp_st_frac_playable, opp_st_top1, opp_st_top2,
 //   us_bingo_prob, opp_bingo_prob,
-//   unplayed_blanks, tiles_unseen, score_diff,
+//   unplayed_blanks, tiles_unseen, score_diff, us_leave_value,
 //   win, final_spread
 //
 // "win" is 0 / 0.5 / 1 from the recording-moment on-turn player's POV.

--- a/src/impl/single_tile_play.c
+++ b/src/impl/single_tile_play.c
@@ -28,8 +28,7 @@ void single_tile_scan(const Game *game, SingleTileScan *scan) {
 
   const Board *board = game_get_board(game);
   const int player_index = game_get_player_on_turn_index(game);
-  const bool kwgs_shared =
-      game_get_data_is_shared(game, PLAYERS_DATA_TYPE_KWG);
+  const bool kwgs_shared = game_get_data_is_shared(game, PLAYERS_DATA_TYPE_KWG);
   const int csi = board_get_cross_set_index(kwgs_shared, player_index);
 
   for (int row = 0; row < BOARD_DIM; row++) {
@@ -37,8 +36,8 @@ void single_tile_scan(const Game *game, SingleTileScan *scan) {
       if (!board_is_empty(board, row, col)) {
         continue;
       }
-      const uint64_t cs_h = board_get_cross_set(
-          board, row, col, BOARD_HORIZONTAL_DIRECTION, csi);
+      const uint64_t cs_h =
+          board_get_cross_set(board, row, col, BOARD_HORIZONTAL_DIRECTION, csi);
       const uint64_t cs_v =
           board_get_cross_set(board, row, col, BOARD_VERTICAL_DIRECTION, csi);
       const uint64_t playable = cs_h & cs_v;
@@ -51,8 +50,8 @@ void single_tile_scan(const Game *game, SingleTileScan *scan) {
       const BonusSquare bonus = board_get_bonus_square(board, row, col);
       const int letter_mult = bonus_square_get_letter_multiplier(bonus);
       const int word_mult = bonus_square_get_word_multiplier(bonus);
-      const Equity h_run = board_get_cross_score(
-          board, row, col, BOARD_VERTICAL_DIRECTION, csi);
+      const Equity h_run =
+          board_get_cross_score(board, row, col, BOARD_VERTICAL_DIRECTION, csi);
       const Equity v_run = board_get_cross_score(
           board, row, col, BOARD_HORIZONTAL_DIRECTION, csi);
       const int has_h_word = (cs_v != TRIVIAL_CROSS_SET) ? 1 : 0;
@@ -307,9 +306,8 @@ void single_tile_features(const SingleTileScan *scan,
 
   // E[top1] = E[max over rack of best_score[L]] — exact via per-letter
   // order statistics.
-  out->e_top1 =
-      e_max_per_letter(scan->best_score, leave_counts, pool_counts, pool_size,
-                       draw_size, denom_eff, effective_d);
+  out->e_top1 = e_max_per_letter(scan->best_score, leave_counts, pool_counts,
+                                 pool_size, draw_size, denom_eff, effective_d);
 
   // E[top2] proxy: per-square E[max], then 2nd-largest across squares.
   // This is a Jensen-biased approximation of E[2nd-largest per-square


### PR DESCRIPTION
## Summary

Third PR in the outcome_model effort (stacked on #524). Adds the autoplay hook that emits per-position training rows for the regression model, plus the bingo-prob feature and the unplayed-blanks/score-diff/leave-value scalars.

\`\`\`
./bin/magpie set -lex CSW21 -wmp true -threads 8
./bin/magpie autoplay games 10000 -tdump train.csv -tbingosamples 14
\`\`\`

→ writes one row per tile-placement move with the 12 features and 2 targets:

\`\`\`
us_st_frac_playable, us_st_top1, us_st_top2,
opp_st_frac_playable, opp_st_top1, opp_st_top2,
us_bingo_prob, opp_bingo_prob,
unplayed_blanks, tiles_unseen, score_diff, us_leave_value,
win, final_spread
\`\`\`

## What's new

- **\`bingo_prob.{h,c}\`** — \`bingo_prob_sampled(...)\`. Calls \`bingo_exists\` over N random racks (default 14) drawn hypergeometrically from the unseen pool, returns the sample fraction. Saves/restores on-turn player's rack so it's safe to call mid-game.
- **\`outcome_features.{h,c}\`** — aggregator. Computes all 12 features for one position from us's POV. Decoupled from the game's bag (caller passes a reconstructed pre-draw pool) so it's safe to call after \`play_move\`.
- **\`outcome_recorder.{h,c}\`** — per-game in-memory buffer + thread-safe CSV writer with a single flush per game (under a mutex). Each thread owns its own buffer.
- **\`autoplay.c\` hook** — after every tile-placement move, reconstructs the pre-draw unseen pool from \`bag + (us_rack − leave) + opp_rack\` and records features at the post-move-pre-draw state from us's (just-played player's) POV. Skips passes/exchanges and the second game in a game pair.
- **Config flags** — \`-tdump <path>\`, \`-tbingosamples <n>\` (default 14).

## Recording-moment semantics

Features describe the position **after** the on-turn player's move is applied to the board, **before** they refill from the bag. So:

- \`us\` = the player who just played; their leave (size 0–6) determines the rack distribution.
- \`opp\` = the other player; their rack is treated as **unknown** so training matches inference (the model never gets to see opp's actual rack at sim leaves).
- \`pool\` = unseen from us's POV = bag (post-draw) + tiles drawn during play_move + opp's rack.
- \`score_diff\` = us minus opp; includes the just-played move's score.
- Targets (\`win\`, \`final_spread\`) propagate the **eventual** game outcome from us's POV.

This matches how the model is intended to be called at sim leaves later — same input distribution at training and inference.

## Validation on a real run

\`autoplay games 1000\` → 21,983 rows, 1.1s wall (8 threads), 2.1 MB CSV. Feature distributions sane (frac_playable ≈ 0.97 mean, top1 ≈ 14 points, bingo_prob ≈ 18%, etc.).

Score-diff-controlled correlations (since marginal correlations are dominated by score_diff itself):

| feature | residual corr with spread |
|---|---:|
| opp_bingo_prob | −0.085 |
| unplayed_blanks | −0.068 |
| us_bingo_prob | +0.045 (Simpson-flipped from marginal) |
| opp_st_top1 | −0.056 |
| opp_st_top2 | −0.054 |
| us_leave_value | **+0.134** |
| us_st_top1 | −0.035 |

\`opp_st_top1\` and \`opp_st_top2\` are r=+0.90 collinear with each other; the regression will likely split or shrink one of them. \`us_leave_value\` is the strongest non-score-diff predictor, which is what we'd expect.

## Notes / open items

- Bingo-prob sampling is per-position random with N=14 → 15 discrete output values. Increasing samples reduces noise linearly. \`-tbingosamples 50\` is a reasonable knob if the model is bingo-prob-noise-bound.
- This PR ships the **data pipeline only**. The model file format and load/eval code (planned PR 4) and the sim-leaf integration (planned PR 5) come next; a real game-pair-autoplay comparison vs win_pct needs both.
- Branch is stacked on #524 (outcome-model-features). Retarget to main once #524 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)