### PR TITLE
Sim leaf: capture initial_player's leave so OCM sees training-matched state

### DIFF
--- a/src/impl/config.c
+++ b/src/impl/config.c
@@ -6069,19 +6069,27 @@ void config_load_lexicon_dependent_data(Config *config,
   }
 
   // Load outcome models (if specified). -ocm sets both players;
-  // -ocm1 / -ocm2 override per player. NULL leaves the slot empty.
-  const char *ocm_shared_name = config_get_parg_value(config, ARG_TOKEN_OCM, 0);
-  const char *p1_ocm_name = ocm_shared_name;
-  const char *p2_ocm_name = ocm_shared_name;
+  // -ocm1 / -ocm2 override per player. If no -ocm flag is given on
+  // this load, preserve whatever is already loaded (so the model
+  // stays sticky across commands without needing settings persistence).
+  const char *new_ocm_shared = config_get_parg_value(config, ARG_TOKEN_OCM, 0);
+  const char *new_p1_ocm = new_ocm_shared;
+  const char *new_p2_ocm = new_ocm_shared;
   if (config_get_parg_num_set_values(config, ARG_TOKEN_P1_OCM) > 0) {
-    p1_ocm_name = config_get_parg_value(config, ARG_TOKEN_P1_OCM, 0);
+    new_p1_ocm = config_get_parg_value(config, ARG_TOKEN_P1_OCM, 0);
   }
   if (config_get_parg_num_set_values(config, ARG_TOKEN_P2_OCM) > 0) {
-    p2_ocm_name = config_get_parg_value(config, ARG_TOKEN_P2_OCM, 0);
+    new_p2_ocm = config_get_parg_value(config, ARG_TOKEN_P2_OCM, 0);
   }
-  players_data_set(config->players_data, PLAYERS_DATA_TYPE_OCM,
-                   config->data_paths, p1_ocm_name, p2_ocm_name,
-                   config->use_mmap_for_rit, error_stack);
+  const bool any_ocm_arg_present =
+      new_ocm_shared != NULL ||
+      config_get_parg_num_set_values(config, ARG_TOKEN_P1_OCM) > 0 ||
+      config_get_parg_num_set_values(config, ARG_TOKEN_P2_OCM) > 0;
+  if (any_ocm_arg_present) {
+    players_data_set(config->players_data, PLAYERS_DATA_TYPE_OCM,
+                     config->data_paths, new_p1_ocm, new_p2_ocm,
+                     config->use_mmap_for_rit, error_stack);
+  }
   if (!error_stack_is_empty(error_stack)) {
     return;
   }

--- a/src/impl/random_variable.c
+++ b/src/impl/random_variable.c
@@ -427,6 +427,17 @@ double rv_sim_sample(RandomVariables *rvs, const uint64_t play_index,
   }
 
   Equity leftover = 0;
+  // OutcomeModel needs initial_player's leave from their LAST move
+  // played in the rollout. The candidate counts as ply -1 (initial
+  // plays it before the rollout loop), so seed initial_last_leave
+  // from there; subsequent initial-player plies overwrite.
+  const LetterDistribution *ld_for_leave = game_get_ld(game);
+  Rack initial_last_leave;
+  rack_set_dist_size(&initial_last_leave, ld_get_size(ld_for_leave));
+  rack_reset(&initial_last_leave);
+  get_leave_for_move(simmed_play_get_move(simmed_play), game,
+                     &initial_last_leave);
+
   game_set_backup_mode(game, BACKUP_MODE_SIMULATION);
   // For one-ply sims, we need to account for the candidate move's leave value
   if (plies == 1) {
@@ -455,6 +466,10 @@ double rv_sim_sample(RandomVariables *rvs, const uint64_t play_index,
     const Move *best_play = get_top_equity_move(game, thread_index, move_list);
     rack_copy(&spare_rack, player_get_rack(player_on_turn));
 
+    if (player_on_turn_index == simmer->initial_player) {
+      get_leave_for_move(best_play, game, &initial_last_leave);
+    }
+
     play_move(best_play, game, NULL);
     sim_results_increment_node_count(sim_results);
     if (ply == plies - 2 || ply == plies - 1) {
@@ -475,37 +490,51 @@ double rv_sim_sample(RandomVariables *rvs, const uint64_t play_index,
   simmed_play_add_equity_stat(simmed_play, simmer->initial_spread, spread,
                               leftover);
 
-  // If the initial player has an OutcomeModel loaded, use it to estimate
-  // the leaf's win probability. Otherwise fall back to the win_pct table.
-  // The model is evaluated from us = simmer->initial_player's POV with
-  // their *current* leaf rack as the "leave" and draw_size = 0; we don't
-  // try to reconstruct the post-move-pre-draw state at the leaf.
+  // OutcomeModel path. Eligibility:
+  //   - Model loaded for initial_player.
+  //   - Even plies (so initial_player is the last to move at the leaf,
+  //     matching the post-move-pre-draw state the model was trained on).
+  //     Odd plies were already rejected at sim setup if a model is
+  //     loaded; the % 2 check is defense in depth.
+  //   - Game still in progress (otherwise the actual outcome is exact;
+  //     we defer to the win_pct path which uses the actual result).
   double wpct;
   const OutcomeModel *model =
       player_get_outcome_model(game_get_player(game, simmer->initial_player));
-  if (model != NULL) {
+  if (model != NULL && plies % 2 == 0 &&
+      game_get_game_end_reason(game) == GAME_END_REASON_NONE) {
     const LetterDistribution *ld = game_get_ld(game);
     const int ld_size = ld_get_size(ld);
     const Player *us_player = game_get_player(game, simmer->initial_player);
     const Player *opp_player =
         game_get_player(game, 1 - simmer->initial_player);
-    const Rack *us_leaf_rack = player_get_rack(us_player);
+    const Rack *us_full_rack = player_get_rack(us_player);
     const Rack *opp_rack = player_get_rack(opp_player);
     const Bag *bag = game_get_bag(game);
 
+    // Reconstruct the post-initial-move-pre-draw unseen pool from
+    // initial_player's POV. After play_move drew tiles into us_full_rack
+    // from the bag, so:
+    //   pre-draw_bag[L] = current_bag[L] + (us_full_rack[L] - leave[L])
+    //   pool[L]         = pre-draw_bag[L] + opp_rack[L]
     uint8_t pool[MAX_ALPHABET_SIZE] = {0};
     int pool_size = 0;
     for (int ml = 0; ml < ld_size; ml++) {
       const int n_bag = bag_get_letter(bag, (MachineLetter)ml);
+      const int n_us_full = rack_get_letter(us_full_rack, (MachineLetter)ml);
+      const int n_leave =
+          rack_get_letter(&initial_last_leave, (MachineLetter)ml);
+      const int n_drawn = n_us_full - n_leave;
       const int n_opp = rack_get_letter(opp_rack, (MachineLetter)ml);
-      pool[ml] = (uint8_t)(n_bag + n_opp);
-      pool_size += n_bag + n_opp;
+      pool[ml] = (uint8_t)(n_bag + n_drawn + n_opp);
+      pool_size += n_bag + n_drawn + n_opp;
     }
 
     OutcomeFeatures features;
-    outcome_features_compute(
-        game, move_list, thread_index, simmer->initial_player, us_leaf_rack,
-        pool, pool_size, /*bingo_samples=*/14, simmer_worker->prng, &features);
+    outcome_features_compute(game, move_list, thread_index,
+                             simmer->initial_player, &initial_last_leave, pool,
+                             pool_size, /*bingo_samples=*/14,
+                             simmer_worker->prng, &features);
     OutcomePrediction pred;
     outcome_model_eval(model, &features, &pred);
     wpct = pred.win_prob;

--- a/src/impl/simmer.c
+++ b/src/impl/simmer.c
@@ -10,6 +10,7 @@
 #include "../ent/game.h"
 #include "../ent/inference_results.h"
 #include "../ent/move.h"
+#include "../ent/player.h"
 #include "../ent/sim_args.h"
 #include "../ent/sim_results.h"
 #include "../ent/stats.h"
@@ -61,6 +62,28 @@ void simulate(SimArgs *sim_args, SimCtx **sim_ctx, SimResults *sim_results,
         error_stack, ERROR_STATUS_SIM_GAME_OVER,
         string_duplicate("cannot simulate when the game is already over"));
     return;
+  }
+
+  // OutcomeModel at sim leaves requires even ply counts so the leaf
+  // state matches what the model was trained on (post-move-pre-draw
+  // from the player who just played's POV — that player is
+  // initial_player when plies is even). Reject odd-ply sims when any
+  // player has a model loaded.
+  if ((sim_args->num_plies % 2) != 0) {
+    for (int p = 0; p < 2; p++) {
+      if (player_get_outcome_model(game_get_player(sim_args->game, p)) !=
+          NULL) {
+        error_stack_push(
+            error_stack, ERROR_STATUS_SIM_GAME_OVER,
+            get_formatted_string(
+                "outcome model is loaded for player %d but num_plies=%d "
+                "is odd; the model requires even ply counts so the leaf "
+                "state matches training. Use an even -plies value or "
+                "unload the model.",
+                p + 1, sim_args->num_plies));
+        return;
+      }
+    }
   }
 
   // If the bag is empty, set sample_limit to the number of moves and


### PR DESCRIPTION
## Summary

Stacked on #527. Closes the calibration gap that PR flagged: the OutcomeModel was trained on \`(leave + future random draw)\` features at post-move-pre-draw state, but PR #527 was evaluating it at post-everything leaf state with \`leave = full rack, draw_size = 0\`. Different distributions; weights miscalibrated.

This PR makes the inference state match training:

1. **Track initial_player's leave during rollouts.** In \`random_variable.c\`'s \`play_simmed_game\`, capture the leave each time \`initial_player\` is on turn — seeded from the candidate move (initial's first play, ply -1) and updated on each subsequent rollout ply where they're on turn. After the rollout, \`initial_last_leave\` holds the leave from initial's most recent move.

2. **Reconstruct pre-draw unseen pool at the leaf.** Same trick as autoplay: \`pool[L] = current_bag[L] + (current_full_rack[L] - leave[L]) + opp_rack[L]\`. The middle term is "tiles drawn after initial's last move" (returned to the conceptual pre-draw bag). The rest is initial's full unseen pool.

3. **Pass leave + pool to \`outcome_features_compute\`.** Now the call has \`draw_size = RACK_SIZE − leave_size > 0\`, matching the training distribution exactly.

4. **Require even ply counts when OCM is loaded.** Setup-time check in \`simulate()\` errors out if \`num_plies\` is odd and any player has a model. Even plies guarantees initial_player is the one who just played at the leaf, matching the "us = whoever just played" training POV. Defense-in-depth at the leaf path also gates on \`plies % 2 == 0\` so the endgame MAX_PLIES=25 override falls back to the win_pct table.

5. **\`-ocm\` flags are now sticky.** Previously each subsequent command re-ran \`config_load_data\` which saw the OCM pargs reset to NULL and silently unloaded the model. Now \`config_load_data\` only calls \`players_data_set\` for OCM when an OCM flag is present on the current command — otherwise the existing model stays loaded.

## Verified

- \`sim -plies 1\` with \`-ocm poc\` loaded → error: "outcome model is loaded for player 1 but num_plies=1 is odd; the model requires even ply counts so the leaf state matches training. Use an even -plies value or unload the model."
- \`sim -plies 2 -seed 42 -threads 1\` with \`-ocm poc\` produces different per-candidate Wp (51.90 for VIRAL) than the same seed without OCM (51.22). The model is now evaluated on the right input distribution.
- \`set -ocm poc\` then \`cgp ...\` then \`sim ...\` keeps the model loaded across the three commands.

## Stacking

Targets #527 (outcome-model-eval). Once that lands, retarget to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)