### PR TITLE
Harden cmd_api: drop magpie_get_config, add libmagpie_core.a

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,6 @@ cflags.release := -O3 -flto -march=native -DNDEBUG -Wall -Wno-trigraphs
 # Test-specific flags: like release but without DNDEBUG (asserts always enabled in tests)
 cflags.test_release := -O3 -flto -march=native -Wall -Wno-trigraphs
 cflags.profile := -O3 -g -march=native -DNDEBUG -Wall -Wno-trigraphs -fno-omit-frame-pointer -mllvm -inline-threshold=0
-cflags.dll_dev = -g -O0 -fpic -Wall
-cflags.dll_release = -O3 -fpic -flto -march=native -Wall -Wno-trigraphs
-
 lflags.cov := --coverage
 
 ldflags.dev := -pthread $(FSAN_ARG)
@@ -57,8 +54,6 @@ ldflags.vlg := -pthread
 ldflags.release := -pthread
 ldflags.profile := -pthread
 ldflags.cov := -pthread
-ldflags.dll_dev := -pthread
-ldflags.dll_release := -pthread
 
 CFLAGS := ${cflags.${BUILD}}
 
@@ -81,8 +76,8 @@ LDLIBS   := -lm
 
 all: magpie magpie_test
 
-magpie_so: $(OBJ_SRC)
-	$(CC) -shared $(LDFLAGS) $(LFLAGS) $^ $(LDLIBS) -o libmagpie.so
+libmagpie_core.a: $(OBJ_SRC)
+	ar rcs $@ $^
 
 magpie: $(OBJ_SRC) $(OBJ_CMD) | $(BIN_DIR)
 	$(CC) $(LDFLAGS) $(LFLAGS) $^ $(LDLIBS) -o $(BIN_DIR)/$@
@@ -104,7 +99,7 @@ $(BIN_DIR) $(OBJ_DIR) $(OBJ_DIR)/$(SRC_DIR) $(OBJ_DIR)/$(CMD_DIR) $(OBJ_DIR)/$(T
 	mkdir -p $@
 
 clean:
-	@$(RM) -rv $(BIN_DIR) $(OBJ_DIR)
+	@$(RM) -rv $(BIN_DIR) $(OBJ_DIR) libmagpie_core.a
 
 -include $(OBJ_SRC:.o=.d)
 -include $(OBJ_CMD:.o=.d)

--- a/src/impl/cmd_api.c
+++ b/src/impl/cmd_api.c
@@ -60,4 +60,7 @@ void magpie_stop_current_command(const Magpie *mp) {
   thread_control_set_status(tc, THREAD_CONTROL_STATUS_USER_INTERRUPT);
 }
 
-Config *magpie_get_config(const Magpie *mp) { return mp->config; }
+int magpie_get_thread_status(const Magpie *mp) {
+  ThreadControl *tc = config_get_thread_control(mp->config);
+  return (int)thread_control_get_status(tc);
+}

--- a/src/impl/cmd_api.h
+++ b/src/impl/cmd_api.h
@@ -27,7 +27,6 @@
 // clang-format on
 
 #include "../util/io_util.h"
-#include "config.h"
 
 // Opaque struct of magpie internal state
 typedef struct Magpie Magpie;
@@ -52,6 +51,8 @@ char *magpie_get_last_command_output(const Magpie *mp);
 
 void magpie_stop_current_command(const Magpie *mp);
 
-Config *magpie_get_config(const Magpie *mp);
+// Returns the current thread status as an int:
+//   0 = uninitialized, 1 = started, 2 = user_interrupt, 3 = finished
+int magpie_get_thread_status(const Magpie *mp);
 
 #endif

--- a/wasmentry/api.c
+++ b/wasmentry/api.c
@@ -1,7 +1,5 @@
 #include "../src/compat/cpthread.h"
-#include "../src/ent/thread_control.h"
 #include "../src/impl/cmd_api.h"
-#include "../src/impl/config.h"
 #include "../src/impl/exec.h"
 #include "../src/util/fileproxy.h"
 #include "../src/util/io_util.h"
@@ -118,15 +116,7 @@ int wasm_get_thread_status(void) {
   if (!wasm_magpie) {
     return 0;
   }
-  Config *config = magpie_get_config(wasm_magpie);
-  if (!config) {
-    return 0;
-  }
-  ThreadControl *tc = config_get_thread_control(config);
-  if (!tc) {
-    return 0;
-  }
-  return (int)thread_control_get_status(tc);
+  return magpie_get_thread_status(wasm_magpie);
 }
 
 void wasm_stop_command(void) {


### PR DESCRIPTION
Replace the Config* opacity leak with a typed magpie_get_thread_status() accessor. The only caller (wasmentry/api.c) now calls one function instead of reaching through Config and ThreadControl itself.

Drop magpie_so in favour of libmagpie_core.a: a static archive is what cgo embedders need; a shared lib was unused and would create runtime path dependencies. Remove the cflags/ldflags.dll_* variables that were defined but never referenced.