### PR TITLE
Add BAI-style adaptive pre-endgame solver

### DIFF
--- a/src/ent/endgame_results.c
+++ b/src/ent/endgame_results.c
@@ -44,6 +44,7 @@ struct EndgameResults {
 EndgameResults *endgame_results_create(void) {
   EndgameResults *endgame_results = malloc_or_die(sizeof(EndgameResults));
   endgame_results->best_pv_data.depth = -1;
+  endgame_results->best_pv_data.value = 0;
   endgame_results->best_pv_data.pv_line.num_moves = 0;
   endgame_results->display_pv_data.depth = -1;
   endgame_results->display_pv_data.value = 0;
@@ -78,8 +79,10 @@ void endgame_results_destroy(EndgameResults *endgame_results) {
 // NOT THREAD SAFE: Caller must ensure synchronization
 void endgame_results_reset(EndgameResults *endgame_results) {
   endgame_results->best_pv_data.depth = -1;
+  endgame_results->best_pv_data.value = 0;
   endgame_results->best_pv_data.pv_line.num_moves = 0;
   endgame_results->display_pv_data.depth = -1;
+  endgame_results->display_pv_data.value = 0;
   endgame_results->display_pv_data.pv_line.num_moves = 0;
   endgame_results->valid_for_current_game_state = false;
   ctimer_start(&endgame_results->timer);

--- a/src/ent/game.c
+++ b/src/ent/game.c
@@ -218,6 +218,16 @@ static inline void traverse_backwards_add_to_rack(const Board *board, int row,
   }
 }
 
+const KWG *game_get_effective_kwg(const Game *game, int player_index) {
+  if (game->override_kwgs[0] != NULL) {
+    if (game->dual_lexicon_mode == DUAL_LEXICON_MODE_IGNORANT) {
+      return game->override_kwgs[0];
+    }
+    return game->override_kwgs[player_index];
+  }
+  return player_get_kwg(game_get_player(game, player_index));
+}
+
 void game_set_override_kwgs(Game *game, const KWG *kwg0, const KWG *kwg1,
                             dual_lexicon_mode_t mode) {
   game->override_kwgs[0] = kwg0;

--- a/src/ent/game.h
+++ b/src/ent/game.h
@@ -67,6 +67,9 @@ void game_gen_cross_set(const Game *game, int row, int col, int dir,
 // Override KWGs for cross-set generation (e.g., word-pruned KWGs in endgame).
 // kwg0/kwg1 are not owned by Game. In IGNORANT mode, kwg0 is used for both
 // cross-set indices. In INFORMED mode, kwg0/kwg1 are used for indices 0/1.
+// Returns the effective KWG for the given player/cross-set index, respecting
+// any override KWGs. Falls back to the player's own KWG if no override is set.
+const KWG *game_get_effective_kwg(const Game *game, int player_index);
 void game_set_override_kwgs(Game *game, const KWG *kwg0, const KWG *kwg1,
                             dual_lexicon_mode_t mode);
 void game_clear_override_kwgs(Game *game);

--- a/src/ent/player.c
+++ b/src/ent/player.c
@@ -139,3 +139,5 @@ void player_set_move_record_type(Player *player,
                                  move_record_t move_record_type) {
   player->move_record_type = move_record_type;
 }
+
+void player_set_wmp(Player *player, const WMP *wmp) { player->wmp = wmp; }

--- a/src/ent/player.h
+++ b/src/ent/player.h
@@ -30,6 +30,7 @@ void player_set_score(Player *player, Equity score);
 void player_set_move_sort_type(Player *player, move_sort_t move_sort_type);
 void player_set_move_record_type(Player *player,
                                  move_record_t move_record_type);
+void player_set_wmp(Player *player, const WMP *wmp);
 void player_add_to_score(Player *player, Equity score);
 
 void player_update(const PlayersData *players_data, Player *player);

--- a/src/impl/bai_peg.c
+++ b/src/impl/bai_peg.c
@@ -767,7 +767,7 @@ void bai_peg_solve(const BaiPegArgs *args, BaiPegResult *result,
         .move_record_type = MOVE_RECORD_ALL_SMALL,
         .move_sort_type = MOVE_SORT_SCORE,
         .override_kwg = NULL,
-        .thread_index = 0,
+        .thread_index = args->thread_index_offset,
         .eq_margin_movegen = 0,
         .target_equity = EQUITY_MAX_VALUE,
         .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
@@ -951,11 +951,11 @@ void bai_peg_solve(const BaiPegArgs *args, BaiPegResult *result,
   if (args->initial_playout) {
     Timer playout_timer;
     ctimer_start(&playout_timer);
-    bp_playout_batch(cands, num_candidates, 0, mover_idx, opp_idx, unseen,
-                     ld_size, tile_types, tile_counts, num_tile_types,
-                     args->thread_control, per_thread_tts, dlm,
-                     args->endgame_time_per_solve, num_threads, 0,
-                     bai_deadline_ns, args->pure_playout);
+    bp_playout_batch(
+        cands, num_candidates, 0, mover_idx, opp_idx, unseen, ld_size,
+        tile_types, tile_counts, num_tile_types, args->thread_control,
+        per_thread_tts, dlm, args->endgame_time_per_solve, num_threads,
+        args->thread_index_offset, bai_deadline_ns, args->pure_playout);
     // Snapshot the playout signal for downstream regression analysis. After
     // PUCT runs, q_* gets overwritten by deeper negamax results.
     for (int ci = 0; ci < num_candidates; ci++) {
@@ -1007,7 +1007,7 @@ void bai_peg_solve(const BaiPegArgs *args, BaiPegResult *result,
       bp_evaluate_cand(&cands[ci], 1, mover_idx, opp_idx, unseen, ld_size,
                        tile_types, tile_counts, num_tile_types,
                        args->thread_control, per_thread_tts, dlm, per_solve,
-                       num_threads, 0, bai_deadline_ns);
+                       num_threads, args->thread_index_offset, bai_deadline_ns);
       double measured = ctimer_elapsed_seconds(&eval_timer);
       cands[ci].time_paid += measured;
       cands[ci].last_eval_seconds = measured;
@@ -1237,7 +1237,7 @@ void bai_peg_solve(const BaiPegArgs *args, BaiPegResult *result,
     bp_evaluate_cand(&cands[chosen], next_depth, mover_idx, opp_idx, unseen,
                      ld_size, tile_types, tile_counts, num_tile_types,
                      args->thread_control, per_thread_tts, dlm, per_solve,
-                     num_threads, 0, bai_deadline_ns);
+                     num_threads, args->thread_index_offset, bai_deadline_ns);
     double measured = ctimer_elapsed_seconds(&eval_timer);
     cands[chosen].time_paid += measured;
     cands[chosen].last_eval_seconds = measured;

--- a/src/impl/bai_peg.c
+++ b/src/impl/bai_peg.c
@@ -1,0 +1,1388 @@
+#include "bai_peg.h"
+
+#include "../compat/cpthread.h"
+#include "../compat/ctime.h"
+#include "../def/board_defs.h"
+#include "../def/cpthread_defs.h"
+#include "../def/equity_defs.h"
+#include "../def/game_defs.h"
+#include "../def/game_history_defs.h"
+#include "../def/kwg_defs.h"
+#include "../def/letter_distribution_defs.h"
+#include "../def/move_defs.h"
+#include "../def/players_data_defs.h"
+#include "../def/rack_defs.h"
+#include "../ent/bag.h"
+#include "../ent/board.h"
+#include "../ent/dictionary_word.h"
+#include "../ent/endgame_results.h"
+#include "../ent/equity.h"
+#include "../ent/game.h"
+#include "../ent/kwg.h"
+#include "../ent/letter_distribution.h"
+#include "../ent/move.h"
+#include "../ent/player.h"
+#include "../ent/rack.h"
+#include "../ent/thread_control.h"
+#include "../ent/transposition_table.h"
+#include "../util/io_util.h"
+#include "endgame.h"
+#include "gameplay.h"
+#include "kwg_maker.h"
+#include "move_gen.h"
+#include "word_prune.h"
+#include <assert.h>
+#include <math.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+enum {
+  BAI_PEG_DEFAULT_TOP_K = 64,
+  BAI_PEG_MOVELIST_CAPACITY = 250000,
+  BAI_PEG_DEFAULT_PROGRESS_TOP = 5,
+};
+
+// ---------------------------------------------------------------------------
+// Local helpers (intentionally duplicated from peg.c so this file stays
+// self-contained and the existing PEG implementation is untouched).
+// ---------------------------------------------------------------------------
+
+static int bp_compute_unseen(const Game *game, int mover_idx,
+                             uint8_t unseen[MAX_ALPHABET_SIZE]) {
+  const LetterDistribution *ld = game_get_ld(game);
+  int ld_size = ld_get_size(ld);
+  memset(unseen, 0, sizeof(uint8_t) * MAX_ALPHABET_SIZE);
+  for (int ml = 0; ml < ld_size; ml++) {
+    unseen[ml] = (uint8_t)ld_get_dist(ld, ml);
+  }
+  const Rack *mover_rack = player_get_rack(game_get_player(game, mover_idx));
+  for (int ml = 0; ml < ld_size; ml++) {
+    unseen[ml] -= (uint8_t)rack_get_letter(mover_rack, ml);
+  }
+  const Board *board = game_get_board(game);
+  for (int row = 0; row < BOARD_DIM; row++) {
+    for (int col = 0; col < BOARD_DIM; col++) {
+      if (board_is_empty(board, row, col)) {
+        continue;
+      }
+      MachineLetter ml = board_get_letter(board, row, col);
+      if (get_is_blanked(ml)) {
+        if (unseen[BLANK_MACHINE_LETTER] > 0) {
+          unseen[BLANK_MACHINE_LETTER]--;
+        }
+      } else {
+        if (unseen[ml] > 0) {
+          unseen[ml]--;
+        }
+      }
+    }
+  }
+  int total = 0;
+  for (int ml = 0; ml < ld_size; ml++) {
+    total += unseen[ml];
+  }
+  return total;
+}
+
+static void bp_set_opp_rack(Rack *opp_rack,
+                            const uint8_t unseen[MAX_ALPHABET_SIZE],
+                            int ld_size, MachineLetter bag_tile) {
+  rack_reset(opp_rack);
+  for (int ml = 0; ml < ld_size; ml++) {
+    int cnt = (int)unseen[ml] - (ml == bag_tile ? 1 : 0);
+    for (int i = 0; i < cnt; i++) {
+      rack_add_letter(opp_rack, (MachineLetter)ml);
+    }
+  }
+}
+
+static void bp_clear_false_game_end(Game *game) {
+  game_set_game_end_reason(game, GAME_END_REASON_NONE);
+}
+
+// ---------------------------------------------------------------------------
+// Per-candidate state
+// ---------------------------------------------------------------------------
+
+typedef struct BaiCand {
+  SmallMove move;
+  Move move_full;
+  int static_score;     // Move score (used to derive prior).
+  Game *post_cand_game; // Post-move game state (board + cross-sets), shared.
+  double prior;         // Softmax-normalized prior in [0, 1].
+  int depth_evaluated;  // 0 = no endgame eval yet; N = N-ply endgame done.
+  int visits;           // Number of (depth) evaluations performed.
+  double time_paid;     // Cumulative wall time spent evaluating this cand.
+  double last_eval_seconds; // Wall time of the most recent evaluation.
+  double cost_estimate;     // Predicted seconds for the next evaluation.
+  double q_mean_spread;     // Mean spread at deepest evaluated depth (0 init).
+  double q_win_pct;         // Win pct at deepest evaluated depth.
+  // Snapshots of two prior signals captured exactly once each, before they
+  // get overwritten by deeper evaluations. Used downstream to study which
+  // signal predicts the eventual real-Q better (regression analysis).
+  double playout_q_mean_spread; // From Phase 0 (initial_playout) only.
+  double playout_q_win_pct;
+  bool playout_q_set;
+  double neighbor_q_mean_spread; // Snapshot of cand[rank-1]'s q at admission.
+  double neighbor_q_win_pct;
+  bool neighbor_q_set;
+  bool fully_explored; // True once depth_evaluated >= max_depth.
+} BaiCand;
+
+// Structural prior on the cost of evaluating one (cand, depth) eval before
+// any measurements exist. After the first eval the running measurement
+// replaces this. Captures: (a) cheaper as candidate consumes more rack
+// tiles (smaller post-move endgame), (b) PASS/EXCHANGE keeps full rack
+// (most expensive), (c) roughly doubles per ply.
+static double bp_initial_cost_estimate(const Move *move, int depth) {
+  // Tiles played by this candidate. PASS/EXCHANGE leaves full rack on board.
+  int tiles_played = (move->move_type == GAME_EVENT_TILE_PLACEMENT_MOVE)
+                         ? move_get_tiles_played(move)
+                         : 0;
+  int rack_remaining = RACK_SIZE - tiles_played; // 0..7
+  const double base = 0.01;          // ~10ms baseline at depth 1, empty rack
+  const double growth_per_ply = 2.0; // rough endgame branching factor
+  // (rack² + 1) so an emptied-rack candidate isn't predicted ~free.
+  double rack_factor = (double)(rack_remaining * rack_remaining) + 1.0;
+  return base * rack_factor * pow(growth_per_ply, (double)depth - 1);
+}
+
+// ---------------------------------------------------------------------------
+// Parallel scenario evaluation: for one (cand, depth), each worker thread
+// pulls a tile_idx atomically and runs an endgame solve on that scenario.
+// ---------------------------------------------------------------------------
+
+typedef struct BpEvalThreadArgs {
+  BaiCand *cand;
+  int depth;
+  int mover_idx;
+  int opp_idx;
+  int thread_index;
+  const uint8_t *unseen;
+  int ld_size;
+  const MachineLetter *tile_types;
+  const int *tile_counts;
+  int num_tile_types;
+  EndgameCtx **endgame_ctx;        // Per-thread, lazily initialized.
+  EndgameResults *endgame_results; // Per-thread.
+  ThreadControl *thread_control;
+  TranspositionTable *shared_tt;
+  dual_lexicon_mode_t dual_lexicon_mode;
+  double endgame_time_per_solve;
+  int64_t external_deadline_ns;
+  // Shared work-stealing counter (only inner-loop atomic).
+  atomic_int *next_tile;
+  // Per-thread output accumulators (no atomics; merged after join).
+  int64_t local_spread_sum;
+  int64_t local_wins_x2;
+  int64_t local_weight_sum;
+} BpEvalThreadArgs;
+
+static void *bp_eval_thread(void *arg) {
+  BpEvalThreadArgs *a = (BpEvalThreadArgs *)arg;
+  int64_t local_spread_sum = 0;
+  int64_t local_wins_x2 = 0;
+  int64_t local_weight_sum = 0;
+  while (true) {
+    int ti = atomic_fetch_add(a->next_tile, 1);
+    if (ti >= a->num_tile_types) {
+      break;
+    }
+    MachineLetter tile = a->tile_types[ti];
+    int tcnt = a->tile_counts[ti];
+
+    Game *scenario = game_duplicate(a->cand->post_cand_game);
+    Rack *opp_rack = player_get_rack(game_get_player(scenario, a->opp_idx));
+    bp_set_opp_rack(opp_rack, a->unseen, a->ld_size, tile);
+    Rack *mover_rack = player_get_rack(game_get_player(scenario, a->mover_idx));
+    rack_add_letter(mover_rack, tile);
+
+    int32_t mover_lead =
+        equity_to_int(
+            player_get_score(game_get_player(scenario, a->mover_idx))) -
+        equity_to_int(player_get_score(game_get_player(scenario, a->opp_idx)));
+
+    EndgameArgs ea = {
+        .thread_control = a->thread_control,
+        .game = scenario,
+        .plies = a->depth,
+        .shared_tt = a->shared_tt,
+        .initial_small_move_arena_size = DEFAULT_INITIAL_SMALL_MOVE_ARENA_SIZE,
+        .num_threads = 1,
+        .use_heuristics = true,
+        .num_top_moves = 1,
+        .dual_lexicon_mode = a->dual_lexicon_mode,
+        .skip_word_pruning = true,
+        .thread_index_offset = a->thread_index,
+        .soft_time_limit = a->endgame_time_per_solve,
+        .hard_time_limit = a->endgame_time_per_solve,
+        .external_deadline_ns = a->external_deadline_ns,
+    };
+
+    endgame_results_reset(a->endgame_results);
+    endgame_solve_inline(a->endgame_ctx, &ea, a->endgame_results);
+    int eg_val =
+        endgame_results_get_value(a->endgame_results, ENDGAME_RESULT_BEST);
+    int32_t mover_total = mover_lead - eg_val;
+
+    local_spread_sum += (int64_t)mover_total * tcnt;
+    int win_contrib;
+    if (mover_total > 0) {
+      win_contrib = 2 * tcnt;
+    } else if (mover_total == 0) {
+      win_contrib = tcnt;
+    } else {
+      win_contrib = 0;
+    }
+    local_wins_x2 += win_contrib;
+    local_weight_sum += tcnt;
+
+    game_destroy(scenario);
+  }
+  a->local_spread_sum = local_spread_sum;
+  a->local_wins_x2 = local_wins_x2;
+  a->local_weight_sum = local_weight_sum;
+  return NULL;
+}
+
+// ---------------------------------------------------------------------------
+// Flattened batch evaluation: a single shared (cand, scenario) work queue
+// across all worker threads. One spawn/join cycle for all num_cands ×
+// num_tile_types scenarios — vs. the per-cand bp_evaluate_cand which pays
+// cpthread_create/join for every candidate. Used by Phase 0 (initial_playout)
+// where 256+ cheap depth-0 evaluations would otherwise spend most of their
+// time on thread ceremony.
+// ---------------------------------------------------------------------------
+
+typedef struct BpBatchWorkItem {
+  int cand_idx;
+  int tile_idx;
+} BpBatchWorkItem;
+
+typedef struct BpBatchThreadArgs {
+  atomic_int *next_item;
+  const BpBatchWorkItem *items;
+  int total_items;
+  BaiCand *cands; // indexed by item->cand_idx
+  int mover_idx;
+  int opp_idx;
+  const uint8_t *unseen;
+  int ld_size;
+  const MachineLetter *tile_types;
+  const int *tile_counts;
+  int thread_index;
+  EndgameCtx **endgame_ctx;
+  EndgameResults *endgame_results;
+  // Per-thread move list reused across all (cand, scenario) work items
+  // when pure_playout is set. NULL when going through endgame_solve_inline.
+  MoveList *move_list;
+  ThreadControl *thread_control;
+  TranspositionTable *shared_tt;
+  dual_lexicon_mode_t dual_lexicon_mode;
+  int depth;
+  double endgame_time_per_solve;
+  int64_t external_deadline_ns;
+  // If true, skip endgame_solve_inline plumbing and run a flat greedy
+  // playout (movegen + play loop, no TT, no alpha-beta).
+  bool pure_playout;
+  // Per-thread, per-cand accumulators (length = num_cands; this thread's row
+  // in the flat all_spread/all_wins/all_weight arrays).
+  int64_t *local_spread;
+  int64_t *local_wins_x2;
+  int64_t *local_weight;
+} BpBatchThreadArgs;
+
+// Streamlined greedy playout: from `game`'s current position (post-cand
+// move played, opp rack and bag-tile placed), play highest-scoring moves
+// alternately until end-of-game or a safety cap. Returns final spread
+// from `solving_player`'s perspective in equity-int units.
+//
+// No TT, no alpha-beta, no endgame_solve infrastructure. Just movegen +
+// play. Standard end-of-game scoring is handled by play_move; if we hit
+// the safety cap without natural end, apply rack penalties manually.
+static int32_t bp_greedy_playout(Game *game, int solving_player,
+                                 MoveList *move_list, int thread_index) {
+  enum { MAX_PLAYOUT_TURNS = 30 };
+  for (int turn = 0; turn < MAX_PLAYOUT_TURNS; turn++) {
+    if (game_get_game_end_reason(game) != GAME_END_REASON_NONE) {
+      break;
+    }
+    const MoveGenArgs ga = {
+        .game = game,
+        .move_list = move_list,
+        .move_record_type = MOVE_RECORD_BEST,
+        .move_sort_type = MOVE_SORT_SCORE,
+        .override_kwg = NULL,
+        .thread_index = thread_index,
+        .eq_margin_movegen = 0,
+        .target_equity = EQUITY_MAX_VALUE,
+        .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+    };
+    generate_moves(&ga);
+    if (move_list_get_count(move_list) == 0) {
+      break;
+    }
+    const Move *best = move_list_get_move(move_list, 0);
+    play_move(best, game, NULL);
+  }
+  const Player *me = game_get_player(game, solving_player);
+  const Player *op = game_get_player(game, 1 - solving_player);
+  int32_t spread = equity_to_int(player_get_score(me) - player_get_score(op));
+  // If we hit the cap before the game ended naturally, apply standard
+  // rack-value adjustments.
+  if (game_get_game_end_reason(game) == GAME_END_REASON_NONE) {
+    const LetterDistribution *ld = game_get_ld(game);
+    spread -= (int32_t)equity_to_int(rack_get_score(ld, player_get_rack(me)));
+    spread += (int32_t)equity_to_int(rack_get_score(ld, player_get_rack(op)));
+  }
+  return spread;
+}
+
+static void *bp_batch_thread(void *arg) {
+  BpBatchThreadArgs *a = (BpBatchThreadArgs *)arg;
+  while (true) {
+    int idx = atomic_fetch_add(a->next_item, 1);
+    if (idx >= a->total_items) {
+      break;
+    }
+    int cand_idx = a->items[idx].cand_idx;
+    int tile_idx = a->items[idx].tile_idx;
+    const BaiCand *cand = &a->cands[cand_idx];
+    MachineLetter tile = a->tile_types[tile_idx];
+    int tcnt = a->tile_counts[tile_idx];
+
+    Game *scenario = game_duplicate(cand->post_cand_game);
+    Rack *opp_rack = player_get_rack(game_get_player(scenario, a->opp_idx));
+    bp_set_opp_rack(opp_rack, a->unseen, a->ld_size, tile);
+    Rack *mover_rack = player_get_rack(game_get_player(scenario, a->mover_idx));
+    rack_add_letter(mover_rack, tile);
+
+    int32_t mover_total;
+    if (a->pure_playout) {
+      // Streamlined: no endgame_solve, no TT, no alpha-beta. Just play
+      // greedy moves to end-of-game and read off the spread.
+      mover_total = bp_greedy_playout(scenario, a->mover_idx, a->move_list,
+                                      a->thread_index);
+    } else {
+      int32_t mover_lead =
+          equity_to_int(
+              player_get_score(game_get_player(scenario, a->mover_idx))) -
+          equity_to_int(
+              player_get_score(game_get_player(scenario, a->opp_idx)));
+      EndgameArgs ea = {
+          .thread_control = a->thread_control,
+          .game = scenario,
+          .plies = a->depth,
+          .shared_tt = a->shared_tt,
+          .initial_small_move_arena_size =
+              DEFAULT_INITIAL_SMALL_MOVE_ARENA_SIZE,
+          .num_threads = 1,
+          .use_heuristics = true,
+          .num_top_moves = 1,
+          .dual_lexicon_mode = a->dual_lexicon_mode,
+          .skip_word_pruning = true,
+          .thread_index_offset = a->thread_index,
+          .soft_time_limit = a->endgame_time_per_solve,
+          .hard_time_limit = a->endgame_time_per_solve,
+          .external_deadline_ns = a->external_deadline_ns,
+      };
+      endgame_results_reset(a->endgame_results);
+      endgame_solve_inline(a->endgame_ctx, &ea, a->endgame_results);
+      int eg_val =
+          endgame_results_get_value(a->endgame_results, ENDGAME_RESULT_BEST);
+      mover_total = mover_lead - eg_val;
+    }
+
+    a->local_spread[cand_idx] += (int64_t)mover_total * tcnt;
+    int win_contrib;
+    if (mover_total > 0) {
+      win_contrib = 2 * tcnt;
+    } else if (mover_total == 0) {
+      win_contrib = tcnt;
+    } else {
+      win_contrib = 0;
+    }
+    a->local_wins_x2[cand_idx] += win_contrib;
+    a->local_weight[cand_idx] += tcnt;
+
+    game_destroy(scenario);
+  }
+  return NULL;
+}
+
+// Evaluate every candidate at a given depth in a single parallel pass.
+// Updates each cand->q_win_pct, q_mean_spread, depth_evaluated, visits.
+// One thread spawn/join cycle for all num_cands*num_tile_types scenarios.
+static void bp_playout_batch(
+    BaiCand *cands, int num_cands, int depth, int mover_idx, int opp_idx,
+    const uint8_t *unseen, int ld_size, const MachineLetter *tile_types,
+    const int *tile_counts, int num_tile_types, ThreadControl *thread_control,
+    TranspositionTable **per_thread_tts, dual_lexicon_mode_t dlm,
+    double endgame_time_per_solve, int num_threads, int thread_index_offset,
+    int64_t external_deadline_ns, bool pure_playout) {
+  int total_items = num_cands * num_tile_types;
+  BpBatchWorkItem *items = malloc_or_die(total_items * sizeof(BpBatchWorkItem));
+  int k = 0;
+  for (int ci = 0; ci < num_cands; ci++) {
+    for (int ti = 0; ti < num_tile_types; ti++) {
+      items[k].cand_idx = ci;
+      items[k].tile_idx = ti;
+      k++;
+    }
+  }
+
+  atomic_int next_item;
+  atomic_init(&next_item, 0);
+
+  EndgameCtx **ctxs = calloc_or_die(num_threads, sizeof(EndgameCtx *));
+  EndgameResults **results =
+      malloc_or_die(num_threads * sizeof(EndgameResults *));
+  for (int ti = 0; ti < num_threads; ti++) {
+    results[ti] = endgame_results_create();
+  }
+  // Per-thread MoveLists used by bp_greedy_playout when pure_playout is on.
+  // We only need top-1 per movegen.
+  MoveList **move_lists = NULL;
+  if (pure_playout) {
+    move_lists = malloc_or_die(num_threads * sizeof(MoveList *));
+    for (int ti = 0; ti < num_threads; ti++) {
+      move_lists[ti] = move_list_create(1);
+    }
+  }
+
+  // Per-thread per-cand accumulators stored in flat arrays so we can free
+  // them in one shot.
+  int64_t *all_spread =
+      calloc_or_die((size_t)num_threads * (size_t)num_cands, sizeof(int64_t));
+  int64_t *all_wins =
+      calloc_or_die((size_t)num_threads * (size_t)num_cands, sizeof(int64_t));
+  int64_t *all_weight =
+      calloc_or_die((size_t)num_threads * (size_t)num_cands, sizeof(int64_t));
+
+  BpBatchThreadArgs *targs =
+      malloc_or_die(num_threads * sizeof(BpBatchThreadArgs));
+  cpthread_t *threads = malloc_or_die(num_threads * sizeof(cpthread_t));
+
+  for (int ti = 0; ti < num_threads; ti++) {
+    targs[ti] = (BpBatchThreadArgs){
+        .next_item = &next_item,
+        .items = items,
+        .total_items = total_items,
+        .cands = cands,
+        .mover_idx = mover_idx,
+        .opp_idx = opp_idx,
+        .unseen = unseen,
+        .ld_size = ld_size,
+        .tile_types = tile_types,
+        .tile_counts = tile_counts,
+        .thread_index = thread_index_offset + ti,
+        .endgame_ctx = &ctxs[ti],
+        .endgame_results = results[ti],
+        .move_list = move_lists ? move_lists[ti] : NULL,
+        .thread_control = thread_control,
+        .shared_tt = per_thread_tts ? per_thread_tts[ti] : NULL,
+        .dual_lexicon_mode = dlm,
+        .depth = depth,
+        .endgame_time_per_solve = endgame_time_per_solve,
+        .external_deadline_ns = external_deadline_ns,
+        .pure_playout = pure_playout,
+        .local_spread = &all_spread[(size_t)ti * num_cands],
+        .local_wins_x2 = &all_wins[(size_t)ti * num_cands],
+        .local_weight = &all_weight[(size_t)ti * num_cands],
+    };
+    cpthread_create(&threads[ti], bp_batch_thread, &targs[ti]);
+  }
+  for (int ti = 0; ti < num_threads; ti++) {
+    cpthread_join(threads[ti]);
+  }
+
+  // Reduce per-thread accumulators into per-cand Q values.
+  for (int ci = 0; ci < num_cands; ci++) {
+    int64_t spread_sum = 0;
+    int64_t wins_sum = 0;
+    int64_t weight_sum = 0;
+    for (int ti = 0; ti < num_threads; ti++) {
+      spread_sum += all_spread[((size_t)ti * num_cands) + ci];
+      wins_sum += all_wins[((size_t)ti * num_cands) + ci];
+      weight_sum += all_weight[((size_t)ti * num_cands) + ci];
+    }
+    if (weight_sum > 0) {
+      cands[ci].q_mean_spread = (double)spread_sum / (double)weight_sum;
+      cands[ci].q_win_pct = (double)wins_sum / (2.0 * (double)weight_sum);
+    }
+    cands[ci].depth_evaluated = depth;
+    cands[ci].visits++;
+  }
+
+  for (int ti = 0; ti < num_threads; ti++) {
+    endgame_ctx_destroy(ctxs[ti]);
+    endgame_results_destroy(results[ti]);
+  }
+  if (move_lists) {
+    for (int ti = 0; ti < num_threads; ti++) {
+      move_list_destroy(move_lists[ti]);
+    }
+    free(move_lists);
+  }
+  free(ctxs);
+  free(results);
+  free(targs);
+  free(threads);
+  free(items);
+  free(all_spread);
+  free(all_wins);
+  free(all_weight);
+}
+
+// Evaluate one candidate at a given depth across all bag-tile scenarios in
+// parallel. Updates cand->q_mean_spread, q_win_pct, depth_evaluated, visits.
+static void
+bp_evaluate_cand(BaiCand *cand, int depth, int mover_idx, int opp_idx,
+                 const uint8_t *unseen, int ld_size,
+                 const MachineLetter *tile_types, const int *tile_counts,
+                 int num_tile_types, ThreadControl *thread_control,
+                 TranspositionTable **per_thread_tts, dual_lexicon_mode_t dlm,
+                 double endgame_time_per_solve, int num_threads,
+                 int thread_index_offset, int64_t external_deadline_ns) {
+  atomic_int next_tile;
+  atomic_init(&next_tile, 0);
+
+  EndgameCtx **ctxs = calloc_or_die(num_threads, sizeof(EndgameCtx *));
+  EndgameResults **results =
+      malloc_or_die(num_threads * sizeof(EndgameResults *));
+  for (int ti = 0; ti < num_threads; ti++) {
+    results[ti] = endgame_results_create();
+  }
+
+  BpEvalThreadArgs *targs =
+      malloc_or_die(num_threads * sizeof(BpEvalThreadArgs));
+  cpthread_t *threads = malloc_or_die(num_threads * sizeof(cpthread_t));
+
+  for (int ti = 0; ti < num_threads; ti++) {
+    targs[ti] = (BpEvalThreadArgs){
+        .cand = cand,
+        .depth = depth,
+        .mover_idx = mover_idx,
+        .opp_idx = opp_idx,
+        .thread_index = thread_index_offset + ti,
+        .unseen = unseen,
+        .ld_size = ld_size,
+        .tile_types = tile_types,
+        .tile_counts = tile_counts,
+        .num_tile_types = num_tile_types,
+        .endgame_ctx = &ctxs[ti],
+        .endgame_results = results[ti],
+        .thread_control = thread_control,
+        .shared_tt = per_thread_tts ? per_thread_tts[ti] : NULL,
+        .dual_lexicon_mode = dlm,
+        .endgame_time_per_solve = endgame_time_per_solve,
+        .external_deadline_ns = external_deadline_ns,
+        .next_tile = &next_tile,
+        .local_spread_sum = 0,
+        .local_wins_x2 = 0,
+        .local_weight_sum = 0,
+    };
+    cpthread_create(&threads[ti], bp_eval_thread, &targs[ti]);
+  }
+  for (int ti = 0; ti < num_threads; ti++) {
+    cpthread_join(threads[ti]);
+  }
+
+  int64_t spread_sum = 0;
+  int64_t wins_x2 = 0;
+  int64_t weight_sum = 0;
+  for (int ti = 0; ti < num_threads; ti++) {
+    spread_sum += targs[ti].local_spread_sum;
+    wins_x2 += targs[ti].local_wins_x2;
+    weight_sum += targs[ti].local_weight_sum;
+  }
+
+  for (int ti = 0; ti < num_threads; ti++) {
+    endgame_ctx_destroy(ctxs[ti]);
+    endgame_results_destroy(results[ti]);
+  }
+  free(ctxs);
+  free(results);
+  free(targs);
+  free(threads);
+
+  if (weight_sum > 0) {
+    cand->q_mean_spread = (double)spread_sum / (double)weight_sum;
+    cand->q_win_pct = (double)wins_x2 / (2.0 * (double)weight_sum);
+  }
+  cand->depth_evaluated = depth;
+  cand->visits++;
+}
+
+// ---------------------------------------------------------------------------
+// Ranking helpers
+// ---------------------------------------------------------------------------
+
+static int bp_compare_cands_by_score(const void *a, const void *b) {
+  const BaiCand *ca = (const BaiCand *)a;
+  const BaiCand *cb = (const BaiCand *)b;
+  return cb->static_score - ca->static_score; // descending
+}
+
+// File-static utility weight read by bp_compare_cand_ptrs_by_q. qsort lacks a
+// portable context parameter, so the compare function reads this; bai_peg_solve
+// sets it at the top of every call.
+static double bp_compare_alpha = 0.0;
+
+static double bp_utility(const BaiCand *c) {
+  return c->q_win_pct + (bp_compare_alpha * c->q_mean_spread);
+}
+
+static int bp_compare_cand_ptrs_by_q(const void *a, const void *b) {
+  const BaiCand *const *pa = (const BaiCand *const *)a;
+  const BaiCand *const *pb = (const BaiCand *const *)b;
+  // Visited cands always rank above unvisited. Without this, in a losing
+  // position a visited cand (q_win=0, spread=-50) ranks BELOW unvisited
+  // cands (q_win=0, spread=0), and qsort instability bubbles a never-
+  // explored move (often pass, the lowest static-score arm) to ranking[0].
+  const bool va = (*pa)->visits > 0;
+  const bool vb = (*pb)->visits > 0;
+  if (va != vb) {
+    return va ? -1 : 1;
+  }
+  if (!va) {
+    // Both unvisited: fall back to static score (matches greedy ranking).
+    return (*pb)->static_score - (*pa)->static_score;
+  }
+  // Both visited: utility = win_pct + alpha * mean_spread, descending.
+  double ua = bp_utility(*pa);
+  double ub = bp_utility(*pb);
+  if (ua > ub) {
+    return -1;
+  }
+  if (ua < ub) {
+    return 1;
+  }
+  // Tiebreak: raw mean spread descending (matters when alpha == 0).
+  if ((*pa)->q_mean_spread > (*pb)->q_mean_spread) {
+    return -1;
+  }
+  if ((*pa)->q_mean_spread < (*pb)->q_mean_spread) {
+    return 1;
+  }
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Main solver
+// ---------------------------------------------------------------------------
+
+void bai_peg_solve(const BaiPegArgs *args, BaiPegResult *result,
+                   ErrorStack *error_stack) {
+  memset(result, 0, sizeof(*result));
+
+  const LetterDistribution *ld = game_get_ld(args->game);
+  int ld_size = ld_get_size(ld);
+  int mover_idx = game_get_player_on_turn_index(args->game);
+  int opp_idx = 1 - mover_idx;
+  int num_threads = args->num_threads > 0 ? args->num_threads : 1;
+  int max_depth = args->max_depth > 0 ? args->max_depth : BAI_PEG_MAX_DEPTH;
+  if (max_depth > BAI_PEG_MAX_DEPTH) {
+    max_depth = BAI_PEG_MAX_DEPTH;
+  }
+  int initial_top_k =
+      args->initial_top_k > 0 ? args->initial_top_k : BAI_PEG_DEFAULT_TOP_K;
+  double puct_c = args->puct_c > 0.0 ? args->puct_c : 1.0;
+  // Set the file-static utility weight read by bp_compare_cand_ptrs_by_q
+  // (qsort doesn't take a context). Reset on every entry.
+  bp_compare_alpha = args->utility_alpha;
+
+  if (bag_get_letters(game_get_bag(args->game)) != 1) {
+    error_stack_push(error_stack, ERROR_STATUS_ENDGAME_BAG_NOT_EMPTY,
+                     get_formatted_string(
+                         "bai_peg_solve requires exactly 1 tile in the bag"));
+    return;
+  }
+
+  uint8_t unseen[MAX_ALPHABET_SIZE];
+  int total_unseen = bp_compute_unseen(args->game, mover_idx, unseen);
+  if (total_unseen < 1 || total_unseen > RACK_SIZE + 1) {
+    error_stack_push(
+        error_stack, ERROR_STATUS_ENDGAME_BAG_NOT_EMPTY,
+        get_formatted_string("bai_peg_solve: invalid unseen count %d",
+                             total_unseen));
+    return;
+  }
+
+  // Build base game with empty bag and WMP disabled (mirrors peg_solve).
+  Game *base_game = game_duplicate(args->game);
+  {
+    Bag *base_bag = game_get_bag(base_game);
+    for (int ml = 0; ml < ld_size; ml++) {
+      while (bag_get_letter(base_bag, ml) > 0) {
+        bag_draw_letter(base_bag, (MachineLetter)ml, mover_idx);
+      }
+    }
+  }
+  for (int player_idx = 0; player_idx < 2; player_idx++) {
+    player_set_wmp(game_get_player(base_game, player_idx), NULL);
+  }
+
+  // Build pruned KWGs (single ignorant copy) and set as override.
+  bool shared_kwg = game_get_data_is_shared(args->game, PLAYERS_DATA_TYPE_KWG);
+  dual_lexicon_mode_t dlm = args->dual_lexicon_mode;
+  if (dlm == DUAL_LEXICON_MODE_INFORMED && shared_kwg) {
+    dlm = DUAL_LEXICON_MODE_IGNORANT;
+  }
+  bool create_separate_kwgs =
+      (dlm == DUAL_LEXICON_MODE_INFORMED) && !shared_kwg;
+  KWG *pruned_kwgs[2] = {NULL, NULL};
+  for (int player_idx = 0; player_idx < (create_separate_kwgs ? 2 : 1);
+       player_idx++) {
+    const KWG *full_kwg =
+        player_get_kwg(game_get_player(base_game, player_idx));
+    DictionaryWordList *word_list = dictionary_word_list_create();
+    generate_possible_words(base_game, full_kwg, word_list);
+    pruned_kwgs[player_idx] = make_kwg_from_words_small(
+        word_list, KWG_MAKER_OUTPUT_GADDAG, KWG_MAKER_MERGE_EXACT);
+    dictionary_word_list_destroy(word_list);
+  }
+  game_set_override_kwgs(base_game, pruned_kwgs[0], pruned_kwgs[1], dlm);
+  game_gen_all_cross_sets(base_game);
+
+  // Generate candidate moves.
+  MoveList *initial_ml = move_list_create_small(BAI_PEG_MOVELIST_CAPACITY);
+  {
+    const MoveGenArgs gen_args = {
+        .game = base_game,
+        .move_list = initial_ml,
+        .move_record_type = MOVE_RECORD_ALL_SMALL,
+        .move_sort_type = MOVE_SORT_SCORE,
+        .override_kwg = NULL,
+        .thread_index = 0,
+        .eq_margin_movegen = 0,
+        .target_equity = EQUITY_MAX_VALUE,
+        .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+    };
+    generate_moves(&gen_args);
+  }
+
+  int num_candidates = initial_ml->count;
+  if (num_candidates == 0) {
+    small_move_list_destroy(initial_ml);
+    if (pruned_kwgs[0]) {
+      kwg_destroy(pruned_kwgs[0]);
+    }
+    if (pruned_kwgs[1]) {
+      kwg_destroy(pruned_kwgs[1]);
+    }
+    game_destroy(base_game);
+    error_stack_push(error_stack, ERROR_STATUS_ENDGAME_BAG_NOT_EMPTY,
+                     get_formatted_string("bai_peg_solve: no legal moves"));
+    return;
+  }
+
+  // Build candidate array, top-K by static score. Skip pass candidates
+  // until PEG recursion is wired in — bai_peg has no way to evaluate the
+  // pass branch correctly without recursing into the post-pass position.
+  BaiCand *cands = calloc_or_die(num_candidates, sizeof(BaiCand));
+  int kept = 0;
+  for (int ci = 0; ci < num_candidates; ci++) {
+    if (small_move_is_pass(initial_ml->small_moves[ci])) {
+      continue;
+    }
+    cands[kept].move = *initial_ml->small_moves[ci];
+    small_move_to_move(&cands[kept].move_full, &cands[kept].move,
+                       game_get_board(base_game));
+    cands[kept].static_score = (int)small_move_get_score(&cands[kept].move);
+    kept++;
+  }
+  small_move_list_destroy(initial_ml);
+  num_candidates = kept;
+  if (num_candidates == 0) {
+    free(cands);
+    if (pruned_kwgs[0]) {
+      kwg_destroy(pruned_kwgs[0]);
+    }
+    if (pruned_kwgs[1]) {
+      kwg_destroy(pruned_kwgs[1]);
+    }
+    game_destroy(base_game);
+    error_stack_push(
+        error_stack, ERROR_STATUS_ENDGAME_BAG_NOT_EMPTY,
+        get_formatted_string("bai_peg_solve: no legal non-pass moves"));
+    return;
+  }
+
+  qsort(cands, num_candidates, sizeof(BaiCand), bp_compare_cands_by_score);
+  // Progressive widening keeps ALL generated moves in the pool — the active
+  // subset grows from a small seed as PUCT accumulates visits, so weak moves
+  // don't get touched at short budgets.
+  if (!args->progressive_widening && num_candidates > initial_top_k) {
+    num_candidates = initial_top_k;
+  }
+
+  // Compute softmax priors over the top-K static scores. Use a scaled
+  // temperature so the gap between top moves doesn't fully starve the rest.
+  {
+    int max_score = cands[0].static_score;
+    double T = 25.0; // points per "natural" temperature unit
+    double sum = 0.0;
+    for (int ci = 0; ci < num_candidates; ci++) {
+      double s = exp((double)(cands[ci].static_score - max_score) / T);
+      cands[ci].prior = s; // store unnormalized for now
+      sum += s;
+    }
+    for (int ci = 0; ci < num_candidates; ci++) {
+      cands[ci].prior /= sum;
+    }
+  }
+
+  // Pre-stage post-candidate games (each candidate's board + cross-sets
+  // after its move is played, opp rack untouched). With *just* progressive
+  // widening (no initial_playout, no min_active), most candidates never
+  // get visited, so we leave post_cand_game = NULL and create it lazily on
+  // first PUCT visit. With initial_playout, every cand gets a Phase 0
+  // visit. With min_active, the top-N cands get a Phase 1 d=1 warmup. In
+  // both cases we must pre-stage at least those cands.
+  // Number of cands to eagerly pre-stage. The rest get lazy creation on
+  // first PUCT visit (saves duplicating thousands of unused Game copies).
+  int prestage_count = num_candidates;
+  if (args->progressive_widening && !args->initial_playout) {
+    if (args->min_active > 0) {
+      prestage_count = (args->min_active < num_candidates) ? args->min_active
+                                                           : num_candidates;
+    } else {
+      prestage_count = 0; // pure pwn: lazy create only when admitted.
+    }
+  }
+  for (int ci = 0; ci < num_candidates; ci++) {
+    if (ci < prestage_count) {
+      Game *g = game_duplicate(base_game);
+      game_set_endgame_solving_mode(g);
+      game_set_backup_mode(g, BACKUP_MODE_OFF);
+      play_move_without_drawing_tiles(&cands[ci].move_full, g);
+      bp_clear_false_game_end(g);
+      cands[ci].post_cand_game = g;
+    } else {
+      cands[ci].post_cand_game = NULL;
+    }
+    // Structural prior on the cost of this candidate's first eval (depth 1).
+    // Replaced by measured time after the warm-up pass.
+    cands[ci].cost_estimate = bp_initial_cost_estimate(&cands[ci].move_full, 1);
+  }
+
+  // Build distinct-tile-types arrays from `unseen` once.
+  MachineLetter tile_types[MAX_ALPHABET_SIZE];
+  int tile_counts[MAX_ALPHABET_SIZE];
+  int num_tile_types = 0;
+  for (int ml = 0; ml < ld_size; ml++) {
+    if (unseen[ml] > 0) {
+      tile_types[num_tile_types] = (MachineLetter)ml;
+      tile_counts[num_tile_types] = (int)unseen[ml];
+      num_tile_types++;
+    }
+  }
+
+  // Per-thread TT setup. Three modes (priority order):
+  //   1. shared_tt_per_thread != NULL: caller-supplied array, length =
+  //   num_threads
+  //   2. shared_tt != NULL (legacy): mirror into a per-thread array
+  //   3. Otherwise allocate num_threads private TTs at fraction/num_threads
+  bool tts_owned_local = false;
+  bool per_tt_array_owned = false;
+  TranspositionTable **per_thread_tts = NULL;
+  if (args->shared_tt_per_thread) {
+    per_thread_tts = args->shared_tt_per_thread;
+  } else if (args->shared_tt) {
+    per_thread_tts =
+        malloc_or_die((size_t)num_threads * sizeof(TranspositionTable *));
+    for (int ti = 0; ti < num_threads; ti++) {
+      per_thread_tts[ti] = args->shared_tt;
+    }
+    per_tt_array_owned = true;
+  } else if (args->tt_fraction_of_mem > 0.0) {
+    per_thread_tts =
+        malloc_or_die((size_t)num_threads * sizeof(TranspositionTable *));
+    double per_thread_fraction = args->tt_fraction_of_mem / (double)num_threads;
+    for (int ti = 0; ti < num_threads; ti++) {
+      per_thread_tts[ti] = transposition_table_create(per_thread_fraction);
+    }
+    per_tt_array_owned = true;
+    tts_owned_local = true;
+  }
+
+  Timer wall_timer;
+  ctimer_start(&wall_timer);
+
+  // Absolute monotonic-ns wall-clock deadline. Plumbed into every endgame
+  // solve so workers stop mid-ply once the bai_peg_solve budget is hit.
+  int64_t bai_deadline_ns = 0;
+  if (args->time_budget_seconds > 0.0) {
+    bai_deadline_ns =
+        ctimer_monotonic_ns() + (int64_t)(args->time_budget_seconds * 1.0e9);
+  }
+
+  // Minimum per-scenario time we'll allow ourselves to commit to a new
+  // evaluation. Below this we'd rather short-circuit than start a doomed-to-
+  // overshoot search.
+  const double MIN_PER_SOLVE = 0.05;
+
+  // Phase 0 (optional, initial_playout): scenario-aware prior. Evaluates
+  // every candidate at depth=0 in a single flattened (cand, scenario) batch
+  // — one thread spawn/join cycle covers all num_candidates*num_tile_types
+  // scenarios. Endgame solver routes plies==0 to greedy leaf playout
+  // (highest-scoring move each turn to end-of-game with rack adjustments).
+  // PUCT then picks depth-1 evals for the candidates that look promising.
+  // Phase 0 runs whenever initial_playout is set, with or without progressive
+  // widening. With widening + ipo, every cand starts the PUCT loop with its
+  // own scenario-aware Q from the playout, so neighbor-inheritance becomes a
+  // no-op (only fires for unvisited cands). Without widening, Phase 0 alone
+  // is the warm-up. Phase 1 (depth-1 negamax sweep) is the fallback for the
+  // non-widening, non-playout case.
+  if (args->initial_playout) {
+    Timer playout_timer;
+    ctimer_start(&playout_timer);
+    bp_playout_batch(cands, num_candidates, 0, mover_idx, opp_idx, unseen,
+                     ld_size, tile_types, tile_counts, num_tile_types,
+                     args->thread_control, per_thread_tts, dlm,
+                     args->endgame_time_per_solve, num_threads, 0,
+                     bai_deadline_ns, args->pure_playout);
+    // Snapshot the playout signal for downstream regression analysis. After
+    // PUCT runs, q_* gets overwritten by deeper negamax results.
+    for (int ci = 0; ci < num_candidates; ci++) {
+      cands[ci].playout_q_win_pct = cands[ci].q_win_pct;
+      cands[ci].playout_q_mean_spread = cands[ci].q_mean_spread;
+      cands[ci].playout_q_set = true;
+    }
+    double playout_total = ctimer_elapsed_seconds(&playout_timer);
+    // Spread playout cost evenly across cands. PUCT uses time_paid in the
+    // exploration bonus denominator; equal time_paid means PUCT's first
+    // negamax pick is driven by Q + prior, exactly what we want from the
+    // playout-as-prior pattern. Don't count playouts in evaluations_done —
+    // they're the prior, not a negamax search at any depth.
+    if (num_candidates > 0) {
+      double per_cand = playout_total / (double)num_candidates;
+      for (int ci = 0; ci < num_candidates; ci++) {
+        cands[ci].time_paid += per_cand;
+        cands[ci].last_eval_seconds = per_cand;
+        // Leave cost_estimate at the bp_initial_cost_estimate(depth=1) value
+        // computed during cand setup — playout time isn't predictive of d1.
+      }
+    }
+  } else if (!args->progressive_widening || args->min_active > 0) {
+    // Phase 1: warm-up — evaluate every candidate at depth 1.
+    // With progressive_widening + min_active set, only warm up the seed
+    // top-min_active cands; widening will admit more later if budget allows.
+    int warmup_count = num_candidates;
+    if (args->progressive_widening && args->min_active > 0 &&
+        args->min_active < warmup_count) {
+      warmup_count = args->min_active;
+    }
+    for (int ci = 0; ci < warmup_count; ci++) {
+      double per_solve = args->endgame_time_per_solve;
+      if (args->time_budget_seconds > 0.0) {
+        double remaining =
+            args->time_budget_seconds - ctimer_elapsed_seconds(&wall_timer);
+        if (remaining <= MIN_PER_SOLVE) {
+          result->stopped_by_time = true;
+          break;
+        }
+        // Cap per-scenario budget so the worst-case eval can't push us past
+        // the wall-clock cap by more than one IDS iteration.
+        if (per_solve <= 0.0 || per_solve > remaining) {
+          per_solve = remaining;
+        }
+      }
+      Timer eval_timer;
+      ctimer_start(&eval_timer);
+      bp_evaluate_cand(&cands[ci], 1, mover_idx, opp_idx, unseen, ld_size,
+                       tile_types, tile_counts, num_tile_types,
+                       args->thread_control, per_thread_tts, dlm, per_solve,
+                       num_threads, 0, bai_deadline_ns);
+      double measured = ctimer_elapsed_seconds(&eval_timer);
+      cands[ci].time_paid += measured;
+      cands[ci].last_eval_seconds = measured;
+      // Predict next-depth cost: rough doubling per ply, floored at the
+      // measured value so it can never under-predict the depth we just ran.
+      cands[ci].cost_estimate = measured * 2.0;
+      result->evaluations_done++;
+      if (max_depth <= 1) {
+        cands[ci].fully_explored = true;
+      }
+    }
+  }
+
+  // Phase 2: PUCT-driven adaptive deepening.
+  int progress_top = args->progress_num_top > 0 ? args->progress_num_top
+                                                : BAI_PEG_DEFAULT_PROGRESS_TOP;
+  if (progress_top > num_candidates) {
+    progress_top = num_candidates;
+  }
+  // Working buffers for the progress callback (reused across calls).
+  SmallMove *cb_moves = malloc_or_die(progress_top * sizeof(SmallMove));
+  double *cb_wp = malloc_or_die(progress_top * sizeof(double));
+  double *cb_sp = malloc_or_die(progress_top * sizeof(double));
+  int *cb_depths = malloc_or_die(progress_top * sizeof(int));
+  BaiCand **ranking = malloc_or_die(num_candidates * sizeof(BaiCand *));
+
+  // Tracks how many candidates were active in the previous PUCT iteration.
+  // When widening expands the active set, each newly-admitted candidate
+  // inherits Q from its rank-up neighbor (the cand just above it by static
+  // score, which has already been visited). Calibration-free seeding —
+  // avoids needing to map move-score to win%/spread, and avoids the cost of
+  // a depth-0 playout per new cand.
+  int prev_active = 0;
+
+  while (!result->stopped_by_time && !result->stopped_by_max_evals &&
+         !result->stopped_by_confidence) {
+    if (args->time_budget_seconds > 0.0 &&
+        ctimer_elapsed_seconds(&wall_timer) >= args->time_budget_seconds) {
+      result->stopped_by_time = true;
+      break;
+    }
+    if (args->max_evaluations > 0 &&
+        result->evaluations_done >= args->max_evaluations) {
+      result->stopped_by_max_evals = true;
+      break;
+    }
+
+    // Cost-weighted PUCT: rather than counting evaluations equally, we use
+    // wall time spent per candidate as the "visit budget." This way a
+    // candidate at depth 4 (which paid ~5s to get there) doesn't get the
+    // same exploration bonus shrinkage as a depth-1 candidate that only
+    // paid 50ms. As the leader gets deeper, its bonus shrinks fast and
+    // cheap-to-explore candidates compete naturally.
+    double total_time = 0.0;
+    for (int ci = 0; ci < num_candidates; ci++) {
+      total_time += cands[ci].time_paid;
+    }
+
+    // Compute remaining wall-clock budget for cost-aware selection.
+    double remaining_budget = -1.0; // -1 = no time budget
+    if (args->time_budget_seconds > 0.0) {
+      remaining_budget =
+          args->time_budget_seconds - ctimer_elapsed_seconds(&wall_timer);
+    }
+
+    // Compute median-ish cost across candidates for bonus normalization.
+    // Use a simple mean of cost_estimates as the reference.
+    double sum_cost = 0.0;
+    int cost_n = 0;
+    for (int ci = 0; ci < num_candidates; ci++) {
+      if (!cands[ci].fully_explored) {
+        sum_cost += cands[ci].cost_estimate;
+        cost_n++;
+      }
+    }
+    double ref_cost = (cost_n > 0) ? sum_cost / cost_n : 0.1;
+    if (ref_cost <= 0) {
+      ref_cost = 0.01;
+    }
+
+    // Progressive widening: only the top-N candidates by static-score order
+    // are eligible for selection, where N grows with total visits done so
+    // far. Bad moves never get touched at short budgets.
+    int active_count = num_candidates;
+    if (args->progressive_widening) {
+      double w_c = args->widening_c > 0.0 ? args->widening_c : 2.0;
+      double sqrt_visits = sqrt((double)result->evaluations_done + 1.0);
+      int target = (int)ceil(w_c * sqrt_visits);
+      if (target < 2) {
+        target = 2;
+      }
+      // Floor to min_active when set: top-K cands are always active even
+      // before widening's sqrt growth catches up.
+      if (args->min_active > 0 && target < args->min_active) {
+        target = args->min_active;
+      }
+      if (target > num_candidates) {
+        target = num_candidates;
+      }
+      active_count = target;
+
+      // Inherit Q from the rank-up neighbor when a new candidate becomes
+      // active. Calibration-free seeding: the neighbor's Q is already on
+      // the right scale (win% in [0,1], spread in points). The new cand
+      // starts where its slightly-stronger predecessor stands; PUCT then
+      // refines via real evaluations. Skip cands whose neighbor is itself
+      // unvisited (cand 0 has no neighbor; later cands rarely hit this
+      // since rank K-1 is admitted before rank K under monotonic growth).
+      const double bw_p = args->blend_w_playout;
+      const double bw_n = args->blend_w_neighbor;
+      const bool blend_enabled = (bw_p > 0.0 || bw_n > 0.0);
+      for (int K = prev_active; K < active_count; K++) {
+        if (K == 0) {
+          continue;
+        }
+        // Snapshot the neighbor's Q at admission for regression analysis,
+        // regardless of whether this cand will use it as a seed. Done once
+        // per cand at the moment of admission.
+        if (!cands[K].neighbor_q_set && cands[K - 1].visits > 0) {
+          cands[K].neighbor_q_win_pct = cands[K - 1].q_win_pct;
+          cands[K].neighbor_q_mean_spread = cands[K - 1].q_mean_spread;
+          cands[K].neighbor_q_set = true;
+        }
+        // Initial Q assignment at admission. Three modes:
+        // 1) Blend (both signals + blend_enabled): weighted combo.
+        // 2) Neighbor-only (cand has no playout, predecessor visited).
+        // 3) No-op (cand already has real-Q from Phase 0 or negamax).
+        const bool predecessor_visited = (cands[K - 1].visits > 0);
+        if (blend_enabled && cands[K].playout_q_set &&
+            cands[K].neighbor_q_set) {
+          cands[K].q_win_pct = bw_p * cands[K].playout_q_win_pct +
+                               bw_n * cands[K].neighbor_q_win_pct;
+          cands[K].q_mean_spread = bw_p * cands[K].playout_q_mean_spread +
+                                   bw_n * cands[K].neighbor_q_mean_spread;
+        } else if (cands[K].visits == 0 && predecessor_visited) {
+          cands[K].q_win_pct = cands[K - 1].q_win_pct;
+          cands[K].q_mean_spread = cands[K - 1].q_mean_spread;
+        }
+      }
+      prev_active = active_count;
+    }
+
+    // Pick the highest-PUCT non-fully-explored candidate.
+    int chosen = -1;
+    double best_puct = -1.0e300;
+    double sqrt_total_time = sqrt(total_time + 1.0);
+    for (int ci = 0; ci < active_count; ci++) {
+      if (cands[ci].fully_explored) {
+        continue;
+      }
+      // (1) Reject infeasible: skip if predicted next-eval cost won't fit
+      //     in the remaining budget. Lets compute focus on candidates that
+      //     can actually finish a useful evaluation.
+      if (remaining_budget > 0.0 &&
+          cands[ci].cost_estimate > remaining_budget) {
+        continue;
+      }
+      // Q is win-rate in [0, 1] so the exploration bonus (also in [0, ~1])
+      // is on a comparable scale.
+      double bonus = puct_c * cands[ci].prior * sqrt_total_time /
+                     (1.0 + cands[ci].time_paid);
+      // (2) Cost-normalize the bonus: an expensive candidate's exploration
+      //     bonus is scaled down by sqrt(its_cost / median_cost). High-Q
+      //     leaders still win on Q dominance; cheap-but-ambiguous arms
+      //     still attract early exploration; expensive arms have to earn
+      //     their deepening through Q rather than bonus.
+      double cost_penalty = sqrt(cands[ci].cost_estimate / ref_cost);
+      if (cost_penalty < 0.1) {
+        cost_penalty = 0.1;
+      }
+      // Q is utility = win_pct + alpha * spread. With alpha == 0 this is pure
+      // win-rate; alpha > 0 rewards spread on the same scale (e.g. alpha=0.01
+      // makes 100 spread points equivalent to 1 win).
+      double q =
+          cands[ci].q_win_pct + (bp_compare_alpha * cands[ci].q_mean_spread);
+      double score = q + (bonus / cost_penalty);
+      // Tiny spread tiebreaker for the alpha==0 case so candidates with
+      // identical win-rates still separate consistently.
+      if (bp_compare_alpha == 0.0) {
+        score += 1e-3 * cands[ci].q_mean_spread;
+      }
+      if (score > best_puct) {
+        best_puct = score;
+        chosen = ci;
+      }
+    }
+    if (chosen < 0) {
+      // Everyone is fully explored; nothing more to do.
+      break;
+    }
+
+    // First visit to any cand starts at depth 1 (full negamax). Without
+    // widening the warm-up phase already ran depth=1 for all cands so
+    // depth_evaluated is at least 1 here. With widening, newly-admitted
+    // cands inherit Q from their rank-up neighbor (calibration-free
+    // seeding) and skip the playout step.
+    int next_depth = cands[chosen].depth_evaluated + 1;
+    if (next_depth > max_depth) {
+      cands[chosen].fully_explored = true;
+      continue;
+    }
+    // Lazy post_cand_game creation: with widening, most cands never get
+    // touched, so we don't pre-stage. Build it now if needed.
+    if (cands[chosen].post_cand_game == NULL) {
+      Game *g = game_duplicate(base_game);
+      game_set_endgame_solving_mode(g);
+      game_set_backup_mode(g, BACKUP_MODE_OFF);
+      play_move_without_drawing_tiles(&cands[chosen].move_full, g);
+      bp_clear_false_game_end(g);
+      cands[chosen].post_cand_game = g;
+    }
+    // Cap per-scenario time to whatever's left so the eval can't overshoot
+    // the wall-clock budget by more than one IDS iteration's worth.
+    double per_solve = args->endgame_time_per_solve;
+    if (args->time_budget_seconds > 0.0) {
+      double remaining =
+          args->time_budget_seconds - ctimer_elapsed_seconds(&wall_timer);
+      if (remaining <= MIN_PER_SOLVE) {
+        result->stopped_by_time = true;
+        break;
+      }
+      if (per_solve <= 0.0 || per_solve > remaining) {
+        per_solve = remaining;
+      }
+    }
+    Timer eval_timer;
+    ctimer_start(&eval_timer);
+    bp_evaluate_cand(&cands[chosen], next_depth, mover_idx, opp_idx, unseen,
+                     ld_size, tile_types, tile_counts, num_tile_types,
+                     args->thread_control, per_thread_tts, dlm, per_solve,
+                     num_threads, 0, bai_deadline_ns);
+    double measured = ctimer_elapsed_seconds(&eval_timer);
+    cands[chosen].time_paid += measured;
+    cands[chosen].last_eval_seconds = measured;
+    // Predict next-depth cost from this measurement.
+    cands[chosen].cost_estimate = measured * 2.0;
+    if (next_depth >= max_depth) {
+      cands[chosen].fully_explored = true;
+    }
+    result->evaluations_done++;
+
+    // Confidence-based early stop: leader vs best challenger by utility.
+    if (args->early_stop_gap > 0.0 && args->early_stop_min_depth > 0) {
+      int li = -1;
+      double l_q = -1.0e300;
+      for (int ci = 0; ci < num_candidates; ci++) {
+        double q = bp_utility(&cands[ci]);
+        if (q > l_q) {
+          l_q = q;
+          li = ci;
+        }
+      }
+      int ci2 = -1;
+      double c_q = -1.0e300;
+      for (int ci = 0; ci < num_candidates; ci++) {
+        if (ci == li) {
+          continue;
+        }
+        double q = bp_utility(&cands[ci]);
+        if (q > c_q) {
+          c_q = q;
+          ci2 = ci;
+        }
+      }
+      if (li >= 0 && ci2 >= 0 &&
+          cands[li].depth_evaluated >= args->early_stop_min_depth &&
+          cands[ci2].depth_evaluated >= args->early_stop_min_depth &&
+          (l_q - c_q) >= args->early_stop_gap) {
+        result->stopped_by_confidence = true;
+      }
+    }
+
+    // Progress callback: ranked snapshot of top-K by win% / spread.
+    if (args->progress_callback) {
+      for (int ci = 0; ci < num_candidates; ci++) {
+        ranking[ci] = &cands[ci];
+      }
+      qsort(ranking, num_candidates, sizeof(BaiCand *),
+            bp_compare_cand_ptrs_by_q);
+      for (int i = 0; i < progress_top; i++) {
+        cb_moves[i] = ranking[i]->move;
+        cb_wp[i] = ranking[i]->q_win_pct;
+        cb_sp[i] = ranking[i]->q_mean_spread;
+        cb_depths[i] = ranking[i]->depth_evaluated;
+      }
+      args->progress_callback(result->evaluations_done,
+                              ctimer_elapsed_seconds(&wall_timer), cb_moves,
+                              cb_wp, cb_sp, cb_depths, progress_top, args->game,
+                              args->progress_callback_data);
+    }
+  }
+
+  // Final ranking and result fill.
+  for (int ci = 0; ci < num_candidates; ci++) {
+    ranking[ci] = &cands[ci];
+  }
+  qsort(ranking, num_candidates, sizeof(BaiCand *), bp_compare_cand_ptrs_by_q);
+  // Sanity: never return an unvisited candidate. If somehow the budget was
+  // so tight that even cand 0 didn't get a depth-0 visit, log an error and
+  // fall back to the top-static-score move (which is what an unvisited
+  // ranking[0] already resolves to via the static-score tiebreak in the
+  // compare, but we want the warning to surface).
+  if (ranking[0]->visits == 0) {
+    log_warn("bai_peg_solve: budget exhausted before any candidate was "
+             "evaluated; falling back to top-static-score move");
+  }
+  result->best_move = ranking[0]->move;
+  result->best_win_pct = ranking[0]->q_win_pct;
+  result->best_mean_spread = ranking[0]->q_mean_spread;
+  result->best_depth_evaluated = ranking[0]->depth_evaluated;
+  result->candidates_considered = num_candidates;
+  result->seconds_elapsed = ctimer_elapsed_seconds(&wall_timer);
+
+  // Per-cand stats for offline analysis (regression on which prior signal
+  // best predicts the final Q). cand_stats[i] follows ranking order: index 0
+  // is the picked move, then descending by utility.
+  if (args->request_cand_stats) {
+    result->cand_stats = malloc_or_die(num_candidates * sizeof(BaiCandStats));
+    for (int i = 0; i < num_candidates; i++) {
+      const BaiCand *c = ranking[i];
+      BaiCandStats *s = &result->cand_stats[i];
+      s->move = c->move;
+      s->static_score = c->static_score;
+      // The original cand index (rank by static score) is its offset from
+      // the sorted cands[] array.
+      s->rank = (int)(c - cands);
+      s->playout_q_set = c->playout_q_set;
+      s->playout_q_win_pct = c->playout_q_win_pct;
+      s->playout_q_mean_spread = c->playout_q_mean_spread;
+      s->neighbor_q_set = c->neighbor_q_set;
+      s->neighbor_q_win_pct = c->neighbor_q_win_pct;
+      s->neighbor_q_mean_spread = c->neighbor_q_mean_spread;
+      s->final_q_win_pct = c->q_win_pct;
+      s->final_q_mean_spread = c->q_mean_spread;
+      s->depth_evaluated = c->depth_evaluated;
+      s->visits = c->visits;
+      s->is_best = (i == 0);
+    }
+  } else {
+    result->cand_stats = NULL;
+  }
+
+  // Visit histogram: a candidate that reached depth_evaluated=N completed one
+  // evaluation at each depth 1..N (BAI's bp_evaluate_cand goes one ply at a
+  // time). So visits_at_depth[d] = count of candidates with depth_evaluated >=
+  // d.
+  for (int d = 0; d <= BAI_PEG_MAX_DEPTH; d++) {
+    result->visits_at_depth[d] = 0;
+  }
+  for (int ci = 0; ci < num_candidates; ci++) {
+    int de = cands[ci].depth_evaluated;
+    if (de > BAI_PEG_MAX_DEPTH) {
+      de = BAI_PEG_MAX_DEPTH;
+    }
+    for (int d = 1; d <= de; d++) {
+      result->visits_at_depth[d]++;
+    }
+  }
+
+  // Cleanup.
+  free(cb_moves);
+  free(cb_wp);
+  free(cb_sp);
+  free(cb_depths);
+  free(ranking);
+  for (int ci = 0; ci < num_candidates; ci++) {
+    if (cands[ci].post_cand_game) {
+      game_destroy(cands[ci].post_cand_game);
+    }
+  }
+  free(cands);
+  if (tts_owned_local) {
+    for (int ti = 0; ti < num_threads; ti++) {
+      transposition_table_destroy(per_thread_tts[ti]);
+    }
+  }
+  if (per_tt_array_owned) {
+    free(per_thread_tts);
+  }
+  if (pruned_kwgs[0]) {
+    kwg_destroy(pruned_kwgs[0]);
+  }
+  if (pruned_kwgs[1]) {
+    kwg_destroy(pruned_kwgs[1]);
+  }
+  game_destroy(base_game);
+}
+
+void bai_cand_stats_free(BaiCandStats *cand_stats) { free(cand_stats); }

--- a/src/impl/bai_peg.c
+++ b/src/impl/bai_peg.c
@@ -129,6 +129,9 @@ typedef struct BaiCand {
   double neighbor_q_win_pct;
   bool neighbor_q_set;
   bool fully_explored; // True once depth_evaluated >= max_depth.
+  double sort_utility; // Transient: populated by bp_populate_sort_utility
+                       // immediately before each qsort, read by the
+                       // qsort comparator. Stale outside that window.
 } BaiCand;
 
 // Structural prior on the cost of evaluating one (cand, depth) eval before
@@ -625,13 +628,22 @@ static int bp_compare_cands_by_score(const void *a, const void *b) {
   return cb->static_score - ca->static_score; // descending
 }
 
-// File-static utility weight read by bp_compare_cand_ptrs_by_q. qsort lacks a
-// portable context parameter, so the compare function reads this; bai_peg_solve
-// sets it at the top of every call.
-static double bp_compare_alpha = 0.0;
+// Stateless utility helper. Callers pass alpha explicitly; the qsort
+// comparator below relies on bp_populate_sort_utility caching the result
+// onto each cand's sort_utility field rather than reading a shared
+// global, so concurrent bai_peg_solve calls do not race on alpha.
+static double bp_compute_utility(const BaiCand *c, double alpha) {
+  return c->q_win_pct + (alpha * c->q_mean_spread);
+}
 
-static double bp_utility(const BaiCand *c) {
-  return c->q_win_pct + (bp_compare_alpha * c->q_mean_spread);
+// Populate cand->sort_utility for every cand in the array. Must be called
+// immediately before any qsort that uses bp_compare_cand_ptrs_by_q; the
+// comparator reads only sort_utility and never alpha.
+static void bp_populate_sort_utility(BaiCand *cands, int num_candidates,
+                                     double alpha) {
+  for (int ci = 0; ci < num_candidates; ci++) {
+    cands[ci].sort_utility = bp_compute_utility(&cands[ci], alpha);
+  }
 }
 
 static int bp_compare_cand_ptrs_by_q(const void *a, const void *b) {
@@ -650,9 +662,9 @@ static int bp_compare_cand_ptrs_by_q(const void *a, const void *b) {
     // Both unvisited: fall back to static score (matches greedy ranking).
     return (*pb)->static_score - (*pa)->static_score;
   }
-  // Both visited: utility = win_pct + alpha * mean_spread, descending.
-  double ua = bp_utility(*pa);
-  double ub = bp_utility(*pb);
+  // Both visited: cached utility (win_pct + alpha * mean_spread), descending.
+  double ua = (*pa)->sort_utility;
+  double ub = (*pb)->sort_utility;
   if (ua > ub) {
     return -1;
   }
@@ -689,9 +701,7 @@ void bai_peg_solve(const BaiPegArgs *args, BaiPegResult *result,
   int initial_top_k =
       args->initial_top_k > 0 ? args->initial_top_k : BAI_PEG_DEFAULT_TOP_K;
   double puct_c = args->puct_c > 0.0 ? args->puct_c : 1.0;
-  // Set the file-static utility weight read by bp_compare_cand_ptrs_by_q
-  // (qsort doesn't take a context). Reset on every entry.
-  bp_compare_alpha = args->utility_alpha;
+  const double alpha = args->utility_alpha;
 
   if (bag_get_letters(game_get_bag(args->game)) != 1) {
     error_stack_push(error_stack, ERROR_STATUS_ENDGAME_BAG_NOT_EMPTY,
@@ -1171,12 +1181,11 @@ void bai_peg_solve(const BaiPegArgs *args, BaiPegResult *result,
       // Q is utility = win_pct + alpha * spread. With alpha == 0 this is pure
       // win-rate; alpha > 0 rewards spread on the same scale (e.g. alpha=0.01
       // makes 100 spread points equivalent to 1 win).
-      double q =
-          cands[ci].q_win_pct + (bp_compare_alpha * cands[ci].q_mean_spread);
+      double q = bp_compute_utility(&cands[ci], alpha);
       double score = q + (bonus / cost_penalty);
       // Tiny spread tiebreaker for the alpha==0 case so candidates with
       // identical win-rates still separate consistently.
-      if (bp_compare_alpha == 0.0) {
+      if (alpha == 0.0) {
         score += 1e-3 * cands[ci].q_mean_spread;
       }
       if (score > best_puct) {
@@ -1244,7 +1253,7 @@ void bai_peg_solve(const BaiPegArgs *args, BaiPegResult *result,
       int li = -1;
       double l_q = -1.0e300;
       for (int ci = 0; ci < num_candidates; ci++) {
-        double q = bp_utility(&cands[ci]);
+        double q = bp_compute_utility(&cands[ci], alpha);
         if (q > l_q) {
           l_q = q;
           li = ci;
@@ -1256,7 +1265,7 @@ void bai_peg_solve(const BaiPegArgs *args, BaiPegResult *result,
         if (ci == li) {
           continue;
         }
-        double q = bp_utility(&cands[ci]);
+        double q = bp_compute_utility(&cands[ci], alpha);
         if (q > c_q) {
           c_q = q;
           ci2 = ci;
@@ -1275,6 +1284,7 @@ void bai_peg_solve(const BaiPegArgs *args, BaiPegResult *result,
       for (int ci = 0; ci < num_candidates; ci++) {
         ranking[ci] = &cands[ci];
       }
+      bp_populate_sort_utility(cands, num_candidates, alpha);
       qsort(ranking, num_candidates, sizeof(BaiCand *),
             bp_compare_cand_ptrs_by_q);
       for (int i = 0; i < progress_top; i++) {
@@ -1294,6 +1304,7 @@ void bai_peg_solve(const BaiPegArgs *args, BaiPegResult *result,
   for (int ci = 0; ci < num_candidates; ci++) {
     ranking[ci] = &cands[ci];
   }
+  bp_populate_sort_utility(cands, num_candidates, alpha);
   qsort(ranking, num_candidates, sizeof(BaiCand *), bp_compare_cand_ptrs_by_q);
   // Sanity: never return an unvisited candidate. If somehow the budget was
   // so tight that even cand 0 didn't get a depth-0 visit, log an error and

--- a/src/impl/bai_peg.c
+++ b/src/impl/bai_peg.c
@@ -710,7 +710,9 @@ void bai_peg_solve(const BaiPegArgs *args, BaiPegResult *result,
     return;
   }
 
-  // Build base game with empty bag and WMP disabled (mirrors peg_solve).
+  // Build base game with empty bag and WMP disabled. Each scenario solve
+  // will replay the bag tile into the mover's rack and populate the
+  // opponent's rack from `unseen - bag_tile`.
   Game *base_game = game_duplicate(args->game);
   {
     Bag *base_bag = game_get_bag(base_game);

--- a/src/impl/bai_peg.c
+++ b/src/impl/bai_peg.c
@@ -304,8 +304,7 @@ typedef struct BpBatchThreadArgs {
 // the safety cap without natural end, apply rack penalties manually.
 static int32_t bp_greedy_playout(Game *game, int solving_player,
                                  MoveList *move_list, int thread_index) {
-  enum { MAX_PLAYOUT_TURNS = 30 };
-  for (int turn = 0; turn < MAX_PLAYOUT_TURNS; turn++) {
+  for (int turn = 0; turn < MAX_SEARCH_DEPTH; turn++) {
     if (game_get_game_end_reason(game) != GAME_END_REASON_NONE) {
       break;
     }

--- a/src/impl/bai_peg.c
+++ b/src/impl/bai_peg.c
@@ -108,12 +108,14 @@ static void bp_clear_false_game_end(Game *game) {
 typedef struct BaiCand {
   SmallMove move;
   Move move_full;
-  int static_score;     // Move score (used to derive prior).
-  Game *post_cand_game; // Post-move game state (board + cross-sets), shared.
-  double prior;         // Softmax-normalized prior in [0, 1].
-  int depth_evaluated;  // 0 = no endgame eval yet; N = N-ply endgame done.
-  int visits;           // Number of (depth) evaluations performed.
-  double time_paid;     // Cumulative wall time spent evaluating this cand.
+  int static_score;        // Move score (used for sort + display).
+  Equity equity_for_prior; // Prior softmax basis = score + KLV leave value
+                           // (movegen's pre-computed equity field).
+  Game *post_cand_game;    // Post-move game state (board + cross-sets), shared.
+  double prior;            // Softmax-normalized prior in [0, 1].
+  int depth_evaluated;     // 0 = no endgame eval yet; N = N-ply endgame done.
+  int visits;              // Number of (depth) evaluations performed.
+  double time_paid;        // Cumulative wall time spent evaluating this cand.
   double last_eval_seconds; // Wall time of the most recent evaluation.
   double cost_estimate;     // Predicted seconds for the next evaluation.
   double q_mean_spread;     // Mean spread at deepest evaluated depth (0 init).
@@ -621,10 +623,20 @@ bp_evaluate_cand(BaiCand *cand, int depth, int mover_idx, int opp_idx,
 // Ranking helpers
 // ---------------------------------------------------------------------------
 
-static int bp_compare_cands_by_score(const void *a, const void *b) {
+// Sort cands by their prior basis (descending). Movegen already produces
+// moves in equity-descending order; this comparator exists as a safety
+// net after the pass filter so the cands array's basis ordering is an
+// invariant the rest of the file can rely on.
+static int bp_compare_cands_by_prior(const void *a, const void *b) {
   const BaiCand *ca = (const BaiCand *)a;
   const BaiCand *cb = (const BaiCand *)b;
-  return cb->static_score - ca->static_score; // descending
+  if (cb->equity_for_prior > ca->equity_for_prior) {
+    return 1;
+  }
+  if (cb->equity_for_prior < ca->equity_for_prior) {
+    return -1;
+  }
+  return 0;
 }
 
 // Stateless utility helper. Callers pass alpha explicitly; the qsort
@@ -767,14 +779,19 @@ void bai_peg_solve(const BaiPegArgs *args, BaiPegResult *result,
   game_set_override_kwgs(base_game, pruned_kwgs[0], pruned_kwgs[1], dlm);
   game_gen_all_cross_sets(base_game);
 
-  // Generate candidate moves.
-  MoveList *initial_ml = move_list_create_small(BAI_PEG_MOVELIST_CAPACITY);
+  // Root movegen uses full Move records (not SmallMove) and MOVE_SORT_EQUITY
+  // so each cand carries movegen's pre-computed equity (= score + KLV leave
+  // value). We use that equity as the prior softmax basis, which empirically
+  // beats score-only by ~0.4pp EmpW% / +0.37 spread on a 1000-position 1s
+  // benchmark (95 vs 73 H2H wins among 174 differing picks; see commit
+  // message for sweep details).
+  MoveList *initial_ml = move_list_create(BAI_PEG_MOVELIST_CAPACITY);
   {
     const MoveGenArgs gen_args = {
         .game = base_game,
         .move_list = initial_ml,
-        .move_record_type = MOVE_RECORD_ALL_SMALL,
-        .move_sort_type = MOVE_SORT_SCORE,
+        .move_record_type = MOVE_RECORD_ALL,
+        .move_sort_type = MOVE_SORT_EQUITY,
         .override_kwg = NULL,
         .thread_index = args->thread_index_offset,
         .eq_margin_movegen = 0,
@@ -788,7 +805,7 @@ void bai_peg_solve(const BaiPegArgs *args, BaiPegResult *result,
   if (num_candidates == 0) {
     // movegen normally returns at least a pass; defensive fallback if it
     // somehow doesn't. Same handling as the "no scoring plays" case below.
-    small_move_list_destroy(initial_ml);
+    move_list_destroy(initial_ml);
     if (pruned_kwgs[0]) {
       kwg_destroy(pruned_kwgs[0]);
     }
@@ -804,22 +821,34 @@ void bai_peg_solve(const BaiPegArgs *args, BaiPegResult *result,
     return;
   }
 
-  // Build candidate array, top-K by static score. Skip pass candidates
-  // until PEG recursion is wired in — bai_peg has no way to evaluate the
-  // pass branch correctly without recursing into the post-pass position.
+  // Build candidate array. Skip pass candidates until PEG recursion is
+  // wired in — bai_peg has no way to evaluate the pass branch correctly
+  // without recursing into the post-pass position.
   BaiCand *cands = calloc_or_die(num_candidates, sizeof(BaiCand));
   int kept = 0;
   for (int ci = 0; ci < num_candidates; ci++) {
-    if (small_move_is_pass(initial_ml->small_moves[ci])) {
+    const Move *m = initial_ml->moves[ci];
+    if (move_get_type(m) == GAME_EVENT_PASS) {
       continue;
     }
-    cands[kept].move = *initial_ml->small_moves[ci];
-    small_move_to_move(&cands[kept].move_full, &cands[kept].move,
-                       game_get_board(base_game));
-    cands[kept].static_score = (int)small_move_get_score(&cands[kept].move);
+    cands[kept].move_full = *m;
+    // Build SmallMove from the full Move so callers (result.best_move,
+    // progress callback, cand_stats) get the compact form. Movegen
+    // pre-swaps row_start/col_start for vertical moves to match the
+    // SmallMove encoding's own swap (set_play_for_record at
+    // move_gen.c:210-213); we have to undo that swap before calling
+    // small_move_set_all (which will re-apply it).
+    const bool is_vert = (m->dir == BOARD_VERTICAL_DIRECTION);
+    const int orig_row = is_vert ? m->col_start : m->row_start;
+    const int orig_col = is_vert ? m->row_start : m->col_start;
+    small_move_set_all(&cands[kept].move, m->tiles, 0, m->tiles_length - 1,
+                       m->score, orig_row, orig_col, m->tiles_played, is_vert,
+                       m->move_type);
+    cands[kept].static_score = (int)equity_to_int(m->score);
+    cands[kept].equity_for_prior = m->equity;
     kept++;
   }
-  small_move_list_destroy(initial_ml);
+  move_list_destroy(initial_ml);
   num_candidates = kept;
   if (num_candidates == 0) {
     // No scoring plays from this rack. bai_peg can't search the pass branch
@@ -842,7 +871,7 @@ void bai_peg_solve(const BaiPegArgs *args, BaiPegResult *result,
     return;
   }
 
-  qsort(cands, num_candidates, sizeof(BaiCand), bp_compare_cands_by_score);
+  qsort(cands, num_candidates, sizeof(BaiCand), bp_compare_cands_by_prior);
   // Progressive widening keeps ALL generated moves in the pool — the active
   // subset grows from a small seed as PUCT accumulates visits, so weak moves
   // don't get touched at short budgets.
@@ -850,14 +879,17 @@ void bai_peg_solve(const BaiPegArgs *args, BaiPegResult *result,
     num_candidates = initial_top_k;
   }
 
-  // Compute softmax priors over the top-K static scores. Use a scaled
-  // temperature so the gap between top moves doesn't fully starve the rest.
+  // Compute softmax priors over each cand's equity_for_prior (= score +
+  // KLV leave value). Cands are already sorted in basis-descending order
+  // by qsort above. Temperature scaled so the gap between top moves
+  // doesn't fully starve the rest.
   {
-    int max_score = cands[0].static_score;
     double T = 25.0; // points per "natural" temperature unit
+    double max_basis = equity_to_double(cands[0].equity_for_prior);
     double sum = 0.0;
     for (int ci = 0; ci < num_candidates; ci++) {
-      double s = exp((double)(cands[ci].static_score - max_score) / T);
+      double basis = equity_to_double(cands[ci].equity_for_prior);
+      double s = exp((basis - max_basis) / T);
       cands[ci].prior = s; // store unnormalized for now
       sum += s;
     }

--- a/src/impl/bai_peg.c
+++ b/src/impl/bai_peg.c
@@ -702,20 +702,30 @@ void bai_peg_solve(const BaiPegArgs *args, BaiPegResult *result,
   double puct_c = args->puct_c > 0.0 ? args->puct_c : 1.0;
   const double alpha = args->utility_alpha;
 
-  if (bag_get_letters(game_get_bag(args->game)) != 1) {
-    error_stack_push(error_stack, ERROR_STATUS_ENDGAME_BAG_NOT_EMPTY,
-                     get_formatted_string(
-                         "bai_peg_solve requires exactly 1 tile in the bag"));
-    return;
-  }
-
-  uint8_t unseen[MAX_ALPHABET_SIZE];
-  int total_unseen = bp_compute_unseen(args->game, mover_idx, unseen);
-  if (total_unseen < 1 || total_unseen > RACK_SIZE + 1) {
+  // Accept any CGP that, from the mover's perspective, has exactly
+  // RACK_SIZE+1 unseen tiles and a full mover rack: this is the canonical
+  // 1-in-bag PEG state regardless of how the CGP partitions the unseen
+  // tiles between opp's rack and the bag (CGPs from analyzers commonly
+  // report opp_rack as empty since the opponent's tiles aren't knowable).
+  // The inner scenario loop will redistribute the unseen pool itself.
+  const Rack *mover_rack_check =
+      player_get_rack(game_get_player(args->game, mover_idx));
+  if (rack_get_total_letters(mover_rack_check) != RACK_SIZE) {
     error_stack_push(
         error_stack, ERROR_STATUS_ENDGAME_BAG_NOT_EMPTY,
-        get_formatted_string("bai_peg_solve: invalid unseen count %d",
-                             total_unseen));
+        get_formatted_string(
+            "bai_peg_solve requires a full mover rack (%d tiles); got %d",
+            RACK_SIZE, (int)rack_get_total_letters(mover_rack_check)));
+    return;
+  }
+  uint8_t unseen[MAX_ALPHABET_SIZE];
+  int total_unseen = bp_compute_unseen(args->game, mover_idx, unseen);
+  if (total_unseen != RACK_SIZE + 1) {
+    error_stack_push(
+        error_stack, ERROR_STATUS_ENDGAME_BAG_NOT_EMPTY,
+        get_formatted_string("bai_peg_solve requires %d unseen tiles "
+                             "(mover full rack + 1 in bag); got %d",
+                             RACK_SIZE + 1, total_unseen));
     return;
   }
 

--- a/src/impl/bai_peg.c
+++ b/src/impl/bai_peg.c
@@ -45,8 +45,7 @@ enum {
 };
 
 // ---------------------------------------------------------------------------
-// Local helpers (intentionally duplicated from peg.c so this file stays
-// self-contained and the existing PEG implementation is untouched).
+// Local helpers
 // ---------------------------------------------------------------------------
 
 static int bp_compute_unseen(const Game *game, int mover_idx,
@@ -777,6 +776,8 @@ void bai_peg_solve(const BaiPegArgs *args, BaiPegResult *result,
 
   int num_candidates = initial_ml->count;
   if (num_candidates == 0) {
+    // movegen normally returns at least a pass; defensive fallback if it
+    // somehow doesn't. Same handling as the "no scoring plays" case below.
     small_move_list_destroy(initial_ml);
     if (pruned_kwgs[0]) {
       kwg_destroy(pruned_kwgs[0]);
@@ -785,8 +786,11 @@ void bai_peg_solve(const BaiPegArgs *args, BaiPegResult *result,
       kwg_destroy(pruned_kwgs[1]);
     }
     game_destroy(base_game);
-    error_stack_push(error_stack, ERROR_STATUS_ENDGAME_BAG_NOT_EMPTY,
-                     get_formatted_string("bai_peg_solve: no legal moves"));
+    small_move_set_as_pass(&result->best_move);
+    result->best_win_pct = 0.0;
+    result->best_mean_spread = 0.0;
+    result->best_depth_evaluated = 0;
+    result->candidates_considered = 0;
     return;
   }
 
@@ -808,6 +812,10 @@ void bai_peg_solve(const BaiPegArgs *args, BaiPegResult *result,
   small_move_list_destroy(initial_ml);
   num_candidates = kept;
   if (num_candidates == 0) {
+    // No scoring plays from this rack. bai_peg can't search the pass branch
+    // (no recursion into the post-pass position), so fall back to pass-with-
+    // score-0 as the best move and return success. The caller decides what
+    // to do; for the CLI we simply surface the pass.
     free(cands);
     if (pruned_kwgs[0]) {
       kwg_destroy(pruned_kwgs[0]);
@@ -816,9 +824,11 @@ void bai_peg_solve(const BaiPegArgs *args, BaiPegResult *result,
       kwg_destroy(pruned_kwgs[1]);
     }
     game_destroy(base_game);
-    error_stack_push(
-        error_stack, ERROR_STATUS_ENDGAME_BAG_NOT_EMPTY,
-        get_formatted_string("bai_peg_solve: no legal non-pass moves"));
+    small_move_set_as_pass(&result->best_move);
+    result->best_win_pct = 0.0;
+    result->best_mean_spread = 0.0;
+    result->best_depth_evaluated = 0;
+    result->candidates_considered = 0;
     return;
   }
 

--- a/src/impl/bai_peg.h
+++ b/src/impl/bai_peg.h
@@ -1,22 +1,52 @@
 #ifndef BAI_PEG_H
 #define BAI_PEG_H
 
+/*
+ * BAI-style adaptive pre-endgame solver.
+ *
+ * Differs from peg_solve: instead of discrete pass-by-pass top-K cuts at
+ * fixed depths, allocates compute adaptively across (candidate, depth)
+ * pairs using a PUCT-like rule. Anytime: at any moment the best-so-far
+ * candidate is meaningful, and the caller can stop on time, evaluation
+ * budget, or a confidence-based early exit when the leader is
+ * statistically dominant.
+ *
+ * One-bag-tile (1-in-bag) positions only, like peg_solve.
+ *
+ * Background and further reading:
+ *
+ * PUCT selection rule. The variant here uses the AlphaZero formula
+ *     bonus = c * prior * sqrt(N_parent) / (1 + N_child)
+ * with `N` measured in cumulative wall-time spent, so cheap candidates
+ * accumulate visits faster and exploration narrows once a leader emerges:
+ *   AlphaZero (Silver et al. 2017, arXiv:1712.01815)
+ *     https://arxiv.org/abs/1712.01815
+ *   Original predictor-UCT formulation:
+ *     Rosin 2011, "Multi-armed bandits with episode context"
+ *     https://link.springer.com/article/10.1007/s10472-011-9258-6
+ *
+ * Progressive widening with `active = ceil(c * sqrt(visits))` keeps the
+ * effective candidate pool small at low budget and grows it as the
+ * search refines. New candidates inherit Q from their static-score
+ * neighbor at admission so PUCT inputs are sensible without a cold
+ * playout:
+ *   Chaslot et al. 2008, "Progressive Strategies for Monte-Carlo
+ *   Tree Search"
+ *     https://dke.maastrichtuniversity.nl/m.winands/documents/pMCTS.pdf
+ *
+ * Best-Arm Identification framing (anytime stopping, confidence-based
+ * early exit). The selection policy here is PUCT rather than a BAI
+ * sampling rule, but the stopping framework is BAI-flavored. See
+ * bai.h in this repo for Top-Two and (planned) Track-and-Stop
+ * implementations over a fixed arm set.
+ */
+
 #include "../def/game_defs.h"
 #include "../ent/game.h"
 #include "../ent/move.h"
 #include "../ent/thread_control.h"
 #include "../ent/transposition_table.h"
 #include "../util/io_util.h"
-
-// BAI-style adaptive pre-endgame solver.
-//
-// Differs from peg_solve: instead of discrete pass-by-pass top-K cuts at
-// fixed depths, allocates compute adaptively across (candidate, depth) pairs
-// using a PUCT-like rule. Anytime: at any moment the best-so-far candidate
-// is meaningful, and the caller can stop on time, evaluation budget, or a
-// confidence-based early-exit when the leader is statistically dominant.
-//
-// One-bag-tile (1-in-bag) positions only, like peg_solve.
 
 // Maximum endgame plies the solver will explore per candidate. Hard-capped
 // at MAX_SEARCH_DEPTH (25) by endgame_solve.

--- a/src/impl/bai_peg.h
+++ b/src/impl/bai_peg.h
@@ -160,8 +160,12 @@ typedef struct BaiPegArgs {
   //     candidates (by move-score order) are considered for selection;
   //     this grows over time so weak moves never get touched at short
   //     budgets.
-  //   - First visit to a candidate runs a depth-0 greedy playout (cheap
-  //     scenario-aware Q estimate). Subsequent visits do depth=1, 2, ...
+  //   - At admission, a newly-active candidate inherits Q from its
+  //     rank-up neighbor (a calibration-free seed); no playout is run.
+  //     If initial_playout is also set, every candidate additionally gets
+  //     a Phase 0 depth-0 greedy playout up front.
+  //   - First negamax visit to a candidate is at depth=1; subsequent
+  //     visits do depth=2, 3, ...
   //   - post_cand_game is created lazily on first visit, not pre-staged.
   // Solves the failure mode where k=256 + Phase 0 playout actively misleads
   // PUCT at short budgets (e.g. 3s).

--- a/src/impl/bai_peg.h
+++ b/src/impl/bai_peg.h
@@ -1,0 +1,207 @@
+#ifndef BAI_PEG_H
+#define BAI_PEG_H
+
+#include "../def/game_defs.h"
+#include "../ent/game.h"
+#include "../ent/move.h"
+#include "../ent/thread_control.h"
+#include "../ent/transposition_table.h"
+#include "../util/io_util.h"
+
+// BAI-style adaptive pre-endgame solver.
+//
+// Differs from peg_solve: instead of discrete pass-by-pass top-K cuts at
+// fixed depths, allocates compute adaptively across (candidate, depth) pairs
+// using a PUCT-like rule. Anytime: at any moment the best-so-far candidate
+// is meaningful, and the caller can stop on time, evaluation budget, or a
+// confidence-based early-exit when the leader is statistically dominant.
+//
+// One-bag-tile (1-in-bag) positions only, like peg_solve.
+
+// Maximum endgame plies the solver will explore per candidate. Hard-capped
+// at MAX_SEARCH_DEPTH (25) by endgame_solve.
+enum { BAI_PEG_MAX_DEPTH = 25 };
+
+// Caller-supplied callback fired whenever a candidate's depth advances (or
+// the solver wants to checkpoint progress). Receives the current ranking
+// (by mean spread, descending) so the caller can render an intermediate
+// answer or decide to terminate.
+typedef void (*BaiPegProgressCallback)(
+    int evaluations_done, double seconds_elapsed, const SmallMove *ranked_moves,
+    const double *ranked_win_pcts, const double *ranked_mean_spreads,
+    const int *ranked_depths_evaluated, int num_ranked, const Game *game,
+    void *user_data);
+
+typedef struct BaiPegArgs {
+  // Game must have exactly 1 tile in the bag.
+  const Game *game;
+  ThreadControl *thread_control;
+  int num_threads;
+
+  // Memory fraction for the shared transposition table used by inner
+  // endgame solves. 0 = no TT (each scenario solves cold).
+  double tt_fraction_of_mem;
+  // If non-NULL, all endgame solves share this TT instead of creating a
+  // private one. Caller owns the lifetime.
+  TranspositionTable *shared_tt;
+
+  // Optional: per-thread TT pointers. When non-NULL, each worker thread
+  // gets its own dedicated TT (eliminating cross-core cache contention on
+  // the shared one). Length must equal num_threads. Caller owns lifetime.
+  TranspositionTable **shared_tt_per_thread;
+
+  dual_lexicon_mode_t dual_lexicon_mode;
+
+  // After greedy generation, keep at most this many candidates by static
+  // score for the adaptive phase. 0 = use a sensible default.
+  int initial_top_k;
+
+  // Maximum depth (plies) any candidate is searched to. Capped to
+  // BAI_PEG_MAX_DEPTH internally. 0 = use BAI_PEG_MAX_DEPTH.
+  int max_depth;
+
+  // Per-scenario endgame solve time budget (seconds). Each (cand, depth)
+  // evaluation runs the endgame at depth `depth` with this time cap on each
+  // of the bag-tile scenarios. 0 = unbounded (depth alone gates).
+  double endgame_time_per_solve;
+
+  // Total wall-clock budget for the whole bai_peg_solve call (seconds).
+  // 0 = no limit; rely on max_evaluations / confidence stop.
+  double time_budget_seconds;
+
+  // Hard cap on the number of (candidate, depth) evaluations performed
+  // across the whole solve. 0 = no cap.
+  int max_evaluations;
+
+  // Confidence-based early stop. If the leader's mean spread exceeds the
+  // best challenger's mean spread by `early_stop_gap` AND both have been
+  // evaluated to at least `early_stop_min_depth` plies, terminate. 0/0
+  // disables the early-stop heuristic and only time / max_evaluations stop.
+  double early_stop_gap;
+  int early_stop_min_depth;
+
+  // PUCT exploration constant. Higher = more exploration of candidates
+  // with weaker priors but unexplored depth. ~1.0 is a sane default.
+  double puct_c;
+
+  // Utility weighting: optimize U = win_pct + utility_alpha * mean_spread.
+  // 0 = pure win% (default); 0.01 = "1 cent per point, $1 per game" (spread
+  // of 100 = 1 win); higher values emphasize spread further. Affects PUCT
+  // selection, candidate ranking, and the final pick.
+  double utility_alpha;
+
+  // If true, populate result->cand_stats with per-candidate snapshots
+  // (playout_q, neighbor_q, final_q, depth, etc.) for offline analysis.
+  // Caller must bai_cand_stats_free(result->cand_stats) when done.
+  bool request_cand_stats;
+
+  // Blend weights for the initial Q assigned at widening admission, when
+  // BOTH playout and neighbor signals are available. Weights should sum to
+  // ~1; the empirical regression at d=1-2 found w_neighbor≈0.6, w_playout
+  // ≈0.4. Set both to 0 to disable (use whatever signal is available alone).
+  double blend_w_playout;
+  double blend_w_neighbor;
+
+  // If true, evaluate every retained candidate at depth=0 (static greedy
+  // playout to end-of-game) before entering the PUCT loop. Gives a
+  // scenario-aware Q prior so weak candidates get pruned/de-prioritized
+  // earlier than they would from the move-score prior alone. Cheap (~ms
+  // per candidate) compared to a real depth-1 endgame. Ignored when
+  // progressive_widening is true (which uses lazy first-visit playouts).
+  bool initial_playout;
+
+  // If true and initial_playout is also true, use a streamlined greedy
+  // playout (movegen + play, no endgame_solve plumbing, no TT, no alpha-
+  // beta) to compute the d=0 prior. ~10-100x faster than going through
+  // endgame_solve_inline at plies=0. Only meaningful with initial_playout.
+  bool pure_playout;
+
+  // If true, use progressive widening with lazy playout instead of the
+  // top-K-fixed pre-staged design. Behavior:
+  //   - initial_top_k is ignored; ALL generated moves stay in the pool.
+  //   - No upfront Phase 0 / Phase 1 sweeps. PUCT handles everything.
+  //   - At any point, only the top ceil(widening_c * sqrt(total_visits))
+  //     candidates (by move-score order) are considered for selection;
+  //     this grows over time so weak moves never get touched at short
+  //     budgets.
+  //   - First visit to a candidate runs a depth-0 greedy playout (cheap
+  //     scenario-aware Q estimate). Subsequent visits do depth=1, 2, ...
+  //   - post_cand_game is created lazily on first visit, not pre-staged.
+  // Solves the failure mode where k=256 + Phase 0 playout actively misleads
+  // PUCT at short budgets (e.g. 3s).
+  bool progressive_widening;
+  // Widening constant: active = ceil(widening_c * sqrt(total_visits)).
+  // 0 = use a sane default (2.0). Higher = wider; lower = narrower.
+  double widening_c;
+  // Minimum active set size when progressive_widening is on. Defaults to 0
+  // (widening starts at 2 and grows). When > 0 the top min_active cands
+  // are unconditionally active from the start AND get a Phase 1 d=1
+  // warmup; widening grows the active set beyond min_active as visits
+  // accumulate. Combines a reliable narrow-baseline (k=32 d=1 warmup)
+  // with the option to widen if budget permits.
+  int min_active;
+
+  // Optional progress callback invoked after every depth advancement.
+  // num_top is how many ranked candidates to surface to the callback.
+  BaiPegProgressCallback progress_callback;
+  void *progress_callback_data;
+  int progress_num_top;
+} BaiPegArgs;
+
+// Per-candidate snapshot for downstream regression / diagnostics. Captures
+// the two prior signals (playout, neighbor) at the moment they were set,
+// alongside the final Q reached by negamax. Comparing playout vs neighbor
+// vs final tells us which signal is more predictive at each candidate's
+// final search depth.
+typedef struct BaiCandStats {
+  SmallMove move;
+  int static_score;
+  int rank; // 0 = best static score
+  // Playout signal (Phase 0). Only populated when initial_playout was on.
+  bool playout_q_set;
+  double playout_q_win_pct;
+  double playout_q_mean_spread;
+  // Neighbor signal (progressive widening). Snapshot of cand[rank-1]'s q
+  // at the moment cand[rank] was admitted to the active set. Only populated
+  // when progressive_widening was on and rank > 0.
+  bool neighbor_q_set;
+  double neighbor_q_win_pct;
+  double neighbor_q_mean_spread;
+  // Final Q after all evaluations.
+  double final_q_win_pct;
+  double final_q_mean_spread;
+  int depth_evaluated;
+  int visits;
+  bool is_best; // True for the picked move.
+} BaiCandStats;
+
+typedef struct BaiPegResult {
+  SmallMove best_move;
+  double best_win_pct;      // [0, 1] over the bag-tile distribution
+  double best_mean_spread;  // Average spread (mover's perspective)
+  int best_depth_evaluated; // Deepest plies the best move was searched to
+
+  // Diagnostics.
+  int candidates_considered; // Top-K size after greedy
+  int evaluations_done;      // Total (cand, depth) evaluations completed
+  // Per-depth visit count: visits_at_depth[d] = number of distinct candidates
+  // that finished an evaluation at depth d. Sum across all depths equals
+  // evaluations_done. Index 0 is unused (depths start at 1).
+  int visits_at_depth[BAI_PEG_MAX_DEPTH + 1];
+  double seconds_elapsed;
+  bool stopped_by_confidence;
+  bool stopped_by_time;
+  bool stopped_by_max_evals;
+  // If non-NULL on input, allocated by bai_peg_solve and filled with one
+  // BaiCandStats per cand (length = candidates_considered). Caller must
+  // free via bai_cand_stats_free. NULL = no stats requested.
+  BaiCandStats *cand_stats;
+} BaiPegResult;
+
+// Free the per-candidate stats array allocated by bai_peg_solve. Safe on NULL.
+void bai_cand_stats_free(BaiCandStats *cand_stats);
+
+void bai_peg_solve(const BaiPegArgs *args, BaiPegResult *result,
+                   ErrorStack *error_stack);
+
+#endif

--- a/src/impl/bai_peg.h
+++ b/src/impl/bai_peg.h
@@ -2,16 +2,14 @@
 #define BAI_PEG_H
 
 /*
- * BAI-style adaptive pre-endgame solver.
- *
- * Differs from peg_solve: instead of discrete pass-by-pass top-K cuts at
- * fixed depths, allocates compute adaptively across (candidate, depth)
- * pairs using a PUCT-like rule. Anytime: at any moment the best-so-far
- * candidate is meaningful, and the caller can stop on time, evaluation
- * budget, or a confidence-based early exit when the leader is
- * statistically dominant.
- *
- * One-bag-tile (1-in-bag) positions only, like peg_solve.
+ * BAI-style adaptive pre-endgame solver. Picks the best move on a
+ * 1-in-bag position by allocating endgame compute adaptively across
+ * (candidate, depth) pairs using a PUCT-like selection rule, evaluating
+ * each candidate against every possible bag tile to integrate over the
+ * unseen-tile distribution. Anytime: the best-so-far candidate is
+ * meaningful at every moment, and the caller can stop on wall-clock
+ * time, evaluation budget, or a confidence-based early exit when the
+ * leader is statistically dominant.
  *
  * Background and further reading:
  *
@@ -35,10 +33,9 @@
  *     https://dke.maastrichtuniversity.nl/m.winands/documents/pMCTS.pdf
  *
  * Best-Arm Identification framing (anytime stopping, confidence-based
- * early exit). The selection policy here is PUCT rather than a BAI
- * sampling rule, but the stopping framework is BAI-flavored. See
- * bai.h in this repo for Top-Two and (planned) Track-and-Stop
- * implementations over a fixed arm set.
+ * early exit). Selection here is PUCT rather than a BAI sampling rule,
+ * but the stopping framework is BAI-flavored. See bai.h for the BAI
+ * sampling rules implemented in this repo over a fixed arm set.
  */
 
 #include "../def/game_defs.h"

--- a/src/impl/bai_peg.h
+++ b/src/impl/bai_peg.h
@@ -79,6 +79,15 @@ typedef struct BaiPegArgs {
 
   dual_lexicon_mode_t dual_lexicon_mode;
 
+  // Base offset added to every internal thread index (for initial movegen,
+  // playout/eval workers, and EndgameArgs.thread_index_offset on each
+  // scenario solve). Move generation uses a global per-thread cache keyed
+  // by thread_index, so concurrent bai_peg_solve calls in the same process
+  // must use disjoint [thread_index_offset, thread_index_offset+num_threads)
+  // ranges to avoid corrupting each other's cache entries. 0 is fine for a
+  // single-threaded caller.
+  int thread_index_offset;
+
   // After greedy generation, keep at most this many candidates by static
   // score for the adaptive phase. 0 = use a sensible default.
   int initial_top_k;

--- a/src/impl/bai_peg.h
+++ b/src/impl/bai_peg.h
@@ -50,9 +50,10 @@
 enum { BAI_PEG_MAX_DEPTH = 25 };
 
 // Caller-supplied callback fired whenever a candidate's depth advances (or
-// the solver wants to checkpoint progress). Receives the current ranking
-// (by mean spread, descending) so the caller can render an intermediate
-// answer or decide to terminate.
+// the solver wants to checkpoint progress). Ranked moves are ordered by
+// utility (win_pct + utility_alpha * mean_spread, with visited candidates
+// always above unvisited and a mean-spread tiebreak), descending; same
+// order the solver itself uses to pick the best move.
 typedef void (*BaiPegProgressCallback)(
     int evaluations_done, double seconds_elapsed, const SmallMove *ranked_moves,
     const double *ranked_win_pcts, const double *ranked_mean_spreads,

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -123,8 +123,10 @@ struct EndgameCtx {
   int num_top_moves;
   int requested_plies;
   int threads;
+  int thread_index_offset;
   double tt_fraction_of_mem;
   TranspositionTable *transposition_table;
+  bool tt_is_external; // true when using a caller-provided shared TT
 
   // Signal for threads to stop early (0=running, 1=done)
   atomic_int search_complete;
@@ -132,6 +134,10 @@ struct EndgameCtx {
   // Thread 0 sets this after each completed depth (from EBF estimate).
   // All worker threads check it periodically and bail if exceeded.
   _Atomic int64_t depth_deadline_ns;
+  // Caller-supplied absolute deadline (CLOCK_MONOTONIC ns). 0 = disabled.
+  // check_depth_deadline takes min(this, depth_deadline_ns) so a caller's
+  // wall-clock budget always wins over the EBF-projected per-depth budget.
+  int64_t external_deadline_ns;
   // Flag: stuck-tile mode has been logged (0=not yet, 1=logged)
   atomic_int stuck_tile_logged;
   // Fraction of opponent's tiles that are stuck at the root (0.0 = none)
@@ -420,8 +426,13 @@ static bool iterative_deepening_should_stop(EndgameCtx *solver);
 // Returns the pruned KWG for the given player index.
 // In shared-KWG mode, only pruned_kwgs[0] exists, so it is always returned.
 // In non-shared mode, each player index maps to its own pruned KWG.
+// When skip_word_pruning was used (pruned_kwgs are NULL), falls back to the
+// game's effective KWG (which respects any override KWGs set by the caller).
 static inline const KWG *solver_get_pruned_kwg(const EndgameCtx *solver,
                                                int player_index) {
+  if (solver->pruned_kwgs[0] == NULL) {
+    return game_get_effective_kwg(solver->game, player_index);
+  }
   if (solver->pruned_kwgs[1] == NULL) {
     return solver->pruned_kwgs[0];
   }
@@ -532,8 +543,8 @@ static float compute_initial_stuck_fraction(const EndgameCtx *solver,
   Game *root_game = game_duplicate(game);
   MoveList *tmp_ml = move_list_create_small(DEFAULT_ENDGAME_MOVELIST_CAPACITY);
   float frac = compute_opp_stuck_fraction(
-      root_game, tmp_ml, solver_get_pruned_kwg(solver, opp_idx), opp_idx, 0,
-      NULL, NULL);
+      root_game, tmp_ml, solver_get_pruned_kwg(solver, opp_idx), opp_idx,
+      solver->thread_index_offset, NULL, NULL);
   small_move_list_destroy(tmp_ml);
   game_destroy(root_game);
   return frac;
@@ -541,7 +552,7 @@ static float compute_initial_stuck_fraction(const EndgameCtx *solver,
 
 void endgame_ctx_reset(EndgameCtx *es, EndgameResults *results,
                        const EndgameArgs *endgame_args) {
-  es->first_win_optim = false;
+  es->first_win_optim = endgame_args->first_win;
   es->transposition_table_optim = true;
   es->iterative_deepening_optim = true;
   es->negascout_optim = true;
@@ -552,6 +563,7 @@ void endgame_ctx_reset(EndgameCtx *es, EndgameResults *results,
   if (es->threads < 1) {
     es->threads = 1;
   }
+  es->thread_index_offset = endgame_args->thread_index_offset;
   es->requested_plies = endgame_args->plies;
   es->solving_player = game_get_player_on_turn_index(endgame_args->game);
   es->initial_small_move_arena_size =
@@ -580,23 +592,29 @@ void endgame_ctx_reset(EndgameCtx *es, EndgameResults *results,
   }
   es->soft_time_limit = endgame_args->soft_time_limit;
   es->hard_time_limit = endgame_args->hard_time_limit;
+  es->external_deadline_ns = endgame_args->external_deadline_ns;
   bool create_separate_kwgs =
       (es->dual_lexicon_mode == DUAL_LEXICON_MODE_INFORMED) && !shared_kwg;
 
-  // Generate pruned KWG(s) from the set of possible words on this board.
-  // In IGNORANT mode (or shared-KWG), one pruned KWG is used for everything.
-  // In INFORMED mode with different lexicons, each player index gets its own
-  // pruned KWG so that cross-set index i uses the pruned KWG derived from
-  // player i's lexicon.
-  for (int player_idx = 0; player_idx < (create_separate_kwgs ? 2 : 1);
-       player_idx++) {
-    const KWG *full_kwg =
-        player_get_kwg(game_get_player(endgame_args->game, player_idx));
-    DictionaryWordList *word_list = dictionary_word_list_create();
-    generate_possible_words(endgame_args->game, full_kwg, word_list);
-    es->pruned_kwgs[player_idx] = make_kwg_from_words_small(
-        word_list, KWG_MAKER_OUTPUT_GADDAG, KWG_MAKER_MERGE_EXACT);
-    dictionary_word_list_destroy(word_list);
+  // skip_word_pruning: leave pruned_kwgs NULL so move gen uses the full KWG
+  // (or any override KWGs the caller set on the game). Used by PEG which
+  // builds its own pruned KWGs once at the root position.
+  if (!endgame_args->skip_word_pruning) {
+    // Generate pruned KWG(s) from the set of possible words on this board.
+    // In IGNORANT mode (or shared-KWG), one pruned KWG is used for everything.
+    // In INFORMED mode with different lexicons, each player index gets its own
+    // pruned KWG so that cross-set index i uses the pruned KWG derived from
+    // player i's lexicon.
+    for (int player_idx = 0; player_idx < (create_separate_kwgs ? 2 : 1);
+         player_idx++) {
+      const KWG *full_kwg =
+          player_get_kwg(game_get_player(endgame_args->game, player_idx));
+      DictionaryWordList *word_list = dictionary_word_list_create();
+      generate_possible_words(endgame_args->game, full_kwg, word_list);
+      es->pruned_kwgs[player_idx] = make_kwg_from_words_small(
+          word_list, KWG_MAKER_OUTPUT_GADDAG, KWG_MAKER_MERGE_EXACT);
+      dictionary_word_list_destroy(word_list);
+    }
   }
 
   // Initialize ABDADA synchronization
@@ -613,24 +631,50 @@ void endgame_ctx_reset(EndgameCtx *es, EndgameResults *results,
   es->game = endgame_args->game;
   es->per_ply_callback = endgame_args->per_ply_callback;
   es->per_ply_callback_data = endgame_args->per_ply_callback_data;
-  if (endgame_args->tt_fraction_of_mem == 0) {
-    transposition_table_destroy(es->transposition_table);
-    es->transposition_table = NULL;
-  } else if (es->tt_fraction_of_mem != endgame_args->tt_fraction_of_mem) {
-    transposition_table_destroy(es->transposition_table);
-    es->transposition_table =
-        transposition_table_create(endgame_args->tt_fraction_of_mem);
+  if (endgame_args->shared_tt) {
+    // Use caller-provided TT. Free any previously owned TT.
+    if (!es->tt_is_external) {
+      transposition_table_destroy(es->transposition_table);
+    }
+    es->transposition_table = endgame_args->shared_tt;
+    es->tt_fraction_of_mem = 0;
+    es->tt_is_external = true;
+  } else {
+    if (!es->tt_is_external) {
+      if (endgame_args->tt_fraction_of_mem == 0) {
+        transposition_table_destroy(es->transposition_table);
+        es->transposition_table = NULL;
+      } else if (es->tt_fraction_of_mem != endgame_args->tt_fraction_of_mem) {
+        transposition_table_destroy(es->transposition_table);
+        es->transposition_table =
+            transposition_table_create(endgame_args->tt_fraction_of_mem);
+      }
+    } else {
+      // Transitioning from external to owned. Don't destroy the external TT.
+      es->transposition_table = NULL;
+      if (endgame_args->tt_fraction_of_mem > 0) {
+        es->transposition_table =
+            transposition_table_create(endgame_args->tt_fraction_of_mem);
+      }
+    }
+    es->tt_fraction_of_mem = endgame_args->tt_fraction_of_mem;
+    es->tt_is_external = false;
   }
-  es->tt_fraction_of_mem = endgame_args->tt_fraction_of_mem;
+  // Disable TT optimization when no TT is available.
+  if (es->transposition_table == NULL) {
+    es->transposition_table_optim = false;
+  }
   es->results = results;
-  endgame_results_lock(es->results, ENDGAME_RESULT_DISPLAY);
-  endgame_results_reset(es->results);
-  endgame_results_set_start_game(es->results, endgame_args->game);
-  endgame_results_set_pvline_extend_args(es->results, es->transposition_table,
-                                         es->solving_player,
-                                         es->requested_plies);
-  endgame_results_set_valid_for_current_game_state(es->results, true);
-  endgame_results_unlock(es->results, ENDGAME_RESULT_DISPLAY);
+  if (es->results) {
+    endgame_results_lock(es->results, ENDGAME_RESULT_DISPLAY);
+    endgame_results_reset(es->results);
+    endgame_results_set_start_game(es->results, endgame_args->game);
+    endgame_results_set_pvline_extend_args(es->results, es->transposition_table,
+                                           es->solving_player,
+                                           es->requested_plies);
+    endgame_results_set_valid_for_current_game_state(es->results, true);
+    endgame_results_unlock(es->results, ENDGAME_RESULT_DISPLAY);
+  }
   // Compute initial stuck-tile fraction for root move ordering.
   // Per-node detection in abdada_negamax recomputes this dynamically.
   es->initial_opp_stuck_frac = 0.0F;
@@ -680,7 +724,9 @@ void endgame_ctx_destroy(EndgameCtx *ctx) {
   }
   free(ctx->workers);
   free(ctx->worker_ids);
-  transposition_table_destroy(ctx->transposition_table);
+  if (!ctx->tt_is_external) {
+    transposition_table_destroy(ctx->transposition_table);
+  }
   kwg_destroy(ctx->pruned_kwgs[0]);
   kwg_destroy(ctx->pruned_kwgs[1]);
   game_destroy(ctx->ext_game);
@@ -743,10 +789,14 @@ void endgame_ctx_reset_worker_and_game(EndgameCtx *solver, uint64_t base_seed,
                                        int worker_index) {
   endgame_ctx_reset_worker(solver->workers[worker_index], solver, solver->game,
                            base_seed);
-  game_set_override_kwgs(solver->workers[worker_index]->game_copy,
-                         solver->pruned_kwgs[0], solver->pruned_kwgs[1],
-                         solver->dual_lexicon_mode);
-  game_gen_all_cross_sets(solver->workers[worker_index]->game_copy);
+  // When skip_word_pruning was used, pruned_kwgs are NULL; the game's existing
+  // KWGs and cross-sets (set by the caller, e.g. PEG) are preserved.
+  if (solver->pruned_kwgs[0] != NULL) {
+    game_set_override_kwgs(solver->workers[worker_index]->game_copy,
+                           solver->pruned_kwgs[0], solver->pruned_kwgs[1],
+                           solver->dual_lexicon_mode);
+    game_gen_all_cross_sets(solver->workers[worker_index]->game_copy);
+  }
 }
 
 // Prepare the worker pool for a new solve. Computes pruned-KWG cross-sets
@@ -776,8 +826,8 @@ static void endgame_ctx_prepare_workers(EndgameCtx *solver,
     solver->worker_ids = realloc_or_die(solver->worker_ids,
                                         sizeof(cpthread_t) * solver->threads);
     for (int idx = solver->cap_workers; idx < solver->threads; idx++) {
-      solver->workers[idx] =
-          endgame_ctx_create_worker(solver, idx, base_seed, solver->game);
+      solver->workers[idx] = endgame_ctx_create_worker(
+          solver, solver->thread_index_offset + idx, base_seed, solver->game);
     }
     solver->cap_workers = solver->threads;
   }
@@ -1668,6 +1718,12 @@ __attribute__((noinline)) static bool
 check_depth_deadline(EndgameCtxWorker *worker) {
   int64_t deadline_ns = atomic_load_explicit(&worker->solver->depth_deadline_ns,
                                              memory_order_relaxed);
+  // External deadline (e.g. PEG's wall-clock cap) takes precedence if it
+  // exists and is earlier than the EBF-projected per-depth deadline.
+  int64_t external = worker->solver->external_deadline_ns;
+  if (external != 0 && (deadline_ns == 0 || external < deadline_ns)) {
+    deadline_ns = external;
+  }
   if (deadline_ns == 0) {
     return false;
   }
@@ -2569,11 +2625,38 @@ static int extract_multi_pvs(EndgameCtx *solver, EndgameCtxWorker *best_worker,
   return k;
 }
 
+// Single-threaded endgame solve that runs in the calling thread (no
+// cpthread_create). Safe for use from concurrent PEG decomp threads.
+void endgame_solve_inline(EndgameCtx **ctx, const EndgameArgs *endgame_args,
+                          EndgameResults *results) {
+  if (*ctx == NULL) {
+    *ctx = endgame_ctx_create();
+  }
+  EndgameCtx *solver = *ctx;
+
+  endgame_ctx_reset(solver, results, endgame_args);
+
+  uint64_t base_seed = (uint64_t)ctime_get_current_time();
+  endgame_ctx_prepare_workers(solver, base_seed);
+
+  // Suppress stuck-tile log to avoid localtime thread safety issues.
+  atomic_store(&solver->stuck_tile_logged, 1);
+
+  // Run IDS directly in the calling thread.
+  iterative_deepening(solver->workers[0], solver->requested_plies);
+
+  if (results) {
+    const PVLine *best_pv =
+        endgame_results_get_pvline(results, ENDGAME_RESULT_BEST);
+    solver->principal_variation = *best_pv;
+  }
+}
+
 void endgame_solve(EndgameCtx **ctx, const EndgameArgs *endgame_args,
                    EndgameResults *results, ErrorStack *error_stack) {
   assert(ctx);
   const int bag_size = bag_get_letters(game_get_bag(endgame_args->game));
-  if (bag_size != 0) {
+  if (bag_size != 0 && !endgame_args->allow_nonempty_bag) {
     error_stack_push(error_stack, ERROR_STATUS_ENDGAME_BAG_NOT_EMPTY,
                      get_formatted_string(
                          "bag must be empty to solve an endgame, but have %d "

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -2629,6 +2629,8 @@ static int extract_multi_pvs(EndgameCtx *solver, EndgameCtxWorker *best_worker,
 // cpthread_create). Safe for use from concurrent PEG decomp threads.
 void endgame_solve_inline(EndgameCtx **ctx, const EndgameArgs *endgame_args,
                           EndgameResults *results) {
+  assert(ctx);
+  assert(results);
   if (*ctx == NULL) {
     *ctx = endgame_ctx_create();
   }
@@ -2647,11 +2649,9 @@ void endgame_solve_inline(EndgameCtx **ctx, const EndgameArgs *endgame_args,
   // Run IDS directly in the calling thread.
   iterative_deepening(solver->workers[0], solver->requested_plies);
 
-  if (results) {
-    const PVLine *best_pv =
-        endgame_results_get_pvline(results, ENDGAME_RESULT_BEST);
-    solver->principal_variation = *best_pv;
-  }
+  const PVLine *best_pv =
+      endgame_results_get_pvline(results, ENDGAME_RESULT_BEST);
+  solver->principal_variation = *best_pv;
 }
 
 void endgame_solve(EndgameCtx **ctx, const EndgameArgs *endgame_args,

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -2636,7 +2636,9 @@ void endgame_solve_inline(EndgameCtx **ctx, const EndgameArgs *endgame_args,
 
   endgame_ctx_reset(solver, results, endgame_args);
 
-  uint64_t base_seed = (uint64_t)ctime_get_current_time();
+  uint64_t base_seed = endgame_args->seed != 0
+                           ? endgame_args->seed
+                           : (uint64_t)ctime_get_current_time();
   endgame_ctx_prepare_workers(solver, base_seed);
 
   // Suppress stuck-tile log to avoid localtime thread safety issues.

--- a/src/impl/endgame.h
+++ b/src/impl/endgame.h
@@ -103,6 +103,8 @@ void endgame_solve(EndgameCtx **ctx, const EndgameArgs *endgame_args,
 // Single-threaded endgame solve that runs in the calling thread (no
 // cpthread_create). Safe for use from concurrent PEG decomp threads
 // when each thread uses a distinct thread_index_offset in EndgameArgs.
+// `results` is required (must be non-NULL); the iterative-deepening loop
+// writes into it on every depth.
 void endgame_solve_inline(EndgameCtx **ctx, const EndgameArgs *endgame_args,
                           EndgameResults *results);
 const TranspositionTable *

--- a/src/impl/endgame.h
+++ b/src/impl/endgame.h
@@ -58,6 +58,30 @@ typedef struct EndgameArgs {
   double soft_time_limit;
   double hard_time_limit;
   uint64_t seed;
+  // If true, skip word pruning (KWG build) during reset. Move generation will
+  // use the full KWG (or any override KWGs set by the caller on the game).
+  // Useful when the caller builds pruned KWGs once and reuses them across many
+  // endgame solves.
+  bool skip_word_pruning;
+  // If true, allow the bag to be non-empty when endgame_solve is called.
+  bool allow_nonempty_bag;
+  // If non-NULL, the solver uses this TT instead of creating/destroying its
+  // own. The caller is responsible for the lifetime of the shared TT.
+  // tt_fraction_of_mem is ignored when shared_tt is set.
+  TranspositionTable *shared_tt;
+  // Offset added to worker thread indices. When multiple endgame_solve calls
+  // run concurrently, each must use a distinct range to avoid collisions on
+  // the global per-thread MoveGen cache.
+  int thread_index_offset;
+  // First-win optimization: search a narrow [-1, +1] window so the solver
+  // returns only win/loss/draw rather than exact spread. Faster (more
+  // alpha-beta cutoffs) but exact spread is unknown when set.
+  bool first_win;
+  // Absolute monotonic-ns deadline (ctimer_monotonic_ns()-compatible). If
+  // non-zero, workers bail out mid-search once now > deadline. Lets a
+  // caller (e.g. PEG) impose a wall-clock budget that propagates through
+  // alpha-beta, not just between IDS depth iterations. 0 = no deadline.
+  int64_t external_deadline_ns;
 } EndgameArgs;
 
 // Selects the movegen cache slot to avoid races between concurrent callers.
@@ -76,6 +100,11 @@ void pvline_extend_from_tt(PVLine *pv_line, Game *game_copy,
 void endgame_ctx_destroy(EndgameCtx *ctx);
 void endgame_solve(EndgameCtx **ctx, const EndgameArgs *endgame_args,
                    EndgameResults *results, ErrorStack *error_stack);
+// Single-threaded endgame solve that runs in the calling thread (no
+// cpthread_create). Safe for use from concurrent PEG decomp threads
+// when each thread uses a distinct thread_index_offset in EndgameArgs.
+void endgame_solve_inline(EndgameCtx **ctx, const EndgameArgs *endgame_args,
+                          EndgameResults *results);
 const TranspositionTable *
 endgame_ctx_get_transposition_table(const EndgameCtx *ctx);
 void endgame_ctx_get_progress(const EndgameCtx *ctx, int *current_depth,

--- a/src/impl/gameplay.c
+++ b/src/impl/gameplay.c
@@ -67,7 +67,7 @@ void get_leave_for_move(const Move *move, const Game *game, Rack *leave) {
   }
 }
 
-void play_move_on_board(const Move *move, const Game *game) {
+static void play_move_on_board(const Move *move, const Game *game) {
   // PlaceMoveTiles
   Board *board = game_get_board(game);
   int row_start = move_get_row_start(move);

--- a/src/impl/gameplay.h
+++ b/src/impl/gameplay.h
@@ -16,6 +16,7 @@ Equity calculate_end_rack_points(const Rack *rack,
                                  const LetterDistribution *ld);
 Equity calculate_end_rack_penalty(const Rack *rack,
                                   const LetterDistribution *ld);
+void play_move_on_board(const Move *move, const Game *game);
 void play_move(const Move *move, Game *game, Rack *leave);
 void play_move_without_drawing_tiles(const Move *move, Game *game);
 void set_random_rack(Game *game, int player_index, const Rack *known_rack);

--- a/src/impl/gameplay.h
+++ b/src/impl/gameplay.h
@@ -16,7 +16,6 @@ Equity calculate_end_rack_points(const Rack *rack,
                                  const LetterDistribution *ld);
 Equity calculate_end_rack_penalty(const Rack *rack,
                                   const LetterDistribution *ld);
-void play_move_on_board(const Move *move, const Game *game);
 void play_move(const Move *move, Game *game, Rack *leave);
 void play_move_without_drawing_tiles(const Move *move, Game *game);
 void set_random_rack(Game *game, int player_index, const Rack *known_rack);

--- a/test/bai_peg_test.c
+++ b/test/bai_peg_test.c
@@ -1,0 +1,91 @@
+#include "bai_peg_test.h"
+
+#include "../src/ent/bag.h"
+#include "../src/ent/game.h"
+#include "../src/ent/move.h"
+#include "../src/impl/bai_peg.h"
+#include "../src/impl/config.h"
+#include "../src/util/io_util.h"
+#include "test_util.h"
+#include <assert.h>
+#include <stdio.h>
+
+// Smoke test: confirms bai_peg_solve runs end-to-end on a 1-in-bag position,
+// returns a non-pass move, and produces non-zero evaluation/candidate counts.
+// Picking quality at low budget is not asserted (the solver may not converge
+// on the truly best move at this budget); the goal here is to catch obvious
+// regressions in the search loop, threading, or progressive widening logic.
+static void test_bai_peg_smoke(void) {
+  Config *config = config_create_or_die("set -s1 score -s2 score");
+  load_and_exec_config_or_die(
+      config, "cgp 15/3Q7U3/3U2TAURINE2/1CHANSONS2W3/2AI6JO3/DIRL1PO3IN3/"
+              "E1D2EF3V4/F1I2p1TRAIK3/O1L2T4E4/ABy1PIT2BRIG2/ME1MOZELLE5/"
+              "1GRADE1O1NOH3/WE3R1V7/AT5E7/G6D7 ENOSTXY/ACEISUY 356/378 0 -lex "
+              "NWL20");
+
+  Game *game = config_get_game(config);
+  assert(bag_get_letters(game_get_bag(game)) == 1);
+
+  BaiPegArgs args = {
+      .game = game,
+      .thread_control = config_get_thread_control(config),
+      .num_threads = 1,
+      .tt_fraction_of_mem = 0.0,
+      .dual_lexicon_mode = DUAL_LEXICON_MODE_IGNORANT,
+      .initial_top_k = 32,
+      .max_depth = 2,
+      .endgame_time_per_solve = 0.5,
+      .time_budget_seconds = 30.0,
+      .puct_c = 1.0,
+  };
+  BaiPegResult result;
+  ErrorStack *error_stack = error_stack_create();
+  bai_peg_solve(&args, &result, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(!small_move_is_pass(&result.best_move));
+  assert(result.evaluations_done > 0);
+  assert(result.candidates_considered > 0);
+  printf("  bai_peg smoke: evals=%d  best_win%%=%.1f%%  best_spread=%+.2f  "
+         "depth=%d  time=%.2fs\n",
+         result.evaluations_done, result.best_win_pct * 100.0,
+         result.best_mean_spread, result.best_depth_evaluated,
+         result.seconds_elapsed);
+  error_stack_destroy(error_stack);
+  bai_cand_stats_free(result.cand_stats);
+  config_destroy(config);
+}
+
+// Confirms bai_peg_solve raises ERROR_STATUS_ENDGAME_BAG_NOT_EMPTY on a
+// position with more than 1 tile in the bag, rather than silently solving
+// a wrong subproblem.
+static void test_bai_peg_rejects_non_one_in_bag(void) {
+  Config *config = config_create_or_die("set -s1 score -s2 score");
+  load_and_exec_config_or_die(
+      config, "cgp 15/15/15/15/15/15/15/7CAT5/15/15/15/15/15/15/15 "
+              "ABCDEFG/HIJKLMN 0/0 0 -lex NWL20");
+  Game *game = config_get_game(config);
+  assert(bag_get_letters(game_get_bag(game)) > 1);
+
+  BaiPegArgs args = {
+      .game = game,
+      .thread_control = config_get_thread_control(config),
+      .num_threads = 1,
+      .tt_fraction_of_mem = 0.0,
+      .dual_lexicon_mode = DUAL_LEXICON_MODE_IGNORANT,
+      .max_depth = 1,
+      .endgame_time_per_solve = 0.1,
+      .time_budget_seconds = 1.0,
+      .puct_c = 1.0,
+  };
+  BaiPegResult result;
+  ErrorStack *error_stack = error_stack_create();
+  bai_peg_solve(&args, &result, error_stack);
+  assert(!error_stack_is_empty(error_stack));
+  error_stack_destroy(error_stack);
+  config_destroy(config);
+}
+
+void test_bai_peg(void) {
+  test_bai_peg_smoke();
+  test_bai_peg_rejects_non_one_in_bag();
+}

--- a/test/bai_peg_test.c
+++ b/test/bai_peg_test.c
@@ -16,7 +16,12 @@
 // Picking quality at low budget is not asserted (the solver may not converge
 // on the truly best move at this budget); the goal here is to catch obvious
 // regressions in the search loop, threading, or progressive widening logic.
-static void test_bai_peg_smoke(void) {
+//
+// Budget is intentionally tight (max_evaluations capped) so this test stays
+// fast and predictable on CI under ASAN/UBSAN. The deeper-search variant
+// lives in test_bai_peg_thorough on the on-demand table.
+static void run_bai_peg_smoke(int max_evaluations, double time_budget,
+                              double endgame_time_per_solve) {
   Config *config = config_create_or_die("set -s1 score -s2 score");
   load_and_exec_config_or_die(
       config, "cgp 15/3Q7U3/3U2TAURINE2/1CHANSONS2W3/2AI6JO3/DIRL1PO3IN3/"
@@ -35,8 +40,9 @@ static void test_bai_peg_smoke(void) {
       .dual_lexicon_mode = DUAL_LEXICON_MODE_IGNORANT,
       .initial_top_k = 32,
       .max_depth = 2,
-      .endgame_time_per_solve = 0.5,
-      .time_budget_seconds = 30.0,
+      .endgame_time_per_solve = endgame_time_per_solve,
+      .time_budget_seconds = time_budget,
+      .max_evaluations = max_evaluations,
       .puct_c = 1.0,
   };
   BaiPegResult result;
@@ -54,6 +60,20 @@ static void test_bai_peg_smoke(void) {
   error_stack_destroy(error_stack);
   bai_cand_stats_free(result.cand_stats);
   config_destroy(config);
+}
+
+static void test_bai_peg_smoke(void) {
+  // CI-friendly: max_evaluations cap guarantees the test exits quickly even
+  // under high CI load when wall-clock is unreliable.
+  run_bai_peg_smoke(/*max_evaluations=*/16, /*time_budget=*/1.0,
+                    /*endgame_time_per_solve=*/0.05);
+}
+
+void test_bai_peg_thorough(void) {
+  // Deeper search for on-demand runs: more evaluations, longer per-scenario
+  // endgame, longer wall-clock budget.
+  run_bai_peg_smoke(/*max_evaluations=*/0, /*time_budget=*/30.0,
+                    /*endgame_time_per_solve=*/0.5);
 }
 
 // Confirms bai_peg_solve raises ERROR_STATUS_ENDGAME_BAG_NOT_EMPTY on a

--- a/test/bai_peg_test.c
+++ b/test/bai_peg_test.c
@@ -1,5 +1,6 @@
 #include "bai_peg_test.h"
 
+#include "../src/def/game_defs.h"
 #include "../src/ent/bag.h"
 #include "../src/ent/game.h"
 #include "../src/ent/move.h"

--- a/test/bai_peg_test.c
+++ b/test/bai_peg_test.c
@@ -101,7 +101,7 @@ static void test_bai_peg_rejects_non_one_in_bag(void) {
   BaiPegResult result;
   ErrorStack *error_stack = error_stack_create();
   bai_peg_solve(&args, &result, error_stack);
-  assert(!error_stack_is_empty(error_stack));
+  assert(error_stack_top(error_stack) == ERROR_STATUS_ENDGAME_BAG_NOT_EMPTY);
   error_stack_destroy(error_stack);
   config_destroy(config);
 }

--- a/test/bai_peg_test.c
+++ b/test/bai_peg_test.c
@@ -6,6 +6,8 @@
 #include "../src/ent/bag.h"
 #include "../src/ent/game.h"
 #include "../src/ent/move.h"
+#include "../src/ent/player.h"
+#include "../src/ent/rack.h"
 #include "../src/impl/bai_peg.h"
 #include "../src/impl/cgp.h"
 #include "../src/impl/config.h"
@@ -599,10 +601,58 @@ static void test_bai_peg_rejects_non_one_in_bag(void) {
   config_destroy(config);
 }
 
+// Macondo's Test1PEGPass (FRA20). The CGP reports opp_rack=empty and
+// bag=8 — but those 8 unseen tiles will be 7 opp draw + 1 bag tile, so
+// from the mover's perspective this is the canonical 1-in-bag state.
+// bai_peg_solve should accept it (since it ignores the opp_rack
+// partition and works directly off the unseen pool).
+//
+// Row 3 of the macondo literal (`8A1E1DO`) is 14 wide; padded to 15
+// here with a trailing `1`. Mover rack: AEINRST. Pass is the winning
+// move in macondo (5W-1D-2L), but our solver doesn't yet evaluate
+// passes — for now we just assert that the CGP loads and the solver
+// completes without an error.
+#define BAI_PEG_TEST_FRENCH_PASS_CGP                                           \
+  "cgp 11ONZE/10J2O1/8A1E1DO1/7QUETEE1H/10E1F1U/8ECUMERA/8C1R1TIR/"            \
+  "7WOKS2ET/6DUR6/5G2N1M4/4HALLALiS3/1G1P1P1OM1XI3/VIVONS1BETEL3/"             \
+  "IF1N3AS1RYAL1/ETUDIAIS7 AEINRST/ 301/300 0 -lex FRA20 -ld french"
+
+static void test_bai_peg_accepts_empty_opp_rack(void) {
+  Config *config = config_create_or_die("set -s1 score -s2 score");
+  load_and_exec_config_or_die(config, BAI_PEG_TEST_FRENCH_PASS_CGP);
+  Game *game = config_get_game(config);
+  // Exact bag size depends on the CGP's tile partition; what matters is
+  // the canonical-1-in-bag invariant from the mover's perspective.
+  assert(rack_get_total_letters(player_get_rack(game_get_player(
+             game, game_get_player_on_turn_index(game)))) == RACK_SIZE);
+
+  BaiPegArgs args = {
+      .game = game,
+      .thread_control = config_get_thread_control(config),
+      .num_threads = 1,
+      .tt_fraction_of_mem = 0.0,
+      .dual_lexicon_mode = DUAL_LEXICON_MODE_IGNORANT,
+      .max_depth = 1,
+      .endgame_time_per_solve = 0.05,
+      .time_budget_seconds = 1.0,
+      .max_evaluations = 8,
+      .puct_c = 1.0,
+  };
+  BaiPegResult result;
+  ErrorStack *error_stack = error_stack_create();
+  bai_peg_solve(&args, &result, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(result.evaluations_done > 0);
+  error_stack_destroy(error_stack);
+  bai_cand_stats_free(result.cand_stats);
+  config_destroy(config);
+}
+
 void test_bai_peg(void) {
   test_bai_peg_smoke();
   test_bai_peg_progressive_widening();
   test_bai_peg_concurrent_invocations();
   test_bai_peg_returns_pass_when_no_scoring_plays();
   test_bai_peg_rejects_non_one_in_bag();
+  test_bai_peg_accepts_empty_opp_rack();
 }

--- a/test/bai_peg_test.c
+++ b/test/bai_peg_test.c
@@ -1,14 +1,20 @@
 #include "bai_peg_test.h"
 
+#include "../src/compat/cpthread.h"
+#include "../src/def/cpthread_defs.h"
 #include "../src/def/game_defs.h"
 #include "../src/ent/bag.h"
 #include "../src/ent/game.h"
 #include "../src/ent/move.h"
 #include "../src/impl/bai_peg.h"
+#include "../src/impl/cgp.h"
 #include "../src/impl/config.h"
+#include "../src/impl/gameplay.h"
 #include "../src/util/io_util.h"
 #include "test_util.h"
 #include <assert.h>
+#include <pthread.h>
+#include <stdatomic.h>
 #include <stdio.h>
 
 // Smoke test: confirms bai_peg_solve runs end-to-end on a 1-in-bag position,
@@ -76,6 +82,493 @@ void test_bai_peg_thorough(void) {
                     /*endgame_time_per_solve=*/0.5);
 }
 
+// Same one-in-bag CGP as run_bai_peg_smoke; pulled out so the widening and
+// concurrent tests can reuse it without duplicating the long literal.
+#define BAI_PEG_TEST_ONE_IN_BAG_CGP                                            \
+  "cgp 15/3Q7U3/3U2TAURINE2/1CHANSONS2W3/2AI6JO3/DIRL1PO3IN3/E1D2EF3V4/"       \
+  "F1I2p1TRAIK3/O1L2T4E4/ABy1PIT2BRIG2/ME1MOZELLE5/1GRADE1O1NOH3/"             \
+  "WE3R1V7/AT5E7/G6D7 ENOSTXY/ACEISUY 356/378 0 -lex NWL20"
+
+// Exercises the progressive_widening + min_active code path that the CLI's
+// default config relies on (widening_c=5, min_active=32). The basic smoke
+// runs without widening, so this catches regressions in the lazy
+// candidate-admission and neighbor-Q-inheritance logic.
+static void test_bai_peg_progressive_widening(void) {
+  Config *config = config_create_or_die("set -s1 score -s2 score");
+  load_and_exec_config_or_die(config, BAI_PEG_TEST_ONE_IN_BAG_CGP);
+  Game *game = config_get_game(config);
+  assert(bag_get_letters(game_get_bag(game)) == 1);
+
+  BaiPegArgs args = {
+      .game = game,
+      .thread_control = config_get_thread_control(config),
+      .num_threads = 1,
+      .tt_fraction_of_mem = 0.0,
+      .dual_lexicon_mode = DUAL_LEXICON_MODE_IGNORANT,
+      .max_depth = 2,
+      .endgame_time_per_solve = 0.05,
+      .time_budget_seconds = 1.0,
+      .max_evaluations = 24,
+      .puct_c = 1.0,
+      .progressive_widening = true,
+      .widening_c = 5.0,
+      .min_active = 8,
+  };
+  BaiPegResult result;
+  ErrorStack *error_stack = error_stack_create();
+  bai_peg_solve(&args, &result, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(!small_move_is_pass(&result.best_move));
+  assert(result.evaluations_done > 0);
+  // With widening, the candidate pool keeps every generated move; the
+  // smoke pool is small enough that this should comfortably exceed the
+  // min_active size once any visits accumulate.
+  assert(result.candidates_considered >= args.min_active);
+  printf("  bai_peg widening: evals=%d  cands=%d  best_win%%=%.1f%%  "
+         "spread=%+.2f  depth=%d  time=%.2fs\n",
+         result.evaluations_done, result.candidates_considered,
+         result.best_win_pct * 100.0, result.best_mean_spread,
+         result.best_depth_evaluated, result.seconds_elapsed);
+  error_stack_destroy(error_stack);
+  bai_cand_stats_free(result.cand_stats);
+  config_destroy(config);
+}
+
+typedef struct ConcurrentInvokeArgs {
+  Config *config;
+  int thread_index_offset;
+  BaiPegResult result;
+  ErrorStack *error_stack;
+} ConcurrentInvokeArgs;
+
+static void *bai_peg_concurrent_worker(void *arg) {
+  ConcurrentInvokeArgs *cargs = (ConcurrentInvokeArgs *)arg;
+  Game *game = config_get_game(cargs->config);
+  BaiPegArgs args = {
+      .game = game,
+      .thread_control = config_get_thread_control(cargs->config),
+      .num_threads = 1,
+      .thread_index_offset = cargs->thread_index_offset,
+      .tt_fraction_of_mem = 0.0,
+      .dual_lexicon_mode = DUAL_LEXICON_MODE_IGNORANT,
+      .initial_top_k = 32,
+      .max_depth = 2,
+      .endgame_time_per_solve = 0.05,
+      .time_budget_seconds = 1.0,
+      .max_evaluations = 16,
+      // Different alphas across the two callers so any leftover shared
+      // state on the qsort path would corrupt results visibly.
+      .utility_alpha = (cargs->thread_index_offset == 0) ? 0.0 : 0.05,
+      .puct_c = 1.0,
+  };
+  bai_peg_solve(&args, &cargs->result, cargs->error_stack);
+  return NULL;
+}
+
+// Two bai_peg_solve calls run in parallel with disjoint thread_index_offset
+// ranges and different utility_alpha values. Verifies the contracts behind
+// the sort_utility caching and thread_index_offset wiring: neither call
+// should crash, both should return non-pass moves, and the cached_gens[]
+// movegen slots should not be corrupted across calls.
+static void test_bai_peg_concurrent_invocations(void) {
+  Config *config_a = config_create_or_die("set -s1 score -s2 score");
+  Config *config_b = config_create_or_die("set -s1 score -s2 score");
+  load_and_exec_config_or_die(config_a, BAI_PEG_TEST_ONE_IN_BAG_CGP);
+  load_and_exec_config_or_die(config_b, BAI_PEG_TEST_ONE_IN_BAG_CGP);
+
+  ConcurrentInvokeArgs args_a = {.config = config_a,
+                                 .thread_index_offset = 0,
+                                 .error_stack = error_stack_create()};
+  ConcurrentInvokeArgs args_b = {.config = config_b,
+                                 .thread_index_offset = 1,
+                                 .error_stack = error_stack_create()};
+
+  pthread_t thread_a;
+  pthread_t thread_b;
+  cpthread_create(&thread_a, bai_peg_concurrent_worker, &args_a);
+  cpthread_create(&thread_b, bai_peg_concurrent_worker, &args_b);
+  cpthread_join(thread_a);
+  cpthread_join(thread_b);
+
+  assert(error_stack_is_empty(args_a.error_stack));
+  assert(error_stack_is_empty(args_b.error_stack));
+  assert(!small_move_is_pass(&args_a.result.best_move));
+  assert(!small_move_is_pass(&args_b.result.best_move));
+  assert(args_a.result.evaluations_done > 0);
+  assert(args_b.result.evaluations_done > 0);
+  printf("  bai_peg concurrent: a_evals=%d a_win%%=%.1f%% | "
+         "b_evals=%d b_win%%=%.1f%%\n",
+         args_a.result.evaluations_done, args_a.result.best_win_pct * 100.0,
+         args_b.result.evaluations_done, args_b.result.best_win_pct * 100.0);
+
+  bai_cand_stats_free(args_a.result.cand_stats);
+  bai_cand_stats_free(args_b.result.cand_stats);
+  error_stack_destroy(args_a.error_stack);
+  error_stack_destroy(args_b.error_stack);
+  config_destroy(config_a);
+  config_destroy(config_b);
+}
+
+// Helper: returns true iff the current side-on-turn has at least one
+// scoring (non-pass) move. Uses MOVE_RECORD_BEST: if the best move comes
+// back as pass-with-score-0, the player has nothing scoring to play.
+// Caller must have WMP enabled for movegen to consider every play.
+static bool has_any_scoring_move(Game *game, MoveList *move_list) {
+  const Move *best = get_top_equity_move(game, 0, move_list);
+  if (best == NULL) {
+    return false;
+  }
+  return move_get_type(best) != GAME_EVENT_PASS || move_get_score(best) != 0;
+}
+
+// Forced-rack tiles for the no-scoring-plays finder. These are
+// individually hard-to-play letters; biasing the mover's rack to this
+// 7-tile set makes it dramatically more likely to land in a stuck
+// position than waiting for it to occur naturally during random play.
+static const char FORCED_STUCK_RACK[] = "QCCVVZJ";
+
+// Returns the number of physically-on-rack tiles (counting duplicates)
+// that have NO single-tile play available on the current board. Counts
+// across all rack tiles; e.g. if a Q is unplayable but C is playable
+// then a QCCVVZJ rack returns 1 + 0 + ... summed by playability.
+// Useful as a histogram input to gauge how often a given rack is fully
+// (or near-fully) stuck.
+static int count_unplayable_rack_tiles(Game *game, MoveList *move_list) {
+  int player_idx = game_get_player_on_turn_index(game);
+  uint64_t tiles_bv = 0;
+  const MoveGenArgs args = {
+      .game = game,
+      .move_list = move_list,
+      .move_record_type = MOVE_RECORD_TILES_PLAYED,
+      .move_sort_type = MOVE_SORT_SCORE,
+      .override_kwg = NULL,
+      .thread_index = 0,
+      .eq_margin_movegen = 0,
+      .target_equity = EQUITY_MAX_VALUE,
+      .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+      .tiles_played_bv = &tiles_bv,
+  };
+  generate_moves(&args);
+  const Rack *rack = player_get_rack(game_get_player(game, player_idx));
+  const LetterDistribution *ld = game_get_ld(game);
+  int ld_size = ld_get_size(ld);
+  int unplayable = 0;
+  for (int ml = 0; ml < ld_size; ml++) {
+    int count = rack_get_letter(rack, ml);
+    if (count == 0) {
+      continue;
+    }
+    // cppcheck-suppress knownConditionTrueFalse
+    if (!(tiles_bv & ((uint64_t)1 << ml))) {
+      unplayable += count;
+    }
+  }
+  return unplayable;
+}
+
+// CGP discovered by test_bai_peg_find_no_scoring_position (run on demand).
+// 1-in-bag position where the mover (CCJQVVZ) has no playable non-pass
+// move on the board, so bai_peg_solve must fall back to pass-with-score-0
+// rather than erroring. If this CGP ever stops triggering the no-scoring
+// path (e.g. lexicon changes), regenerate via the on-demand finder.
+// Uses TWL98: that lexicon lacks several letter-pair plays (notably QI)
+// that newer lexica include, which is what makes a fully-stuck rack
+// findable in the first place.
+#define BAI_PEG_TEST_NO_SCORING_PLAYS_CGP                                      \
+  "cgp 5G1K7/1RETRO1UNRAISED/5OWE2U4/5PI3T4/4S1L3U4/1FOOTIE3M4/"               \
+  "AAH1R5N4/AX1GENTS7/4W2A7/3BEY1N7/2DIDO1I7/1RAG1U1t7/"                       \
+  "FIN4I2ALA2/OBI4E2LIMY1/H1O4SEDATiON CCJQVVZ/EEELPRT 0/643 0 -lex TWL98"
+
+// Confirms bai_peg_solve returns success with a pass-move best (score 0)
+// when the rack has no playable non-pass move. The "no scoring plays" path
+// is a fallback rather than an error because the caller has nothing
+// actionable to do besides pass.
+static void test_bai_peg_returns_pass_when_no_scoring_plays(void) {
+  Config *config = config_create_or_die("set -wmp true -s1 score -s2 score");
+  load_and_exec_config_or_die(config, BAI_PEG_TEST_NO_SCORING_PLAYS_CGP);
+  Game *game = config_get_game(config);
+  assert(bag_get_letters(game_get_bag(game)) == 1);
+  // Sanity: the fixture must actually exhibit "no scoring moves", or the
+  // assertion below tests nothing.
+  MoveList *probe_ml = move_list_create(1);
+  assert(!has_any_scoring_move(game, probe_ml));
+  move_list_destroy(probe_ml);
+
+  BaiPegArgs args = {
+      .game = game,
+      .thread_control = config_get_thread_control(config),
+      .num_threads = 1,
+      .tt_fraction_of_mem = 0.0,
+      .dual_lexicon_mode = DUAL_LEXICON_MODE_IGNORANT,
+      .max_depth = 1,
+      .endgame_time_per_solve = 0.05,
+      .time_budget_seconds = 1.0,
+      .puct_c = 1.0,
+  };
+  BaiPegResult result;
+  ErrorStack *error_stack = error_stack_create();
+  bai_peg_solve(&args, &result, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(small_move_is_pass(&result.best_move));
+  assert(small_move_get_score(&result.best_move) == 0);
+  assert(result.candidates_considered == 0);
+  error_stack_destroy(error_stack);
+  bai_cand_stats_free(result.cand_stats);
+  config_destroy(config);
+}
+
+enum {
+  FINDER_NUM_THREADS = 1,
+  FINDER_MAX_ATTEMPTS = 10000000,
+  FINDER_BASE_SEED = 1,
+};
+
+// Score-bucket boundaries for the natural-best-move histogram. Bin k
+// counts positions whose top-equity best move scores in
+// [SCORE_BUCKETS[k], SCORE_BUCKETS[k+1]). The final bin catches everything
+// at or above the last boundary. Bin 0 = "score == 0", which is exactly
+// the stuck case (best move is a 0-score pass).
+static const int SCORE_BUCKETS[] = {0, 1, 5, 10, 20, 30, 50};
+enum { NUM_SCORE_BUCKETS = sizeof(SCORE_BUCKETS) / sizeof(SCORE_BUCKETS[0]) };
+
+typedef struct FinderThreadArgs {
+  int thread_index;
+  atomic_int *next_attempt;
+  atomic_int *found;
+  cpthread_mutex_t *print_mutex;
+  cpthread_mutex_t *init_mutex;
+  // Histogram of natural top-equity-best-move scores at 1-in-bag, before
+  // any rack forcing: tells us how rare a stuck rack actually is from
+  // random self-play. Bin 0 = "best score == 0" = the case we're hunting.
+  atomic_uint *score_hist;
+  // Histogram of "stuck-tile count" across QCCVVZJ racks: hist[k] is the
+  // number of positions where exactly k of the 7 forced rack tiles have no
+  // single-tile play. hist[7] = fully stuck. Only filled when
+  // force_stuck_rack succeeds at constructing the swap.
+  atomic_uint *hist;
+} FinderThreadArgs;
+
+static int score_bucket(int score) {
+  for (int k = NUM_SCORE_BUCKETS - 1; k >= 0; k--) {
+    if (score >= SCORE_BUCKETS[k]) {
+      return k;
+    }
+  }
+  return 0;
+}
+
+static void *finder_worker(void *arg) {
+  FinderThreadArgs *fa = (FinderThreadArgs *)arg;
+  // Serialize Config creation: data filepath / KWG loading isn't safe
+  // to run in parallel from multiple threads. After this block the Game
+  // and MoveList are thread-local and parallel work begins.
+  cpthread_mutex_lock(fa->init_mutex);
+  Config *config = config_create_or_die(
+      "set -lex TWL98 -wmp true -threads 1 -s1 score -s2 score");
+  load_and_exec_config_or_die(config, "new");
+  cpthread_mutex_unlock(fa->init_mutex);
+  MoveList *move_list = move_list_create(1);
+  Game *game = config_get_game(config);
+
+  while (!atomic_load(fa->found)) {
+    int i = atomic_fetch_add(fa->next_attempt, 1);
+    if (i >= FINDER_MAX_ATTEMPTS) {
+      break;
+    }
+    if (i > 0 && i % 10000 == 0) {
+      cpthread_mutex_lock(fa->print_mutex);
+      printf("  pegfindnoscore: %d attempts.\n", i);
+      printf("    natural best-move score buckets ");
+      for (int k = 0; k < NUM_SCORE_BUCKETS; k++) {
+        printf("[≥%d]", SCORE_BUCKETS[k]);
+        if (k < NUM_SCORE_BUCKETS - 1) {
+          printf(" ");
+        }
+      }
+      printf(":\n     ");
+      for (int k = 0; k < NUM_SCORE_BUCKETS; k++) {
+        printf("%u%s", atomic_load(&fa->score_hist[k]),
+               k == NUM_SCORE_BUCKETS - 1 ? "\n" : " ");
+      }
+      printf("    QCCVVZJ unplayable-tile histogram: ");
+      for (int k = 0; k <= 7; k++) {
+        printf("%u%s", atomic_load(&fa->hist[k]), k == 7 ? "\n" : " ");
+      }
+      fflush(stdout);
+      cpthread_mutex_unlock(fa->print_mutex);
+    }
+
+    game_reset(game);
+    game_seed(game, (uint64_t)FINDER_BASE_SEED + (uint64_t)i);
+
+    // Withhold the FORCED_STUCK_RACK tiles from the bag so they're never
+    // drawn during random play. Then draw starting racks and immediately
+    // return the mover's tiles to the bag — only the opponent will play.
+    // After 85 tiles end up on the board the bag has 1 left and the
+    // opponent has 7; injecting FORCED_STUCK_RACK into the mover's empty
+    // rack yields a fully-balanced 100-tile 1-in-bag position.
+    Bag *bag = game_get_bag(game);
+    const LetterDistribution *ld = game_get_ld(game);
+    const int ld_size = ld_get_size(ld);
+    {
+      uint8_t withhold[MAX_ALPHABET_SIZE] = {0};
+      for (size_t k = 0; FORCED_STUCK_RACK[k] != '\0'; k++) {
+        const char tile_str[2] = {FORCED_STUCK_RACK[k], '\0'};
+        MachineLetter ml = ld_hl_to_ml(ld, tile_str);
+        withhold[ml]++;
+      }
+      for (int ml = 0; ml < ld_size; ml++) {
+        for (int n = 0; n < withhold[ml]; n++) {
+          if (!bag_draw_letter(bag, (MachineLetter)ml, 0)) {
+            // Couldn't withhold (bag didn't contain enough of this tile).
+            // Distribution mismatch — skip this attempt.
+            continue;
+          }
+        }
+      }
+    }
+    draw_starting_racks(game);
+    int starting_mover_idx = game_get_player_on_turn_index(game);
+    {
+      Rack *mover_rack =
+          player_get_rack(game_get_player(game, starting_mover_idx));
+      for (int ml = 0; ml < ld_size; ml++) {
+        int n = rack_get_letter(mover_rack, ml);
+        for (int j = 0; j < n; j++) {
+          bag_add_letter(bag, (MachineLetter)ml, 0);
+        }
+      }
+      rack_reset(mover_rack);
+    }
+
+    // Solo opp play. The mover passes implicitly (no rack to play) — we
+    // step the side-on-turn manually, only running movegen when it's the
+    // opp's turn.
+    int opp_idx = 1 - starting_mover_idx;
+    int play_count = 0;
+    while (bag_get_letters(bag) > 1) {
+      if (++play_count > 200) {
+        break;
+      }
+      // Force the opp to be on turn.
+      game_set_player_on_turn_index(game, opp_idx);
+      const Move *move = get_top_equity_move(game, fa->thread_index, move_list);
+      if (move == NULL || move_get_type(move) == GAME_EVENT_PASS) {
+        break;
+      }
+      play_move(move, game, NULL);
+      if (game_get_game_end_reason(game) != GAME_END_REASON_NONE) {
+        break;
+      }
+    }
+    if (bag_get_letters(bag) != 1) {
+      continue;
+    }
+    if (game_get_game_end_reason(game) != GAME_END_REASON_NONE) {
+      continue;
+    }
+
+    // Inject FORCED_STUCK_RACK into the mover's rack and put them on turn.
+    {
+      Rack *mover_rack =
+          player_get_rack(game_get_player(game, starting_mover_idx));
+      rack_reset(mover_rack);
+      for (size_t k = 0; FORCED_STUCK_RACK[k] != '\0'; k++) {
+        const char tile_str[2] = {FORCED_STUCK_RACK[k], '\0'};
+        MachineLetter ml = ld_hl_to_ml(ld, tile_str);
+        rack_add_letter(mover_rack, ml);
+      }
+      game_set_player_on_turn_index(game, starting_mover_idx);
+    }
+
+    // Natural-rack histogram (reused with a single-bin meaning): score
+    // bucket of the QCCVVZJ rack's best move.
+    const Move *natural_best =
+        get_top_equity_move(game, fa->thread_index, move_list);
+    int natural_score =
+        natural_best != NULL ? (int)move_get_score(natural_best) : 0;
+    atomic_fetch_add(&fa->score_hist[score_bucket(natural_score)], 1);
+    int unplayable = count_unplayable_rack_tiles(game, move_list);
+    atomic_fetch_add(&fa->hist[unplayable], 1);
+    if (natural_score != 0) {
+      continue;
+    }
+    char *cgp = game_get_cgp(game, true);
+    cpthread_mutex_lock(fa->print_mutex);
+    if (!atomic_load(fa->found)) {
+      printf("Found no-scoring 1-in-bag position (QCCVVZJ rack) at seed "
+             "%d:\n  %s\n",
+             i, cgp);
+      fflush(stdout);
+      atomic_store(fa->found, 1);
+    }
+    cpthread_mutex_unlock(fa->print_mutex);
+    free(cgp);
+  }
+
+  move_list_destroy(move_list);
+  config_destroy(config);
+  return NULL;
+}
+
+// On-demand finder: parallel random self-play across FINDER_NUM_THREADS
+// workers, each driving games to a 1-in-bag state and checking whether
+// the side on turn has any scoring play. Prints the first CGP whose side
+// on turn has only the pass option. Used to discover the
+// BAI_PEG_TEST_NO_SCORING_PLAYS_CGP fixture above; not part of the CI
+// suite (expected to take minutes). Run via `magpie_test pegfindnoscore`.
+void test_bai_peg_find_no_scoring_position(void) {
+  printf("  pegfindnoscore: starting parallel search across %d threads\n",
+         FINDER_NUM_THREADS);
+  fflush(stdout);
+
+  cpthread_mutex_t print_mutex;
+  cpthread_mutex_t init_mutex;
+  cpthread_mutex_init(&print_mutex);
+  cpthread_mutex_init(&init_mutex);
+  atomic_int next_attempt = 0;
+  atomic_int found = 0;
+  atomic_uint hist[8] = {0};
+  atomic_uint score_hist[NUM_SCORE_BUCKETS] = {0};
+
+  pthread_t threads[FINDER_NUM_THREADS];
+  FinderThreadArgs targs[FINDER_NUM_THREADS];
+  for (int t = 0; t < FINDER_NUM_THREADS; t++) {
+    targs[t] = (FinderThreadArgs){
+        .thread_index = t,
+        .next_attempt = &next_attempt,
+        .found = &found,
+        .print_mutex = &print_mutex,
+        .init_mutex = &init_mutex,
+        .hist = hist,
+        .score_hist = score_hist,
+    };
+    cpthread_create(&threads[t], finder_worker, &targs[t]);
+  }
+  for (int t = 0; t < FINDER_NUM_THREADS; t++) {
+    cpthread_join(threads[t]);
+  }
+
+  printf("Final natural best-move score histogram (buckets ");
+  for (int k = 0; k < NUM_SCORE_BUCKETS; k++) {
+    printf("[≥%d]%s", SCORE_BUCKETS[k],
+           k == NUM_SCORE_BUCKETS - 1 ? "):\n" : " ");
+  }
+  printf("  ");
+  for (int k = 0; k < NUM_SCORE_BUCKETS; k++) {
+    printf("%u%s", atomic_load(&score_hist[k]),
+           k == NUM_SCORE_BUCKETS - 1 ? "\n" : " ");
+  }
+  printf("Final QCCVVZJ unplayable-tile histogram: ");
+  for (int k = 0; k <= 7; k++) {
+    printf("%u%s", atomic_load(&hist[k]), k == 7 ? "\n" : " ");
+  }
+  if (!atomic_load(&found)) {
+    printf("No no-scoring 1-in-bag position found in %d attempts\n",
+           FINDER_MAX_ATTEMPTS);
+  }
+}
+
 // Confirms bai_peg_solve raises ERROR_STATUS_ENDGAME_BAG_NOT_EMPTY on a
 // position with more than 1 tile in the bag, rather than silently solving
 // a wrong subproblem.
@@ -108,5 +601,8 @@ static void test_bai_peg_rejects_non_one_in_bag(void) {
 
 void test_bai_peg(void) {
   test_bai_peg_smoke();
+  test_bai_peg_progressive_widening();
+  test_bai_peg_concurrent_invocations();
+  test_bai_peg_returns_pass_when_no_scoring_plays();
   test_bai_peg_rejects_non_one_in_bag();
 }

--- a/test/bai_peg_test.h
+++ b/test/bai_peg_test.h
@@ -2,5 +2,6 @@
 #define BAI_PEG_TEST_H
 
 void test_bai_peg(void);
+void test_bai_peg_thorough(void);
 
 #endif

--- a/test/bai_peg_test.h
+++ b/test/bai_peg_test.h
@@ -1,0 +1,6 @@
+#ifndef BAI_PEG_TEST_H
+#define BAI_PEG_TEST_H
+
+void test_bai_peg(void);
+
+#endif

--- a/test/bai_peg_test.h
+++ b/test/bai_peg_test.h
@@ -3,5 +3,6 @@
 
 void test_bai_peg(void);
 void test_bai_peg_thorough(void);
+void test_bai_peg_find_no_scoring_position(void);
 
 #endif

--- a/test/test.c
+++ b/test/test.c
@@ -6,6 +6,7 @@
 #include "analyze_test.h"
 #include "autoplay_test.h"
 #include "bag_test.h"
+#include "bai_peg_test.h"
 #include "bai_test.h"
 #include "benchmark_endgame_test.h"
 #include "bit_rack_test.h"
@@ -100,6 +101,7 @@ static TestEntry test_table[] = {
     {"sim", test_sim},
     {"math", test_math_util},
     {"bai", test_bai},
+    {"peg", test_bai_peg},
     {"command", test_command},
     {"gcg", test_gcg},
     {"analyze", test_analyze},

--- a/test/test.c
+++ b/test/test.c
@@ -146,6 +146,7 @@ static TestEntry on_demand_test_table[] = {
     {"monsterq", test_monster_q},
     {"simbench", test_sim_benchmark},
     {"ap_rit", test_autoplay_rit_correctness},
+    {"pegthorough", test_bai_peg_thorough},
     {NULL, NULL} // Sentinel value to mark end of array
 };
 

--- a/test/test.c
+++ b/test/test.c
@@ -147,6 +147,7 @@ static TestEntry on_demand_test_table[] = {
     {"simbench", test_sim_benchmark},
     {"ap_rit", test_autoplay_rit_correctness},
     {"pegthorough", test_bai_peg_thorough},
+    {"pegfindnoscore", test_bai_peg_find_no_scoring_position},
     {NULL, NULL} // Sentinel value to mark end of array
 };
 


### PR DESCRIPTION
## Summary

Adds `bai_peg_solve`, a new pre-endgame solver for 1-in-bag positions that allocates compute adaptively across `(candidate, depth)` pairs using a PUCT-like rule, instead of fixed pass-by-pass top-K cuts. The solver is anytime — at any moment the best-so-far candidate is meaningful — and supports stopping on time, evaluation budget, or a confidence-based early exit.

Key features:
- **Progressive widening** with neighbor-Q inheritance: only the top `ceil(c · √visits)` candidates (by prior basis) are PUCT-eligible at any moment. New candidates inherit Q from their neighbor at admission, giving sensible PUCT inputs without a cold-start playout.
- **Leave-value-aware prior**: the softmax prior basis is movegen's pre-computed equity (= score + KLV leave value), not raw score. Empirically validated by an A/B sweep — see "Prior basis tuning" below.
- **Optional Phase 0 greedy playout** as a scenario-aware Q prior (cheap movegen+play loop, no endgame_solve plumbing).
- **Per-thread transposition tables** to eliminate cross-core contention.
- **Utility weighting** `U = win_pct + alpha · spread`, optimizing for "win first, spread as tiebreaker" without a separate sort key.
- **Per-scenario parallelism**: a flattened `(candidate, scenario)` work queue so wide candidate pools at low depth can saturate all cores.

Includes a small set of endgame plumbing changes (`endgame_solve_inline`, `skip_word_pruning`, `thread_index_offset`, `tt_is_external` flag) needed to drive scenario solves from a higher-level adaptive search. The plumbing is general-purpose and not specific to the BAI solver — future callers can use it too.

The empirical defaults landed via offline tuning over hundreds of positions: `widening_c=5`, `min_active=32`, `max_depth=8`, `utility_alpha=0.01`. These are exposed as `BaiPegArgs` fields so callers can override them.

## Prior basis tuning

The prior softmax basis was switched from raw move score to movegen's pre-computed equity (score + KLV leave value). Justification from a 1000-position / 1s benchmark on NWL20:

**Aggregate** (oracle-scored vs full-search ground truth):

| regime              | prior=score          | prior=score+leave    |
|---------------------|----------------------|----------------------|
| 100 pos, 10s budget | EmpW%=50.6%, S=+9.23 | EmpW%=51.1%, S=+9.49 |
| 1000 pos, 1s budget | EmpW%=48.6%, S=−3.75 | EmpW%=49.0%, S=−3.38 |

**Head-to-head** (`i_better / same / j_better / ties`):

| regime              | score vs score+leave |
|---------------------|----------------------|
| 100 pos, 10s budget |   10 / 76 / 13 / 1   |
| 1000 pos, 1s budget |   73 / 826 / 95 / 6  |

At 1s the leave-value prior wins 95 vs 73 H2H among 174 differing picks (z ≈ 1.70, one-tailed p ≈ 0.044), consistent in direction with the smaller 100-pos sweep. Effect size is small (≈+0.4pp EmpW%, +0.37 spread) but free, since movegen already computes the equity for `MOVE_SORT_EQUITY` regardless.

## Test plan

- [x] `./bin/magpie_test peg` passes (smoke test on a 1-in-bag CGP + non-1-in-bag rejection)
- [x] cppcheck clean
- [x] clang-format clean
- [x] no circular dependencies
- [x] clang-tidy clean on the new files (CI version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
