### PR TITLE
Endgame engine: before_search_callback for live d=0 progress

### DIFF
--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -697,6 +697,12 @@ endgame_ctx_get_transposition_table(const EndgameCtx *ctx) {
   return ctx->transposition_table;
 }
 
+void endgame_ctx_clear_transposition_table(EndgameCtx *ctx) {
+  if (ctx->transposition_table != NULL) {
+    transposition_table_reset(ctx->transposition_table);
+  }
+}
+
 void endgame_ctx_get_progress(const EndgameCtx *ctx, int *current_depth,
                               int *root_moves_completed, int *root_moves_total,
                               int *ply2_moves_completed,

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -247,6 +247,22 @@ struct EndgameCtxWorker {
   _Atomic int32_t live_pv_value;
   _Atomic int live_pv_length;
   _Atomic uint64_t live_pv_seq;
+
+  // Live multi-PV top-K snapshot, updated per root completion (so
+  // every per_root_move_callback firing also republishes here).
+  // Each slot has (root tiny_move, spread-adjusted value, the
+  // continuation tiny_moves from after the root move, and the
+  // continuation length).  Entries are sorted descending by value.
+  // live_top_k_filled is how many of MAX_ENDGAME_DISPLAY_PVS slots
+  // are currently populated. Same seqlock pattern as live_pv.
+  // Reset to 0 entries at the start of each new IDS depth so the
+  // leaderboard reflects the current depth's evaluations only.
+  uint64_t live_top_k_root_tiny[MAX_ENDGAME_DISPLAY_PVS];
+  int32_t live_top_k_value[MAX_ENDGAME_DISPLAY_PVS];
+  uint64_t live_top_k_continuation[MAX_ENDGAME_DISPLAY_PVS][MAX_SEARCH_DEPTH];
+  int live_top_k_continuation_len[MAX_ENDGAME_DISPLAY_PVS];
+  _Atomic int live_top_k_filled;
+  _Atomic uint64_t live_top_k_seq;
 };
 
 #ifndef MAX
@@ -830,6 +846,47 @@ int endgame_ctx_get_live_pv(const EndgameCtx *ctx, int thread_index,
   return 0;
 }
 
+int endgame_ctx_get_live_top_k_pvs(const EndgameCtx *ctx, int thread_index,
+                                   EndgameLivePvSnapshot *out, int max_k) {
+  if (thread_index < 0 || thread_index >= ctx->cap_workers || max_k <= 0) {
+    return 0;
+  }
+  const EndgameCtxWorker *w = ctx->workers[thread_index];
+  for (int attempt = 0; attempt < 4; attempt++) {
+    const uint64_t seq1 =
+        atomic_load_explicit(&w->live_top_k_seq, memory_order_acquire);
+    if ((seq1 & 1ULL) != 0) {
+      continue; // writer in progress
+    }
+    int filled =
+        atomic_load_explicit(&w->live_top_k_filled, memory_order_relaxed);
+    if (filled > max_k) {
+      filled = max_k;
+    }
+    if (filled > MAX_ENDGAME_DISPLAY_PVS) {
+      filled = MAX_ENDGAME_DISPLAY_PVS;
+    }
+    for (int i = 0; i < filled; i++) {
+      out[i].root_tiny = w->live_top_k_root_tiny[i];
+      out[i].value = w->live_top_k_value[i];
+      int cont_len = w->live_top_k_continuation_len[i];
+      if (cont_len > MAX_SEARCH_DEPTH) {
+        cont_len = MAX_SEARCH_DEPTH;
+      }
+      out[i].continuation_len = cont_len;
+      for (int j = 0; j < cont_len; j++) {
+        out[i].continuation_tiny[j] = w->live_top_k_continuation[i][j];
+      }
+    }
+    const uint64_t seq2 =
+        atomic_load_explicit(&w->live_top_k_seq, memory_order_acquire);
+    if (seq1 == seq2) {
+      return filled;
+    }
+  }
+  return 0;
+}
+
 double endgame_ctx_get_current_depth_eta_fraction(const EndgameCtx *ctx) {
   int64_t started_ns;
   int64_t prev_ns;
@@ -945,6 +1002,10 @@ static EndgameCtxWorker *endgame_ctx_create_worker(EndgameCtx *solver,
                         memory_order_relaxed);
   atomic_store_explicit(&solver_worker->live_pv_value, 0, memory_order_relaxed);
   atomic_store_explicit(&solver_worker->live_pv_seq, 0, memory_order_relaxed);
+  atomic_store_explicit(&solver_worker->live_top_k_filled, 0,
+                        memory_order_relaxed);
+  atomic_store_explicit(&solver_worker->live_top_k_seq, 0,
+                        memory_order_relaxed);
 
   return solver_worker;
 }
@@ -974,6 +1035,8 @@ static void endgame_ctx_reset_worker(EndgameCtxWorker *worker,
   atomic_store_explicit(&worker->live_pv_length, 0, memory_order_relaxed);
   atomic_store_explicit(&worker->live_pv_value, 0, memory_order_relaxed);
   atomic_store_explicit(&worker->live_pv_seq, 0, memory_order_relaxed);
+  atomic_store_explicit(&worker->live_top_k_filled, 0, memory_order_relaxed);
+  atomic_store_explicit(&worker->live_top_k_seq, 0, memory_order_relaxed);
 }
 
 void endgame_ctx_reset_worker_and_game(EndgameCtx *solver, uint64_t base_seed,
@@ -1968,6 +2031,92 @@ check_depth_deadline(EndgameCtxWorker *worker) {
   return false;
 }
 
+// Insert (root_tiny, value, continuation_pv) into the worker's live
+// multi-PV top-K snapshot under its seqlock. If a slot already exists
+// for the same root_tiny (e.g. ABDADA pass-2 re-evaluation) it's
+// removed first so re-inserting reflects the new value/continuation.
+// Insertion is sorted descending by value; capped at K_max slots.
+// Caller must be the worker's owning thread (only thread 0 should
+// call this so the writer side stays single-threaded).
+static void publish_live_top_k_pv(EndgameCtxWorker *worker, uint64_t root_tiny,
+                                  int32_t value,
+                                  const struct PVLine *continuation,
+                                  int K_max) {
+  if (K_max < 1) {
+    return;
+  }
+  if (K_max > MAX_ENDGAME_DISPLAY_PVS) {
+    K_max = MAX_ENDGAME_DISPLAY_PVS;
+  }
+  // Begin seqlock write window: bump seq odd.
+  const uint64_t seq_before =
+      atomic_load_explicit(&worker->live_top_k_seq, memory_order_relaxed);
+  atomic_store_explicit(&worker->live_top_k_seq, seq_before + 1,
+                        memory_order_release);
+
+  int filled =
+      atomic_load_explicit(&worker->live_top_k_filled, memory_order_relaxed);
+
+  // Remove existing entry for same root_tiny so we can re-insert sorted.
+  for (int i = 0; i < filled; i++) {
+    if (worker->live_top_k_root_tiny[i] == root_tiny) {
+      for (int j = i; j < filled - 1; j++) {
+        worker->live_top_k_root_tiny[j] = worker->live_top_k_root_tiny[j + 1];
+        worker->live_top_k_value[j] = worker->live_top_k_value[j + 1];
+        worker->live_top_k_continuation_len[j] =
+            worker->live_top_k_continuation_len[j + 1];
+        memcpy(worker->live_top_k_continuation[j],
+               worker->live_top_k_continuation[j + 1],
+               sizeof(uint64_t) * MAX_SEARCH_DEPTH);
+      }
+      filled--;
+      break;
+    }
+  }
+
+  // Find insertion position (descending order by value).
+  int insert_pos = filled;
+  for (int i = 0; i < filled; i++) {
+    if (value > worker->live_top_k_value[i]) {
+      insert_pos = i;
+      break;
+    }
+  }
+
+  if (insert_pos < K_max) {
+    const int last = (filled < K_max) ? filled : (K_max - 1);
+    for (int i = last; i > insert_pos; i--) {
+      worker->live_top_k_root_tiny[i] = worker->live_top_k_root_tiny[i - 1];
+      worker->live_top_k_value[i] = worker->live_top_k_value[i - 1];
+      worker->live_top_k_continuation_len[i] =
+          worker->live_top_k_continuation_len[i - 1];
+      memcpy(worker->live_top_k_continuation[i],
+             worker->live_top_k_continuation[i - 1],
+             sizeof(uint64_t) * MAX_SEARCH_DEPTH);
+    }
+    worker->live_top_k_root_tiny[insert_pos] = root_tiny;
+    worker->live_top_k_value[insert_pos] = value;
+    int cont_len = (continuation != NULL) ? continuation->num_moves : 0;
+    if (cont_len > MAX_SEARCH_DEPTH) {
+      cont_len = MAX_SEARCH_DEPTH;
+    }
+    for (int i = 0; i < cont_len; i++) {
+      worker->live_top_k_continuation[insert_pos][i] =
+          continuation->moves[i].tiny_move;
+    }
+    worker->live_top_k_continuation_len[insert_pos] = cont_len;
+    if (filled < K_max) {
+      filled++;
+    }
+    atomic_store_explicit(&worker->live_top_k_filled, filled,
+                          memory_order_relaxed);
+  }
+
+  // End seqlock write window: bump seq even.
+  atomic_store_explicit(&worker->live_top_k_seq, seq_before + 2,
+                        memory_order_release);
+}
+
 int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
                        int32_t alpha, int32_t beta, PVLine *pv, bool pv_node,
                        bool exclusive_p, float opp_stuck_frac) {
@@ -2485,14 +2634,21 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
         // are not missed.
         if (worker->thread_index == 0) {
           atomic_fetch_add(&worker->solver->root_moves_completed, 1);
+          // Spread-adjusted value, same sign convention as PVLine.score.
+          const int32_t reported_value =
+              -value - worker->solver->initial_spread;
           if (worker->solver->per_root_move_callback) {
-            // Spread-adjusted value, same sign convention as PVLine.score.
-            const int32_t reported_value =
-                -value - worker->solver->initial_spread;
             worker->solver->per_root_move_callback(
                 depth, idx, small_move, reported_value,
                 worker->solver->per_root_move_callback_data);
           }
+          // Live multi-PV: republish the top-K leaderboard with this
+          // root's evaluation. Covers all root completions (including
+          // ABDADA pass-2 deferred re-evaluations), so the displayed
+          // leaderboard always reflects the most recent value seen for
+          // each root move at the current depth.
+          publish_live_top_k_pv(worker, small_move->tiny_move, reported_value,
+                                &child_pv, worker->solver->num_top_moves);
         }
       }
       if (is_ply2) {
@@ -2723,6 +2879,18 @@ void iterative_deepening(EndgameCtxWorker *worker, int plies) {
       atomic_store(&worker->solver->ply2_moves_total, 0);
       atomic_store(&worker->solver->current_depth_started_ns,
                    ctimer_monotonic_ns());
+      // Live multi-PV: clear the top-K leaderboard so it reflects the
+      // new depth's evaluations only. Brief seqlock window; reader
+      // will see filled=0 momentarily and then watch entries fill in
+      // as roots complete.
+      const uint64_t topk_seq_before =
+          atomic_load_explicit(&worker->live_top_k_seq, memory_order_relaxed);
+      atomic_store_explicit(&worker->live_top_k_seq, topk_seq_before + 1,
+                            memory_order_release);
+      atomic_store_explicit(&worker->live_top_k_filled, 0,
+                            memory_order_relaxed);
+      atomic_store_explicit(&worker->live_top_k_seq, topk_seq_before + 2,
+                            memory_order_release);
       worker->in_first_root_move = false;
     }
     double depth_start_time = ctimer_elapsed_seconds(&ids_timer);

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -149,16 +149,6 @@ struct EndgameCtx {
   atomic_int ply2_moves_completed;
   atomic_int ply2_moves_total;
 
-  // Live ETA tracking (thread 0 only writes). Times in CLOCK_MONOTONIC ns.
-  // Set to monotonic_ns() when each new IDS depth begins; 0 = no depth yet.
-  _Atomic int64_t current_depth_started_ns;
-  // Wall-clock duration of the most recently completed IDS depth.
-  _Atomic int64_t prev_completed_depth_ns;
-  // Wall-clock duration of the depth before that. With both, callers can
-  // compute a 2-ply EBF (sqrt(prev/prev_prev)) and predict this depth's
-  // total wall-clock time (= prev_completed_depth_ns * EBF).
-  _Atomic int64_t prev_prev_completed_depth_ns;
-
   // Per-ply callback for iterative deepening progress
   EndgamePerPlyCallback per_ply_callback;
   void *per_ply_callback_data;
@@ -709,9 +699,6 @@ void endgame_ctx_reset(EndgameCtx *es, EndgameResults *results,
   atomic_store(&es->current_depth, 0);
   atomic_store(&es->ply2_moves_completed, 0);
   atomic_store(&es->ply2_moves_total, 0);
-  atomic_store(&es->current_depth_started_ns, 0);
-  atomic_store(&es->prev_completed_depth_ns, 0);
-  atomic_store(&es->prev_prev_completed_depth_ns, 0);
 
   es->thread_control = endgame_args->thread_control;
   es->game = endgame_args->game;
@@ -795,18 +782,6 @@ int endgame_ctx_get_current_line(const EndgameCtx *ctx, int thread_index,
   return len;
 }
 
-void endgame_ctx_get_eta_data(const EndgameCtx *ctx,
-                              int64_t *current_depth_started_ns,
-                              int64_t *prev_completed_depth_ns,
-                              int64_t *prev_prev_completed_depth_ns) {
-  *current_depth_started_ns = atomic_load_explicit(
-      &ctx->current_depth_started_ns, memory_order_relaxed);
-  *prev_completed_depth_ns =
-      atomic_load_explicit(&ctx->prev_completed_depth_ns, memory_order_relaxed);
-  *prev_prev_completed_depth_ns = atomic_load_explicit(
-      &ctx->prev_prev_completed_depth_ns, memory_order_relaxed);
-}
-
 int endgame_ctx_get_live_pv(const EndgameCtx *ctx, int thread_index,
                             uint64_t *out_moves, int max_len,
                             int32_t *out_value) {
@@ -885,44 +860,6 @@ int endgame_ctx_get_live_top_k_pvs(const EndgameCtx *ctx, int thread_index,
     }
   }
   return 0;
-}
-
-double endgame_ctx_get_current_depth_eta_fraction(const EndgameCtx *ctx) {
-  int64_t started_ns;
-  int64_t prev_ns;
-  int64_t prev_prev_ns;
-  endgame_ctx_get_eta_data(ctx, &started_ns, &prev_ns, &prev_prev_ns);
-  if (started_ns == 0 || prev_ns <= 0) {
-    return -1.0;
-  }
-  // 2-ply EBF when we have two completed depths; otherwise assume 4
-  // (representative endgame branching factor at typical fullness).
-  double per_ply_ebf;
-  if (prev_prev_ns > 0) {
-    const double ratio_2ply = (double)prev_ns / (double)prev_prev_ns;
-    per_ply_ebf = sqrt(ratio_2ply);
-    // Clamp to a sane range so a fluky first-depth ratio doesn't blow up.
-    if (per_ply_ebf < 1.5) {
-      per_ply_ebf = 1.5;
-    } else if (per_ply_ebf > 20.0) {
-      per_ply_ebf = 20.0;
-    }
-  } else {
-    per_ply_ebf = 4.0;
-  }
-  const double predicted_ns = (double)prev_ns * per_ply_ebf;
-  const int64_t now_ns = ctimer_monotonic_ns();
-  const double elapsed_ns = (double)(now_ns - started_ns);
-  if (predicted_ns <= 0.0) {
-    return -1.0;
-  }
-  double fraction = elapsed_ns / predicted_ns;
-  if (fraction < 0.0) {
-    fraction = 0.0;
-  } else if (fraction > 1.0) {
-    fraction = 1.0;
-  }
-  return fraction;
 }
 
 void endgame_ctx_get_progress(const EndgameCtx *ctx, int *current_depth,
@@ -2877,8 +2814,6 @@ void iterative_deepening(EndgameCtxWorker *worker, int plies) {
       atomic_store(&worker->solver->root_moves_total, worker->n_initial_moves);
       atomic_store(&worker->solver->ply2_moves_completed, 0);
       atomic_store(&worker->solver->ply2_moves_total, 0);
-      atomic_store(&worker->solver->current_depth_started_ns,
-                   ctimer_monotonic_ns());
       // Live multi-PV: clear the top-K leaderboard so it reflects the
       // new depth's evaluations only. Brief seqlock window; reader
       // will see filled=0 momentarily and then watch entries fill in
@@ -2952,23 +2887,6 @@ void iterative_deepening(EndgameCtxWorker *worker, int plies) {
     }
 
     prev_value = val;
-
-    // Live ETA tracking: snapshot the just-completed depth's wall-clock
-    // duration into the public atomics so a polling reader can predict
-    // the next depth's ETA via 2-ply EBF. Thread 0 only — soft_time_limit
-    // gating in the block below decides whether to STOP based on EBF; we
-    // expose the data unconditionally so even untimed solves get an ETA.
-    if (worker->thread_index == 0) {
-      const int64_t now_ns = ctimer_monotonic_ns();
-      const int64_t depth_started_ns =
-          atomic_load(&worker->solver->current_depth_started_ns);
-      const int64_t this_depth_ns =
-          (depth_started_ns > 0) ? (now_ns - depth_started_ns) : 0;
-      const int64_t prev_ns =
-          atomic_load(&worker->solver->prev_completed_depth_ns);
-      atomic_store(&worker->solver->prev_prev_completed_depth_ns, prev_ns);
-      atomic_store(&worker->solver->prev_completed_depth_ns, this_depth_ns);
-    }
 
     // sort initial moves by valuation for next time.
     SmallMove *initial_moves = (SmallMove *)(worker->small_move_arena->memory);

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -206,6 +206,25 @@ struct EndgameCtxWorker {
   // For multi-PV (num_top_moves > 1) this is topk_n; for single-PV it is 1
   // when any best move was found, else 0.
   int root_topk_n;
+
+  // Per-thread node counter for the live-progress getter. Plain uint64
+  // (no atomics on the writer side); flushed periodically to the
+  // shared atomic via the deadline-check rhythm. The reader sums per-
+  // thread atomics, so a brief lag (up to DEPTH_DEADLINE_CHECK_INTERVAL
+  // nodes) is acceptable.
+  uint64_t local_nodes_searched;
+  _Atomic uint64_t published_nodes_searched;
+
+  // Per-thread "current line being explored" for the live-progress
+  // getter. current_line[i] is the tiny_move played at the i-th ply
+  // from the root; current_line_len is the number of valid entries.
+  // Worker writes the move slot, then atomic_store_release the length;
+  // reader does atomic_load_acquire on the length, then reads the
+  // line. Reader may see torn entries if the worker is concurrently
+  // ascending into a sibling subtree, but the result remains
+  // structurally consistent (length matches what's been written).
+  uint64_t current_line[MAX_SEARCH_DEPTH];
+  _Atomic int current_line_len;
 };
 
 #ifndef MAX
@@ -703,6 +722,38 @@ void endgame_ctx_clear_transposition_table(EndgameCtx *ctx) {
   }
 }
 
+uint64_t endgame_ctx_get_nodes_searched(const EndgameCtx *ctx) {
+  uint64_t total = 0;
+  for (int i = 0; i < ctx->cap_workers; i++) {
+    total += atomic_load_explicit(&ctx->workers[i]->published_nodes_searched,
+                                  memory_order_relaxed);
+  }
+  return total;
+}
+
+int endgame_ctx_get_current_line(const EndgameCtx *ctx, int thread_index,
+                                 uint64_t *out_line, int max_len) {
+  if (thread_index < 0 || thread_index >= ctx->cap_workers) {
+    return 0;
+  }
+  const EndgameCtxWorker *w = ctx->workers[thread_index];
+  // Acquire on length pairs with release on writer side: by the time we
+  // observe length L, all writes to current_line[0..L-1] up to that
+  // store are visible. The worker may have moved on since then; entries
+  // beyond what we read may correspond to a different sibling subtree.
+  int len = atomic_load_explicit(&w->current_line_len, memory_order_acquire);
+  if (len > max_len) {
+    len = max_len;
+  }
+  if (len > MAX_SEARCH_DEPTH) {
+    len = MAX_SEARCH_DEPTH;
+  }
+  for (int i = 0; i < len; i++) {
+    out_line[i] = w->current_line[i];
+  }
+  return len;
+}
+
 void endgame_ctx_get_progress(const EndgameCtx *ctx, int *current_depth,
                               int *root_moves_completed, int *root_moves_total,
                               int *ply2_moves_completed,
@@ -771,6 +822,11 @@ static EndgameCtxWorker *endgame_ctx_create_worker(EndgameCtx *solver,
   solver_worker->completed_depth = 0;
   solver_worker->nodes_since_deadline_check = 0;
   solver_worker->root_topk_n = 0;
+  solver_worker->local_nodes_searched = 0;
+  atomic_store_explicit(&solver_worker->published_nodes_searched, 0,
+                        memory_order_relaxed);
+  atomic_store_explicit(&solver_worker->current_line_len, 0,
+                        memory_order_relaxed);
 
   return solver_worker;
 }
@@ -793,6 +849,10 @@ static void endgame_ctx_reset_worker(EndgameCtxWorker *worker,
   worker->completed_depth = 0;
   worker->nodes_since_deadline_check = 0;
   worker->root_topk_n = 0;
+  worker->local_nodes_searched = 0;
+  atomic_store_explicit(&worker->published_nodes_searched, 0,
+                        memory_order_relaxed);
+  atomic_store_explicit(&worker->current_line_len, 0, memory_order_relaxed);
 }
 
 void endgame_ctx_reset_worker_and_game(EndgameCtx *solver, uint64_t base_seed,
@@ -1793,6 +1853,13 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
 
   assert(pv_node || alpha == beta - 1);
 
+  // Live-progress: count this node visit in the per-thread local counter.
+  // The published-to-shared atomic is updated alongside the deadline check
+  // below, batching ~DEPTH_DEADLINE_CHECK_INTERVAL increments into one
+  // atomic_store. Reader sees an upper-bound-stale view, which is fine for
+  // a "is the engine making progress" UI.
+  worker->local_nodes_searched++;
+
   if (iterative_deepening_should_stop(worker->solver)) {
     return ABDADA_INTERRUPTED;
   }
@@ -1804,6 +1871,11 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
   // deep searches (e.g. 25-ply) would otherwise overflow the stack.
   if (++worker->nodes_since_deadline_check >= DEPTH_DEADLINE_CHECK_INTERVAL) {
     worker->nodes_since_deadline_check = 0;
+    // Flush per-thread node count to the shared atomic at the same
+    // cadence as the deadline check, so the live-progress getter sees
+    // updates ~once per DEPTH_DEADLINE_CHECK_INTERVAL nodes per worker.
+    atomic_store_explicit(&worker->published_nodes_searched,
+                          worker->local_nodes_searched, memory_order_relaxed);
     if (check_depth_deadline(worker)) {
       return ABDADA_INTERRUPTED;
     }
@@ -2115,6 +2187,16 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
       // Calculate undo index for incremental backup
       int undo_index = worker->solver->requested_plies - depth;
 
+      // Live-progress: publish this move into the per-thread "current
+      // line" buffer before recursing so a polling reader can see what
+      // the engine is currently exploring even during a long single-
+      // root subtree where no other signal updates. Length store uses
+      // release ordering so the reader (acquire on length) sees the
+      // tiny_move write.
+      worker->current_line[undo_index] = small_move->tiny_move;
+      atomic_store_explicit(&worker->current_line_len, undo_index + 1,
+                            memory_order_release);
+
       // Use optimized function for outplays - skips board/cross-set updates
       if (is_outplay) {
         play_move_endgame_outplay(worker->move_list->spare_move,
@@ -2207,6 +2289,13 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
                                                  worker->game_copy);
         board_set_cross_sets_valid(game_get_board(worker->game_copy), true);
       }
+
+      // Live-progress: pop the line back to the parent's depth. The
+      // entry at undo_index is left as-is (will be overwritten by the
+      // next sibling's push). Release pairs with reader's acquire on
+      // length.
+      atomic_store_explicit(&worker->current_line_len, undo_index,
+                            memory_order_release);
 
       if (value == ABDADA_INTERRUPTED) {
         all_done = true;

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -149,6 +149,16 @@ struct EndgameCtx {
   atomic_int ply2_moves_completed;
   atomic_int ply2_moves_total;
 
+  // Live ETA tracking (thread 0 only writes). Times in CLOCK_MONOTONIC ns.
+  // Set to monotonic_ns() when each new IDS depth begins; 0 = no depth yet.
+  _Atomic int64_t current_depth_started_ns;
+  // Wall-clock duration of the most recently completed IDS depth.
+  _Atomic int64_t prev_completed_depth_ns;
+  // Wall-clock duration of the depth before that. With both, callers can
+  // compute a 2-ply EBF (sqrt(prev/prev_prev)) and predict this depth's
+  // total wall-clock time (= prev_completed_depth_ns * EBF).
+  _Atomic int64_t prev_prev_completed_depth_ns;
+
   // Per-ply callback for iterative deepening progress
   EndgamePerPlyCallback per_ply_callback;
   void *per_ply_callback_data;
@@ -671,6 +681,9 @@ void endgame_ctx_reset(EndgameCtx *es, EndgameResults *results,
   atomic_store(&es->current_depth, 0);
   atomic_store(&es->ply2_moves_completed, 0);
   atomic_store(&es->ply2_moves_total, 0);
+  atomic_store(&es->current_depth_started_ns, 0);
+  atomic_store(&es->prev_completed_depth_ns, 0);
+  atomic_store(&es->prev_prev_completed_depth_ns, 0);
 
   es->thread_control = endgame_args->thread_control;
   es->game = endgame_args->game;
@@ -752,6 +765,56 @@ int endgame_ctx_get_current_line(const EndgameCtx *ctx, int thread_index,
     out_line[i] = w->current_line[i];
   }
   return len;
+}
+
+void endgame_ctx_get_eta_data(const EndgameCtx *ctx,
+                              int64_t *current_depth_started_ns,
+                              int64_t *prev_completed_depth_ns,
+                              int64_t *prev_prev_completed_depth_ns) {
+  *current_depth_started_ns = atomic_load_explicit(
+      &ctx->current_depth_started_ns, memory_order_relaxed);
+  *prev_completed_depth_ns =
+      atomic_load_explicit(&ctx->prev_completed_depth_ns, memory_order_relaxed);
+  *prev_prev_completed_depth_ns = atomic_load_explicit(
+      &ctx->prev_prev_completed_depth_ns, memory_order_relaxed);
+}
+
+double endgame_ctx_get_current_depth_eta_fraction(const EndgameCtx *ctx) {
+  int64_t started_ns;
+  int64_t prev_ns;
+  int64_t prev_prev_ns;
+  endgame_ctx_get_eta_data(ctx, &started_ns, &prev_ns, &prev_prev_ns);
+  if (started_ns == 0 || prev_ns <= 0) {
+    return -1.0;
+  }
+  // 2-ply EBF when we have two completed depths; otherwise assume 4
+  // (representative endgame branching factor at typical fullness).
+  double per_ply_ebf;
+  if (prev_prev_ns > 0) {
+    const double ratio_2ply = (double)prev_ns / (double)prev_prev_ns;
+    per_ply_ebf = sqrt(ratio_2ply);
+    // Clamp to a sane range so a fluky first-depth ratio doesn't blow up.
+    if (per_ply_ebf < 1.5) {
+      per_ply_ebf = 1.5;
+    } else if (per_ply_ebf > 20.0) {
+      per_ply_ebf = 20.0;
+    }
+  } else {
+    per_ply_ebf = 4.0;
+  }
+  const double predicted_ns = (double)prev_ns * per_ply_ebf;
+  const int64_t now_ns = ctimer_monotonic_ns();
+  const double elapsed_ns = (double)(now_ns - started_ns);
+  if (predicted_ns <= 0.0) {
+    return -1.0;
+  }
+  double fraction = elapsed_ns / predicted_ns;
+  if (fraction < 0.0) {
+    fraction = 0.0;
+  } else if (fraction > 1.0) {
+    fraction = 1.0;
+  }
+  return fraction;
 }
 
 void endgame_ctx_get_progress(const EndgameCtx *ctx, int *current_depth,
@@ -2574,6 +2637,8 @@ void iterative_deepening(EndgameCtxWorker *worker, int plies) {
       atomic_store(&worker->solver->root_moves_total, worker->n_initial_moves);
       atomic_store(&worker->solver->ply2_moves_completed, 0);
       atomic_store(&worker->solver->ply2_moves_total, 0);
+      atomic_store(&worker->solver->current_depth_started_ns,
+                   ctimer_monotonic_ns());
       worker->in_first_root_move = false;
     }
     double depth_start_time = ctimer_elapsed_seconds(&ids_timer);
@@ -2635,6 +2700,23 @@ void iterative_deepening(EndgameCtxWorker *worker, int plies) {
     }
 
     prev_value = val;
+
+    // Live ETA tracking: snapshot the just-completed depth's wall-clock
+    // duration into the public atomics so a polling reader can predict
+    // the next depth's ETA via 2-ply EBF. Thread 0 only — soft_time_limit
+    // gating in the block below decides whether to STOP based on EBF; we
+    // expose the data unconditionally so even untimed solves get an ETA.
+    if (worker->thread_index == 0) {
+      const int64_t now_ns = ctimer_monotonic_ns();
+      const int64_t depth_started_ns =
+          atomic_load(&worker->solver->current_depth_started_ns);
+      const int64_t this_depth_ns =
+          (depth_started_ns > 0) ? (now_ns - depth_started_ns) : 0;
+      const int64_t prev_ns =
+          atomic_load(&worker->solver->prev_completed_depth_ns);
+      atomic_store(&worker->solver->prev_prev_completed_depth_ns, prev_ns);
+      atomic_store(&worker->solver->prev_completed_depth_ns, this_depth_ns);
+    }
 
     // sort initial moves by valuation for next time.
     SmallMove *initial_moves = (SmallMove *)(worker->small_move_arena->memory);

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -158,6 +158,11 @@ struct EndgameCtx {
   EndgameBeforeSearchCallback before_search_callback;
   void *before_search_callback_data;
 
+  // Fired from thread 0 each time a root move completes at the current
+  // depth. Per-root resolution for live leaderboard re-ranking.
+  EndgamePerRootMoveCallback per_root_move_callback;
+  void *per_root_move_callback_data;
+
   // Owned by the caller:
   EndgameResults *results;
   ThreadControl *thread_control;
@@ -654,6 +659,8 @@ void endgame_ctx_reset(EndgameCtx *es, EndgameResults *results,
   es->per_ply_callback_data = endgame_args->per_ply_callback_data;
   es->before_search_callback = endgame_args->before_search_callback;
   es->before_search_callback_data = endgame_args->before_search_callback_data;
+  es->per_root_move_callback = endgame_args->per_root_move_callback;
+  es->per_root_move_callback_data = endgame_args->per_root_move_callback_data;
   if (endgame_args->tt_fraction_of_mem == 0) {
     transposition_table_destroy(es->transposition_table);
     es->transposition_table = NULL;
@@ -2236,6 +2243,14 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
         // are not missed.
         if (worker->thread_index == 0) {
           atomic_fetch_add(&worker->solver->root_moves_completed, 1);
+          if (worker->solver->per_root_move_callback) {
+            // Spread-adjusted value, same sign convention as PVLine.score.
+            const int32_t reported_value =
+                -value - worker->solver->initial_spread;
+            worker->solver->per_root_move_callback(
+                depth, idx, small_move, reported_value,
+                worker->solver->per_root_move_callback_data);
+          }
         }
       }
       if (is_ply2) {

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -235,6 +235,18 @@ struct EndgameCtxWorker {
   // structurally consistent (length matches what's been written).
   uint64_t current_line[MAX_SEARCH_DEPTH];
   _Atomic int current_line_len;
+
+  // Live best-PV-from-root snapshot. Updated by abdada_negamax every
+  // time best_value improves at the root (is_root=true), so a polling
+  // reader can watch the engine's evolving best line refine through
+  // each depth.  Seqlock pattern: live_pv_seq is even when the
+  // snapshot is consistent, odd while a write is in progress. Reader
+  // loads seq, reads length+moves+value, loads seq again; retries on
+  // odd or mismatched seq.
+  uint64_t live_pv_tiny_moves[MAX_SEARCH_DEPTH];
+  _Atomic int32_t live_pv_value;
+  _Atomic int live_pv_length;
+  _Atomic uint64_t live_pv_seq;
 };
 
 #ifndef MAX
@@ -779,6 +791,45 @@ void endgame_ctx_get_eta_data(const EndgameCtx *ctx,
       &ctx->prev_prev_completed_depth_ns, memory_order_relaxed);
 }
 
+int endgame_ctx_get_live_pv(const EndgameCtx *ctx, int thread_index,
+                            uint64_t *out_moves, int max_len,
+                            int32_t *out_value) {
+  if (thread_index < 0 || thread_index >= ctx->cap_workers) {
+    *out_value = 0;
+    return 0;
+  }
+  const EndgameCtxWorker *w = ctx->workers[thread_index];
+  // Seqlock read: try a few times to capture a consistent snapshot
+  // (length, moves, value all from the same writer update).
+  for (int attempt = 0; attempt < 4; attempt++) {
+    const uint64_t seq1 =
+        atomic_load_explicit(&w->live_pv_seq, memory_order_acquire);
+    if ((seq1 & 1ULL) != 0) {
+      continue; // writer in progress
+    }
+    int len = atomic_load_explicit(&w->live_pv_length, memory_order_relaxed);
+    const int32_t value =
+        atomic_load_explicit(&w->live_pv_value, memory_order_relaxed);
+    if (len > max_len) {
+      len = max_len;
+    }
+    if (len > MAX_SEARCH_DEPTH) {
+      len = MAX_SEARCH_DEPTH;
+    }
+    for (int i = 0; i < len; i++) {
+      out_moves[i] = w->live_pv_tiny_moves[i];
+    }
+    const uint64_t seq2 =
+        atomic_load_explicit(&w->live_pv_seq, memory_order_acquire);
+    if (seq1 == seq2) {
+      *out_value = value;
+      return len;
+    }
+  }
+  *out_value = 0;
+  return 0;
+}
+
 double endgame_ctx_get_current_depth_eta_fraction(const EndgameCtx *ctx) {
   int64_t started_ns;
   int64_t prev_ns;
@@ -890,6 +941,10 @@ static EndgameCtxWorker *endgame_ctx_create_worker(EndgameCtx *solver,
                         memory_order_relaxed);
   atomic_store_explicit(&solver_worker->current_line_len, 0,
                         memory_order_relaxed);
+  atomic_store_explicit(&solver_worker->live_pv_length, 0,
+                        memory_order_relaxed);
+  atomic_store_explicit(&solver_worker->live_pv_value, 0, memory_order_relaxed);
+  atomic_store_explicit(&solver_worker->live_pv_seq, 0, memory_order_relaxed);
 
   return solver_worker;
 }
@@ -916,6 +971,9 @@ static void endgame_ctx_reset_worker(EndgameCtxWorker *worker,
   atomic_store_explicit(&worker->published_nodes_searched, 0,
                         memory_order_relaxed);
   atomic_store_explicit(&worker->current_line_len, 0, memory_order_relaxed);
+  atomic_store_explicit(&worker->live_pv_length, 0, memory_order_relaxed);
+  atomic_store_explicit(&worker->live_pv_value, 0, memory_order_relaxed);
+  atomic_store_explicit(&worker->live_pv_seq, 0, memory_order_relaxed);
 }
 
 void endgame_ctx_reset_worker_and_game(EndgameCtx *solver, uint64_t base_seed,
@@ -2391,6 +2449,32 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
         pvline_update(pv, &child_pv, small_move,
                       best_value - worker->solver->initial_spread);
         pv->negamax_depth = child_pv.negamax_depth + 1;
+        // Live PV publish (root only): a polling reader sees the
+        // engine's evolving best line refine through each depth as
+        // root moves get evaluated. Seqlock pattern: bump seq odd to
+        // signal "writing", write moves+value+length, bump seq even
+        // to signal "consistent". Reader retries on odd / mismatched
+        // seq.
+        if (is_root) {
+          int new_len = pv->num_moves;
+          if (new_len > MAX_SEARCH_DEPTH) {
+            new_len = MAX_SEARCH_DEPTH;
+          }
+          const uint64_t seq_before =
+              atomic_load_explicit(&worker->live_pv_seq, memory_order_relaxed);
+          atomic_store_explicit(&worker->live_pv_seq, seq_before + 1,
+                                memory_order_release);
+          for (int i = 0; i < new_len; i++) {
+            worker->live_pv_tiny_moves[i] = pv->moves[i].tiny_move;
+          }
+          atomic_store_explicit(&worker->live_pv_length, new_len,
+                                memory_order_relaxed);
+          atomic_store_explicit(&worker->live_pv_value,
+                                best_value - worker->solver->initial_spread,
+                                memory_order_relaxed);
+          atomic_store_explicit(&worker->live_pv_seq, seq_before + 2,
+                                memory_order_release);
+        }
       }
       if (is_root) {
         // At the very top depth, set the estimated value of the small move,

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -153,6 +153,11 @@ struct EndgameCtx {
   EndgamePerPlyCallback per_ply_callback;
   void *per_ply_callback_data;
 
+  // Fired once from worker thread 0 after initial movegen and before
+  // depth-1 negamax. Lets clients render a d=0 leaderboard immediately.
+  EndgameBeforeSearchCallback before_search_callback;
+  void *before_search_callback_data;
+
   // Owned by the caller:
   EndgameResults *results;
   ThreadControl *thread_control;
@@ -647,6 +652,8 @@ void endgame_ctx_reset(EndgameCtx *es, EndgameResults *results,
   es->game = endgame_args->game;
   es->per_ply_callback = endgame_args->per_ply_callback;
   es->per_ply_callback_data = endgame_args->per_ply_callback_data;
+  es->before_search_callback = endgame_args->before_search_callback;
+  es->before_search_callback_data = endgame_args->before_search_callback_data;
   if (endgame_args->tt_fraction_of_mem == 0) {
     transposition_table_destroy(es->transposition_table);
     es->transposition_table = NULL;
@@ -2405,6 +2412,22 @@ void iterative_deepening(EndgameCtxWorker *worker, int plies) {
   worker->n_initial_moves = initial_move_count;
   assert((size_t)worker->small_move_arena->size ==
          initial_move_count * sizeof(SmallMove));
+
+  // Publish the d=0 root-move list to clients before any depth begins.
+  // root_moves_total is bumped here (rather than only at depth-loop entry)
+  // so the polled progress atomics agree with the callback's view of the
+  // candidate count even before depth-1 starts. Thread 0 only.
+  if (worker->thread_index == 0) {
+    atomic_store(&worker->solver->root_moves_total, initial_move_count);
+    if (worker->solver->before_search_callback) {
+      const SmallMove *initial_moves =
+          (const SmallMove *)worker->small_move_arena->memory;
+      worker->solver->before_search_callback(
+          worker->game_copy, initial_moves, initial_move_count,
+          worker->solver->initial_spread, worker->solver->solving_player,
+          worker->solver->before_search_callback_data);
+    }
+  }
 
   worker->current_iterative_deepening_depth = 1;
   int start = 1;

--- a/src/impl/endgame.h
+++ b/src/impl/endgame.h
@@ -160,37 +160,6 @@ uint64_t endgame_ctx_get_nodes_searched(const EndgameCtx *ctx);
 int endgame_ctx_get_current_line(const EndgameCtx *ctx, int thread_index,
                                  uint64_t *out_line, int max_len);
 
-// Live ETA data for callers that want to render a wall-clock progress
-// bar for the in-flight IDS depth.  All values are CLOCK_MONOTONIC ns.
-//
-//   *current_depth_started_ns  - timestamp when the engine entered the
-//                                current IDS depth. 0 if no depth has
-//                                begun yet (callable before search).
-//   *prev_completed_depth_ns   - duration of the most recently completed
-//                                IDS depth. 0 if no depth has completed.
-//   *prev_prev_completed_depth_ns - duration of the depth before that
-//                                (so callers can compute a 2-ply EBF
-//                                = prev / prev_prev, per-ply EBF
-//                                = sqrt of that).
-//
-// Suggested use: predicted_total_for_current_depth =
-// prev_completed_depth_ns * sqrt(prev / prev_prev). Fraction done =
-// (now - current_depth_started_ns) / predicted_total. Time-based
-// rather than node-based to avoid TT cache effects (an engine that
-// hits a hot TT runs faster per-node but doesn't get more wall-clock
-// done — the node count would mislead).
-void endgame_ctx_get_eta_data(const EndgameCtx *ctx,
-                              int64_t *current_depth_started_ns,
-                              int64_t *prev_completed_depth_ns,
-                              int64_t *prev_prev_completed_depth_ns);
-
-// Convenience: returns an estimated 0..1 fraction of the current IDS
-// depth's wall-clock done. Returns -1.0 if no estimate is possible
-// (first depth, or no depth has begun yet). Capped at 1.0 if the
-// search has overshot the prediction. Uses 2-ply EBF when available,
-// falls back to a fixed assumption otherwise.
-double endgame_ctx_get_current_depth_eta_fraction(const EndgameCtx *ctx);
-
 // Snapshot of the live best PV from worker `thread_index`. Updated by
 // the engine each time best_value improves at the root (so during a
 // long depth the reader can see the engine's best line refine as

--- a/src/impl/endgame.h
+++ b/src/impl/endgame.h
@@ -131,6 +131,12 @@ void endgame_solve(EndgameCtx **ctx, const EndgameArgs *endgame_args,
                    EndgameResults *results, ErrorStack *error_stack);
 const TranspositionTable *
 endgame_ctx_get_transposition_table(const EndgameCtx *ctx);
+// Reset (zero) the transposition table contents but keep the allocation.
+// Useful between unrelated solves on the same ctx when the caller wants
+// each solve to start from a cold cache without paying the realloc cost
+// (the cost is the same — a memset of the full TT — but no malloc/free).
+// No-op if the ctx has no TT (tt_fraction_of_mem == 0).
+void endgame_ctx_clear_transposition_table(EndgameCtx *ctx);
 void endgame_ctx_get_progress(const EndgameCtx *ctx, int *current_depth,
                               int *root_moves_completed, int *root_moves_total,
                               int *ply2_moves_completed, int *ply2_moves_total);

--- a/src/impl/endgame.h
+++ b/src/impl/endgame.h
@@ -191,4 +191,23 @@ void endgame_ctx_get_eta_data(const EndgameCtx *ctx,
 // falls back to a fixed assumption otherwise.
 double endgame_ctx_get_current_depth_eta_fraction(const EndgameCtx *ctx);
 
+// Snapshot of the live best PV from worker `thread_index`. Updated by
+// the engine each time best_value improves at the root (so during a
+// long depth the reader can see the engine's best line refine as
+// successive root moves get evaluated).
+//
+// Writes up to `max_len` `tiny_move` entries into `out_moves` and
+// returns the number written (0..max_len). `*out_value` is set to
+// the spread-adjusted PV value (same sign convention as
+// PVLine.score).
+//
+// Uses a seqlock so the moves array, length, and value all come
+// from the same writer update — never from a half-overwritten
+// state. If a consistent snapshot can't be obtained after a few
+// retries (writer continuously updating) returns 0 and *out_value=0;
+// callers should treat that as "no fresh PV this frame".
+int endgame_ctx_get_live_pv(const EndgameCtx *ctx, int thread_index,
+                            uint64_t *out_moves, int max_len,
+                            int32_t *out_value);
+
 #endif

--- a/src/impl/endgame.h
+++ b/src/impl/endgame.h
@@ -52,6 +52,29 @@ typedef void (*EndgameBeforeSearchCallback)(
     int initial_move_count, int initial_spread, int solving_player,
     void *user_data);
 
+// Callback fired each time a root move completes its negamax evaluation
+// at the current iterative-deepening depth, from worker thread 0 only.
+// Lets clients re-rank the leaderboard live (per-root resolution rather
+// than per-completed-depth) and watch values swing during long depths.
+//
+// Parameters:
+//   depth      - the IDS depth this completion is at (>= 1)
+//   root_index - index of the root move within the (currently sorted)
+//                root_moves array, 0..root_moves_total-1
+//   move       - the root move that just completed (caller must copy if
+//                it needs the value past callback return)
+//   value      - the negamax value of this root, in spread units
+//                (already adjusted by initial_spread; same sign convention
+//                as PVLine.score)
+//   user_data  - opaque
+//
+// Fires from inside abdada_negamax. Multiple per-root callbacks may
+// happen back-to-back at the same depth as roots complete in scan order.
+// Implementations must be thread-safe even though only thread 0 calls.
+typedef void (*EndgamePerRootMoveCallback)(int depth, int root_index,
+                                           const struct SmallMove *move,
+                                           int32_t value, void *user_data);
+
 typedef struct EndgameArgs {
   ThreadControl *thread_control;
   const Game *game;
@@ -67,6 +90,8 @@ typedef struct EndgameArgs {
   void *per_ply_callback_data;
   EndgameBeforeSearchCallback before_search_callback;
   void *before_search_callback_data;
+  EndgamePerRootMoveCallback per_root_move_callback;
+  void *per_root_move_callback_data;
   dual_lexicon_mode_t dual_lexicon_mode;
   // If true, play forced passes without consuming a depth ply (default: false)
   bool forced_pass_bypass;

--- a/src/impl/endgame.h
+++ b/src/impl/endgame.h
@@ -160,4 +160,35 @@ uint64_t endgame_ctx_get_nodes_searched(const EndgameCtx *ctx);
 int endgame_ctx_get_current_line(const EndgameCtx *ctx, int thread_index,
                                  uint64_t *out_line, int max_len);
 
+// Live ETA data for callers that want to render a wall-clock progress
+// bar for the in-flight IDS depth.  All values are CLOCK_MONOTONIC ns.
+//
+//   *current_depth_started_ns  - timestamp when the engine entered the
+//                                current IDS depth. 0 if no depth has
+//                                begun yet (callable before search).
+//   *prev_completed_depth_ns   - duration of the most recently completed
+//                                IDS depth. 0 if no depth has completed.
+//   *prev_prev_completed_depth_ns - duration of the depth before that
+//                                (so callers can compute a 2-ply EBF
+//                                = prev / prev_prev, per-ply EBF
+//                                = sqrt of that).
+//
+// Suggested use: predicted_total_for_current_depth =
+// prev_completed_depth_ns * sqrt(prev / prev_prev). Fraction done =
+// (now - current_depth_started_ns) / predicted_total. Time-based
+// rather than node-based to avoid TT cache effects (an engine that
+// hits a hot TT runs faster per-node but doesn't get more wall-clock
+// done — the node count would mislead).
+void endgame_ctx_get_eta_data(const EndgameCtx *ctx,
+                              int64_t *current_depth_started_ns,
+                              int64_t *prev_completed_depth_ns,
+                              int64_t *prev_prev_completed_depth_ns);
+
+// Convenience: returns an estimated 0..1 fraction of the current IDS
+// depth's wall-clock done. Returns -1.0 if no estimate is possible
+// (first depth, or no depth has begun yet). Capped at 1.0 if the
+// search has overshot the prediction. Uses 2-ply EBF when available,
+// falls back to a fixed assumption otherwise.
+double endgame_ctx_get_current_depth_eta_fraction(const EndgameCtx *ctx);
+
 #endif

--- a/src/impl/endgame.h
+++ b/src/impl/endgame.h
@@ -33,6 +33,25 @@ typedef void (*EndgamePerPlyCallback)(int depth, int32_t value,
                                       const struct PVLine *ranked_pvs,
                                       int num_ranked_pvs, void *user_data);
 
+// Callback fired once before iterative deepening begins. Provides the
+// d=0 root-move list (sorted descending by static estimate from
+// assign_estimates_and_sort), letting the caller render an initial
+// leaderboard before any depth completes. Fires from worker thread 0
+// after its initial-move generation finishes (sub-ms after
+// endgame_solve start) and before any negamax call. The polled
+// atomics (endgame_ctx_get_progress) are guaranteed to show
+// root_moves_total == initial_move_count and root_moves_completed == 0
+// at the moment this callback fires; current_depth is still 0.
+//
+// game is the worker's game copy (already in endgame_solving_mode);
+// initial_moves points into the worker's small_move_arena and is
+// valid only for the duration of the callback. Copy out anything
+// needed past callback return.
+typedef void (*EndgameBeforeSearchCallback)(
+    const struct Game *game, const struct SmallMove *initial_moves,
+    int initial_move_count, int initial_spread, int solving_player,
+    void *user_data);
+
 typedef struct EndgameArgs {
   ThreadControl *thread_control;
   const Game *game;
@@ -46,6 +65,8 @@ typedef struct EndgameArgs {
   int num_top_moves;
   EndgamePerPlyCallback per_ply_callback;
   void *per_ply_callback_data;
+  EndgameBeforeSearchCallback before_search_callback;
+  void *before_search_callback_data;
   dual_lexicon_mode_t dual_lexicon_mode;
   // If true, play forced passes without consuming a depth ply (default: false)
   bool forced_pass_bypass;

--- a/src/impl/endgame.h
+++ b/src/impl/endgame.h
@@ -141,4 +141,23 @@ void endgame_ctx_get_progress(const EndgameCtx *ctx, int *current_depth,
                               int *root_moves_completed, int *root_moves_total,
                               int *ply2_moves_completed, int *ply2_moves_total);
 
+// Sum of nodes searched across all worker threads, lagging by up to
+// DEPTH_DEADLINE_CHECK_INTERVAL nodes per thread (the period at which
+// each worker flushes its non-atomic local counter to the shared
+// atomic). Cheap to call from any thread; intended for "is the engine
+// alive / nodes per second" UI heartbeats during long single-root
+// subtree evaluations.
+uint64_t endgame_ctx_get_nodes_searched(const EndgameCtx *ctx);
+
+// Snapshot of the line currently being explored by worker thread
+// `thread_index`. Writes up to `max_len` `tiny_move` entries into
+// `out_line` and returns the number written (0..max_len). The line
+// reads thread-local state without locking; the reader uses
+// release/acquire on the length so the prefix length is always
+// consistent, but individual entries past the length may still be
+// torn if the worker is concurrently swapping into a sibling subtree.
+// For display only; never used to drive search decisions.
+int endgame_ctx_get_current_line(const EndgameCtx *ctx, int thread_index,
+                                 uint64_t *out_line, int max_len);
+
 #endif

--- a/src/impl/endgame.h
+++ b/src/impl/endgame.h
@@ -210,4 +210,31 @@ int endgame_ctx_get_live_pv(const EndgameCtx *ctx, int thread_index,
                             uint64_t *out_moves, int max_len,
                             int32_t *out_value);
 
+// One slot of the live multi-PV top-K leaderboard. root_tiny is the
+// first move (a SmallMove tiny_move); value is the spread-adjusted
+// negamax value (same sign convention as PVLine.score); continuation
+// is the rest of the line (depth - 1 moves at most), with
+// continuation_len in [0, MAX_SEARCH_DEPTH].
+typedef struct EndgameLivePvSnapshot {
+  uint64_t root_tiny;
+  int32_t value;
+  int continuation_len;
+  uint64_t continuation_tiny[MAX_SEARCH_DEPTH];
+} EndgameLivePvSnapshot;
+
+// Snapshot of the live multi-PV top-K leaderboard from worker
+// `thread_index`. Each slot in `out` is filled with one root move,
+// its current value, and the continuation line found at this depth.
+// Slots are sorted descending by value; the leaderboard is reset at
+// the start of each IDS depth and fills in as roots complete (so the
+// reader may see fewer than max_k entries early in a depth).
+//
+// Writes up to min(max_k, MAX_ENDGAME_DISPLAY_PVS, K_currently_filled)
+// entries and returns the number written. Uses a seqlock so a
+// snapshot is consistent (every entry came from the same writer
+// update). Returns 0 if a consistent snapshot can't be obtained
+// after a few retries.
+int endgame_ctx_get_live_top_k_pvs(const EndgameCtx *ctx, int thread_index,
+                                   EndgameLivePvSnapshot *out, int max_k);
+
 #endif

--- a/test/endgame_test.c
+++ b/test/endgame_test.c
@@ -1056,7 +1056,6 @@ static void *stream_reader_thread(void *arg) {
     uint64_t nodes = 0;
     uint64_t line[MAX_SEARCH_DEPTH];
     int line_len = 0;
-    double eta_fraction = -1.0;
     uint64_t live_pv[MAX_SEARCH_DEPTH];
     int live_pv_len = 0;
     int32_t live_pv_value = 0;
@@ -1067,7 +1066,6 @@ static void *stream_reader_thread(void *arg) {
                                &ply2_total);
       nodes = endgame_ctx_get_nodes_searched(ctx);
       line_len = endgame_ctx_get_current_line(ctx, 0, line, MAX_SEARCH_DEPTH);
-      eta_fraction = endgame_ctx_get_current_depth_eta_fraction(ctx);
       live_pv_len = endgame_ctx_get_live_pv(ctx, 0, live_pv, MAX_SEARCH_DEPTH,
                                             &live_pv_value);
       live_top_k_n = endgame_ctx_get_live_top_k_pvs(ctx, 0, live_top_k, 10);
@@ -1152,13 +1150,6 @@ static void *stream_reader_thread(void *arg) {
     // from worker thread 0. Either alone is enough to prove the engine
     // is alive during a long single-root subtree where no other signal
     // updates.
-    char eta_str[32];
-    if (eta_fraction < 0.0) {
-      snprintf(eta_str, sizeof(eta_str), "depth_eta=--");
-    } else {
-      snprintf(eta_str, sizeof(eta_str), "depth_eta=%2.0f%%",
-               eta_fraction * 100.0);
-    }
     char pv_str[256];
     int pv_written = 0;
     pv_written +=
@@ -1190,23 +1181,22 @@ static void *stream_reader_thread(void *arg) {
     snprintf(topk_str + topk_written, sizeof(topk_str) - topk_written, "}");
 
     if (s->mode == STREAM_MODE_POLL_PLY2) {
-      printf("%s | ply2 %d/%d | %.0fk nps | %s | t0_line %s | "
+      printf("%s | ply2 %d/%d | %.0fk nps | t0_line %s | "
              "live_pv val=%d %s | top_k %s\n",
-             prefix, ply2_done, ply2_total, knodes_per_sec, eta_str, line_str,
+             prefix, ply2_done, ply2_total, knodes_per_sec, line_str,
              live_pv_value, pv_str, topk_str);
     } else {
       if (per_root_calls == 0) {
-        printf("%s | per_root: 0 calls | %.0fk nps | %s | t0_line %s | "
+        printf("%s | per_root: 0 calls | %.0fk nps | t0_line %s | "
                "live_pv val=%d %s | top_k %s\n",
-               prefix, knodes_per_sec, eta_str, line_str, live_pv_value, pv_str,
+               prefix, knodes_per_sec, line_str, live_pv_value, pv_str,
                topk_str);
       } else {
         printf("%s | per_root: %d calls, last d%d idx=%d val=%d tiny=0x%llx | "
-               "%.0fk nps | %s | t0_line %s | live_pv val=%d %s | top_k %s\n",
+               "%.0fk nps | t0_line %s | live_pv val=%d %s | top_k %s\n",
                prefix, per_root_calls, last_root_depth, last_root_idx,
                last_root_value, (unsigned long long)last_root_tiny,
-               knodes_per_sec, eta_str, line_str, live_pv_value, pv_str,
-               topk_str);
+               knodes_per_sec, line_str, live_pv_value, pv_str, topk_str);
       }
     }
     (void)fflush(stdout);

--- a/test/endgame_test.c
+++ b/test/endgame_test.c
@@ -1222,6 +1222,13 @@ void test_endgame_progress_stream(void) {
         args.per_root_move_callback_data = &stream;
       }
 
+      // Clear the TT before each timed iteration so each one searches
+      // from a cold cache. This costs a 2GB memset (~200ms) on this
+      // host but happens BEFORE the reader thread is spawned and before
+      // the timer is started by the d=0 callback, so it isn't counted
+      // in any displayed elapsed time.
+      endgame_ctx_clear_transposition_table(ctx);
+
       cpthread_t reader;
       cpthread_create(&reader, stream_reader_thread, &stream);
 

--- a/test/endgame_test.c
+++ b/test/endgame_test.c
@@ -11,6 +11,7 @@
 #include "../src/ent/player.h"
 #include "../src/ent/rack.h"
 #include "../src/ent/thread_control.h"
+#include "../src/ent/xoshiro.h"
 #include "../src/impl/config.h"
 #include "../src/impl/endgame.h"
 #include "../src/impl/gameplay.h"
@@ -23,6 +24,7 @@
 #include "test_constants.h"
 #include "test_util.h"
 #include <assert.h>
+#include <stdatomic.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -803,6 +805,315 @@ void test_topk_no_duplicates(void) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// before_search_callback tests
+// ---------------------------------------------------------------------------
+
+typedef struct BeforeSearchCaptured {
+  int call_count;
+  int initial_move_count;
+  int initial_spread;
+  int solving_player;
+  // first move's tiny_move + estimated_value (lets us verify the array is
+  // sorted descending by static estimate at the moment of firing)
+  uint64_t first_move_tiny;
+  int32_t first_move_estimate;
+  // sortedness check across all received moves
+  bool sorted_desc_by_estimate;
+} BeforeSearchCaptured;
+
+static void capture_before_search_cb(const Game *game,
+                                     const SmallMove *initial_moves,
+                                     int initial_move_count, int initial_spread,
+                                     int solving_player, void *user_data) {
+  (void)game;
+  BeforeSearchCaptured *c = (BeforeSearchCaptured *)user_data;
+  c->call_count++;
+  c->initial_move_count = initial_move_count;
+  c->initial_spread = initial_spread;
+  c->solving_player = solving_player;
+  if (initial_move_count > 0) {
+    c->first_move_tiny = initial_moves[0].tiny_move;
+    c->first_move_estimate = small_move_get_estimated_value(&initial_moves[0]);
+  }
+  c->sorted_desc_by_estimate = true;
+  for (int i = 1; i < initial_move_count; i++) {
+    if (small_move_get_estimated_value(&initial_moves[i]) >
+        small_move_get_estimated_value(&initial_moves[i - 1])) {
+      c->sorted_desc_by_estimate = false;
+      break;
+    }
+  }
+}
+
+// Asserts the new before_search_callback fires exactly once per solve, with
+// initial_move_count > 0, sorted descending by estimated_value, and that the
+// polled progress atomics show root_moves_total == initial_move_count and
+// root_moves_completed == 0 immediately at callback time (so a UI polling
+// the atomics can render a coherent d=0 leaderboard from the same snapshot
+// the callback delivered).
+static atomic_int g_atomic_check_state_total;
+static atomic_int g_atomic_check_state_completed;
+static atomic_int g_atomic_check_state_depth;
+static EndgameCtx **g_atomic_check_ctx_pp;
+
+static void capture_and_poll_before_search_cb(
+    const Game *game, const SmallMove *initial_moves, int initial_move_count,
+    int initial_spread, int solving_player, void *user_data) {
+  capture_before_search_cb(game, initial_moves, initial_move_count,
+                           initial_spread, solving_player, user_data);
+  // Poll the public progress atomics from inside the callback so we can
+  // assert UI-visible state agrees with the callback args at the same
+  // moment in time.
+  int cur_depth = 0;
+  int done = 0;
+  int total = 0;
+  int dummy_a = 0;
+  int dummy_b = 0;
+  endgame_ctx_get_progress(*g_atomic_check_ctx_pp, &cur_depth, &done, &total,
+                           &dummy_a, &dummy_b);
+  atomic_store(&g_atomic_check_state_depth, cur_depth);
+  atomic_store(&g_atomic_check_state_completed, done);
+  atomic_store(&g_atomic_check_state_total, total);
+}
+
+void test_before_search_callback(void) {
+  Config *config = config_create_or_die("set -s1 score -s2 score");
+  load_and_exec_config_or_die(
+      config, "cgp 9A1PIXY/9S1L3/2ToWNLETS1O3/9U1DA1R/3GERANIAL1U1I/9g2T1C/"
+              "8WE2OBI/6EMU4ON/6AID3GO1/5HUN4ET1/4ZA1T4ME1/1Q1FAKEY3JOES/"
+              "FIVE1E5IT1C/5SPORRAN2A/6ORE2N2D BGIV/DEHILOR 384/389 0 "
+              "-lex NWL20");
+
+  EndgameCtx *ctx = NULL;
+  BeforeSearchCaptured captured = {0};
+  atomic_store(&g_atomic_check_state_total, -1);
+  atomic_store(&g_atomic_check_state_completed, -1);
+  atomic_store(&g_atomic_check_state_depth, -1);
+  g_atomic_check_ctx_pp = &ctx;
+
+  EndgameArgs args = {0};
+  args.thread_control = config_get_thread_control(config);
+  args.game = config_get_game(config);
+  args.plies = 3;
+  args.tt_fraction_of_mem = config_get_tt_fraction_of_mem(config);
+  args.initial_small_move_arena_size = DEFAULT_INITIAL_SMALL_MOVE_ARENA_SIZE;
+  args.num_threads = 4;
+  args.num_top_moves = 1;
+  args.use_heuristics = true;
+  args.forced_pass_bypass = true;
+  args.enable_iterative_deepening = true;
+  args.enable_pv_display = true;
+  args.seed = 42;
+  args.before_search_callback = capture_and_poll_before_search_cb;
+  args.before_search_callback_data = &captured;
+
+  EndgameResults *results = config_get_endgame_results(config);
+  ErrorStack *error_stack = error_stack_create();
+  endgame_solve(&ctx, &args, results, error_stack);
+  assert(error_stack_is_empty(error_stack));
+
+  assert(captured.call_count == 1);
+  assert(captured.initial_move_count > 0);
+  assert(captured.solving_player == 0);
+  assert(captured.first_move_tiny != 0); // not PASS at slot 0
+  assert(captured.sorted_desc_by_estimate);
+
+  // Polled atomics seen from inside the callback must match the callback's
+  // own view of the candidate count, with no prior depth started.
+  const int polled_total = atomic_load(&g_atomic_check_state_total);
+  const int polled_completed = atomic_load(&g_atomic_check_state_completed);
+  const int polled_depth = atomic_load(&g_atomic_check_state_depth);
+  assert(polled_total == captured.initial_move_count);
+  assert(polled_completed == 0);
+  assert(polled_depth == 0);
+
+  endgame_ctx_destroy(ctx);
+  error_stack_destroy(error_stack);
+  config_destroy(config);
+}
+
+// ---------------------------------------------------------------------------
+// On-demand: streaming-progress test
+// ---------------------------------------------------------------------------
+
+// Shared state between the main solver thread and the reader/printer thread.
+// All cross-thread fields are either atomic_* or guarded by `mutex`.
+typedef struct ProgressStream {
+  EndgameCtx **ctx_pp;        // populated by endgame_solve when it creates ctx
+  cpthread_mutex_t mutex;     // guards completed-depth snapshot fields below
+  bool seen_initial;          // before_search_callback has fired
+  int last_completed_depth;   // most recent per_ply_callback's depth (0 = none)
+  int32_t last_completed_val; // and value
+  int initial_move_count;     // from before_search_callback
+  int64_t solve_start_ns;
+  atomic_int should_stop; // main thread sets to 1 when endgame_solve returns
+  int frames_printed;     // bumped by the reader; used so we can verify
+                          // the test actually streamed something
+} ProgressStream;
+
+static void stream_before_search_cb(const Game *game,
+                                    const SmallMove *initial_moves,
+                                    int initial_move_count, int initial_spread,
+                                    int solving_player, void *user_data) {
+  (void)game;
+  (void)initial_moves;
+  (void)initial_spread;
+  (void)solving_player;
+  ProgressStream *s = (ProgressStream *)user_data;
+  cpthread_mutex_lock(&s->mutex);
+  s->seen_initial = true;
+  s->initial_move_count = initial_move_count;
+  cpthread_mutex_unlock(&s->mutex);
+}
+
+static void stream_per_ply_cb(int depth, int32_t value,
+                              const struct PVLine *pv_line,
+                              const struct Game *game,
+                              const struct PVLine *ranked_pvs,
+                              int num_ranked_pvs, void *user_data) {
+  (void)pv_line;
+  (void)game;
+  (void)ranked_pvs;
+  (void)num_ranked_pvs;
+  ProgressStream *s = (ProgressStream *)user_data;
+  cpthread_mutex_lock(&s->mutex);
+  s->last_completed_depth = depth;
+  s->last_completed_val = value;
+  cpthread_mutex_unlock(&s->mutex);
+}
+
+static void *stream_reader_thread(void *arg) {
+  ProgressStream *s = (ProgressStream *)arg;
+  while (!atomic_load(&s->should_stop)) {
+    const EndgameCtx *ctx = *s->ctx_pp;
+    cpthread_mutex_lock(&s->mutex);
+    const bool seen_initial = s->seen_initial;
+    const int last_depth = s->last_completed_depth;
+    const int32_t last_val = s->last_completed_val;
+    const int initial_count = s->initial_move_count;
+    cpthread_mutex_unlock(&s->mutex);
+
+    int cur_depth = 0;
+    int done = 0;
+    int total = 0;
+    int dummy_a = 0;
+    int dummy_b = 0;
+    if (ctx != NULL) {
+      endgame_ctx_get_progress(ctx, &cur_depth, &done, &total, &dummy_a,
+                               &dummy_b);
+    }
+    const double elapsed_ms =
+        (double)(ctimer_monotonic_ns() - s->solve_start_ns) / 1.0e6;
+    if (!seen_initial) {
+      printf("  [%6.0fms] (waiting for d=0 callback)\n", elapsed_ms);
+    } else if (last_depth == 0) {
+      printf("  [%6.0fms] d=0 published (n=%d) "
+             "cur_depth=%d searching %d/%d\n",
+             elapsed_ms, initial_count, cur_depth, done, total);
+    } else {
+      printf("  [%6.0fms] last_completed=d%d val=%d "
+             "cur_depth=%d searching %d/%d\n",
+             elapsed_ms, last_depth, last_val, cur_depth, done, total);
+    }
+    (void)fflush(stdout);
+    s->frames_printed++;
+    ctime_nap(0.016); // ~60fps
+  }
+  return NULL;
+}
+
+void test_endgame_progress_stream(void) {
+  // Hand-picked positions tuned so each solve runs for ~1-3 seconds with
+  // multiple completed depths visible in the stream.  Don't crank
+  // eplies higher: deep searches on a wide root (n>500) blow past 30s
+  // per iteration and the test stops being useful as a demo.
+  static const struct {
+    const char *cgp;
+    const char *lex;
+    int eplies;
+  } positions[] = {
+      // Tight 7-tile endgame, ~60-100 root moves, completes through d=5
+      // quickly enough to show many depth transitions in the stream.
+      {"9A1PIXY/9S1L3/2ToWNLETS1O3/9U1DA1R/3GERANIAL1U1I/9g2T1C/8WE2OBI/"
+       "6EMU4ON/6AID3GO1/5HUN4ET1/4ZA1T4ME1/1Q1FAKEY3JOES/FIVE1E5IT1C/"
+       "5SPORRAN2A/6ORE2N2D BGIV/DEHILOR 384/389 0",
+       "NWL20", 6},
+      // Stuck-tile (Z) position, asymmetric racks, slower per-ply.
+      {"GATELEGs1POGOED/R4MOOLI3X1/AA10U2/YU4BREDRIN2/1TITULE3E1IN1/"
+       "1E4N3c1BOK/1C2O4CHARD1/QI1FLAWN2E1OE1/IS2E1HIN1A1W2/"
+       "1MOTIVATE1T1S2/1S2N5S4/3PERJURY5/15/15/15 FV/AADIZ 442/388 0",
+       "CSW21", 5},
+  };
+  static const int npos = (int)(sizeof(positions) / sizeof(positions[0]));
+  static const int kIterations = 4;
+
+  // Use system time for "random". Each run picks a different
+  // (position, threads, plies) tuple per iteration.
+  XoshiroPRNG *prng = prng_create((uint64_t)ctime_get_current_time());
+
+  for (int iter = 0; iter < kIterations; iter++) {
+    const int pos_idx = (int)prng_get_random_number(prng, (uint64_t)npos);
+    const int threads = 2 + (int)prng_get_random_number(prng, 5); // 2..6
+
+    Config *config = config_create_or_die("set -s1 score -s2 score");
+    char cmd[1024];
+    snprintf(cmd, sizeof(cmd), "cgp %s -lex %s", positions[pos_idx].cgp,
+             positions[pos_idx].lex);
+    load_and_exec_config_or_die(config, cmd);
+
+    printf("\n=== iter %d/%d: pos=%d threads=%d plies=%d lex=%s ===\n",
+           iter + 1, kIterations, pos_idx, threads, positions[pos_idx].eplies,
+           positions[pos_idx].lex);
+
+    EndgameCtx *ctx = NULL;
+    ProgressStream stream = {0};
+    cpthread_mutex_init(&stream.mutex);
+    atomic_store(&stream.should_stop, 0);
+    stream.ctx_pp = &ctx;
+    stream.solve_start_ns = ctimer_monotonic_ns();
+
+    EndgameArgs args = {0};
+    args.thread_control = config_get_thread_control(config);
+    args.game = config_get_game(config);
+    args.plies = positions[pos_idx].eplies;
+    args.tt_fraction_of_mem = config_get_tt_fraction_of_mem(config);
+    args.initial_small_move_arena_size = DEFAULT_INITIAL_SMALL_MOVE_ARENA_SIZE;
+    args.num_threads = threads;
+    args.num_top_moves = 5;
+    args.use_heuristics = true;
+    args.forced_pass_bypass = true;
+    args.enable_iterative_deepening = true;
+    args.enable_pv_display = true;
+    args.seed = 42;
+    args.before_search_callback = stream_before_search_cb;
+    args.before_search_callback_data = &stream;
+    args.per_ply_callback = stream_per_ply_cb;
+    args.per_ply_callback_data = &stream;
+
+    cpthread_t reader;
+    cpthread_create(&reader, stream_reader_thread, &stream);
+
+    EndgameResults *results = config_get_endgame_results(config);
+    ErrorStack *error_stack = error_stack_create();
+    endgame_solve(&ctx, &args, results, error_stack);
+    assert(error_stack_is_empty(error_stack));
+
+    atomic_store(&stream.should_stop, 1);
+    cpthread_join(reader);
+
+    printf("  [done] frames_printed=%d final_completed_depth=%d\n",
+           stream.frames_printed, stream.last_completed_depth);
+    assert(stream.frames_printed > 0);
+    assert(stream.seen_initial);
+
+    endgame_ctx_destroy(ctx);
+    error_stack_destroy(error_stack);
+    config_destroy(config);
+  }
+  prng_destroy(prng);
+}
+
 void test_endgame(void) {
   test_single_pv_display();
   test_ctx_reuse();
@@ -818,6 +1129,10 @@ void test_endgame(void) {
   test_topk_fully_solved();
   test_topk_full_solve_no_pipe();
   test_topk_no_duplicates();
+  test_before_search_callback();
+  // test_endgame_progress_stream is on-demand (registered as
+  // "endgame_stream"); it prints live progress to stdout and isn't
+  // suitable for the silent CI run.
   //  Uncomment out more of these tests once we add more optimizations,
   //  and/or if we can run the endgame tests in release mode.
   // test_vs_joey();

--- a/test/endgame_test.c
+++ b/test/endgame_test.c
@@ -972,6 +972,8 @@ typedef struct ProgressStream {
   int frames_printed;       // bumped by the reader; used so we can verify
                             // the test actually streamed something
   int live_pv_change_count; // distinct live PVs the reader observed
+  int live_top_k_change_count; // distinct top-K snapshots observed
+  uint64_t last_topk_hash;     // hash of last top-K snapshot seen
 } ProgressStream;
 
 static void stream_before_search_cb(const Game *game,
@@ -1058,6 +1060,8 @@ static void *stream_reader_thread(void *arg) {
     uint64_t live_pv[MAX_SEARCH_DEPTH];
     int live_pv_len = 0;
     int32_t live_pv_value = 0;
+    EndgameLivePvSnapshot live_top_k[10];
+    int live_top_k_n = 0;
     if (ctx != NULL) {
       endgame_ctx_get_progress(ctx, &cur_depth, &done, &total, &ply2_done,
                                &ply2_total);
@@ -1066,6 +1070,7 @@ static void *stream_reader_thread(void *arg) {
       eta_fraction = endgame_ctx_get_current_depth_eta_fraction(ctx);
       live_pv_len = endgame_ctx_get_live_pv(ctx, 0, live_pv, MAX_SEARCH_DEPTH,
                                             &live_pv_value);
+      live_top_k_n = endgame_ctx_get_live_top_k_pvs(ctx, 0, live_top_k, 10);
     }
     // Hash the live PV (length + moves + value) so we can count the
     // number of distinct snapshots seen by the reader. This isn't the
@@ -1081,6 +1086,23 @@ static void *stream_reader_thread(void *arg) {
       live_pv_change_count++;
       last_pv_hash = pv_hash;
       s->live_pv_change_count = live_pv_change_count;
+    }
+    // Hash the multi-PV top-K snapshot (length + each entry's
+    // root_tiny + value + continuation) to count how often the
+    // observable leaderboard changes between polls.
+    uint64_t topk_hash = (uint64_t)live_top_k_n * 0x9E3779B97F4A7C15ULL;
+    for (int i = 0; i < live_top_k_n; i++) {
+      topk_hash ^=
+          live_top_k[i].root_tiny + (topk_hash << 6) + (topk_hash >> 2);
+      topk_hash ^= (uint64_t)(uint32_t)live_top_k[i].value;
+      for (int j = 0; j < live_top_k[i].continuation_len; j++) {
+        topk_hash ^= live_top_k[i].continuation_tiny[j] + (topk_hash << 6) +
+                     (topk_hash >> 2);
+      }
+    }
+    if (topk_hash != s->last_topk_hash) {
+      s->live_top_k_change_count++;
+      s->last_topk_hash = topk_hash;
     }
     const int64_t now_ns = ctimer_monotonic_ns();
     double knodes_per_sec = 0.0;
@@ -1149,23 +1171,42 @@ static void *stream_reader_thread(void *arg) {
     }
     snprintf(pv_str + pv_written, sizeof(pv_str) - pv_written, "]");
 
+    // Compact "top-K" tail: show first-move tiny + value for each slot,
+    // then "+continuation_len" for the longest continuation. Reader
+    // verifies the leaderboard fills in as roots complete.
+    char topk_str[128];
+    int topk_written = 0;
+    topk_written +=
+        snprintf(topk_str + topk_written, sizeof(topk_str) - topk_written,
+                 "%d{", live_top_k_n);
+    for (int i = 0;
+         i < live_top_k_n && topk_written < (int)sizeof(topk_str) - 32; i++) {
+      topk_written +=
+          snprintf(topk_str + topk_written, sizeof(topk_str) - topk_written,
+                   "%s0x%llx=%d+%d", i == 0 ? "" : ",",
+                   (unsigned long long)live_top_k[i].root_tiny,
+                   live_top_k[i].value, live_top_k[i].continuation_len);
+    }
+    snprintf(topk_str + topk_written, sizeof(topk_str) - topk_written, "}");
+
     if (s->mode == STREAM_MODE_POLL_PLY2) {
       printf("%s | ply2 %d/%d | %.0fk nps | %s | t0_line %s | "
-             "live_pv val=%d %s\n",
+             "live_pv val=%d %s | top_k %s\n",
              prefix, ply2_done, ply2_total, knodes_per_sec, eta_str, line_str,
-             live_pv_value, pv_str);
+             live_pv_value, pv_str, topk_str);
     } else {
       if (per_root_calls == 0) {
         printf("%s | per_root: 0 calls | %.0fk nps | %s | t0_line %s | "
-               "live_pv val=%d %s\n",
-               prefix, knodes_per_sec, eta_str, line_str, live_pv_value,
-               pv_str);
+               "live_pv val=%d %s | top_k %s\n",
+               prefix, knodes_per_sec, eta_str, line_str, live_pv_value, pv_str,
+               topk_str);
       } else {
         printf("%s | per_root: %d calls, last d%d idx=%d val=%d tiny=0x%llx | "
-               "%.0fk nps | %s | t0_line %s | live_pv val=%d %s\n",
+               "%.0fk nps | %s | t0_line %s | live_pv val=%d %s | top_k %s\n",
                prefix, per_root_calls, last_root_depth, last_root_idx,
                last_root_value, (unsigned long long)last_root_tiny,
-               knodes_per_sec, eta_str, line_str, live_pv_value, pv_str);
+               knodes_per_sec, eta_str, line_str, live_pv_value, pv_str,
+               topk_str);
       }
     }
     (void)fflush(stdout);
@@ -1319,9 +1360,11 @@ void test_endgame_progress_stream(void) {
       cpthread_join(reader);
 
       printf("  [done] frames_printed=%d final_completed_depth=%d "
-             "per_root_calls=%d live_pv_changes=%d\n",
+             "per_root_calls=%d live_pv_changes=%d "
+             "live_top_k_changes=%d\n",
              stream.frames_printed, stream.last_completed_depth,
-             stream.per_root_calls, stream.live_pv_change_count);
+             stream.per_root_calls, stream.live_pv_change_count,
+             stream.live_top_k_change_count);
       assert(stream.frames_printed > 0);
       assert(stream.seen_initial);
       if (mode == STREAM_MODE_CALLBACK_PER_ROOT) {

--- a/test/endgame_test.c
+++ b/test/endgame_test.c
@@ -968,9 +968,10 @@ typedef struct ProgressStream {
   uint64_t last_root_tiny;
   int per_root_calls;
   int64_t solve_start_ns;
-  atomic_int should_stop; // main thread sets to 1 when endgame_solve returns
-  int frames_printed;     // bumped by the reader; used so we can verify
-                          // the test actually streamed something
+  atomic_int should_stop;   // main thread sets to 1 when endgame_solve returns
+  int frames_printed;       // bumped by the reader; used so we can verify
+                            // the test actually streamed something
+  int live_pv_change_count; // distinct live PVs the reader observed
 } ProgressStream;
 
 static void stream_before_search_cb(const Game *game,
@@ -1026,6 +1027,10 @@ static void *stream_reader_thread(void *arg) {
   ProgressStream *s = (ProgressStream *)arg;
   uint64_t prev_nodes = 0;
   int64_t prev_nodes_ns = 0;
+  // Track how often the live PV's content actually changes between
+  // poll frames (not just the seqlock seq, the displayed bytes).
+  uint64_t last_pv_hash = 0;
+  int live_pv_change_count = 0;
   while (!atomic_load(&s->should_stop)) {
     const EndgameCtx *ctx = *s->ctx_pp;
     cpthread_mutex_lock(&s->mutex);
@@ -1050,12 +1055,32 @@ static void *stream_reader_thread(void *arg) {
     uint64_t line[MAX_SEARCH_DEPTH];
     int line_len = 0;
     double eta_fraction = -1.0;
+    uint64_t live_pv[MAX_SEARCH_DEPTH];
+    int live_pv_len = 0;
+    int32_t live_pv_value = 0;
     if (ctx != NULL) {
       endgame_ctx_get_progress(ctx, &cur_depth, &done, &total, &ply2_done,
                                &ply2_total);
       nodes = endgame_ctx_get_nodes_searched(ctx);
       line_len = endgame_ctx_get_current_line(ctx, 0, line, MAX_SEARCH_DEPTH);
       eta_fraction = endgame_ctx_get_current_depth_eta_fraction(ctx);
+      live_pv_len = endgame_ctx_get_live_pv(ctx, 0, live_pv, MAX_SEARCH_DEPTH,
+                                            &live_pv_value);
+    }
+    // Hash the live PV (length + moves + value) so we can count the
+    // number of distinct snapshots seen by the reader. This isn't the
+    // engine-side update count — it's "how often a polling display
+    // would observe a change."
+    uint64_t pv_hash = (uint64_t)live_pv_len * 0x9E3779B97F4A7C15ULL;
+    for (int i = 0; i < live_pv_len; i++) {
+      pv_hash ^=
+          live_pv[i] + 0x9E3779B97F4A7C15ULL + (pv_hash << 6) + (pv_hash >> 2);
+    }
+    pv_hash ^= (uint64_t)(uint32_t)live_pv_value;
+    if (pv_hash != last_pv_hash) {
+      live_pv_change_count++;
+      last_pv_hash = pv_hash;
+      s->live_pv_change_count = live_pv_change_count;
     }
     const int64_t now_ns = ctimer_monotonic_ns();
     double knodes_per_sec = 0.0;
@@ -1112,19 +1137,35 @@ static void *stream_reader_thread(void *arg) {
       snprintf(eta_str, sizeof(eta_str), "depth_eta=%2.0f%%",
                eta_fraction * 100.0);
     }
+    char pv_str[256];
+    int pv_written = 0;
+    pv_written +=
+        snprintf(pv_str + pv_written, sizeof(pv_str) - pv_written, "[");
+    for (int i = 0; i < live_pv_len && pv_written < (int)sizeof(pv_str) - 32;
+         i++) {
+      pv_written +=
+          snprintf(pv_str + pv_written, sizeof(pv_str) - pv_written, "%s0x%llx",
+                   i == 0 ? "" : ",", (unsigned long long)live_pv[i]);
+    }
+    snprintf(pv_str + pv_written, sizeof(pv_str) - pv_written, "]");
+
     if (s->mode == STREAM_MODE_POLL_PLY2) {
-      printf("%s | ply2 %d/%d | %.0fk nps | %s | t0_line %s\n", prefix,
-             ply2_done, ply2_total, knodes_per_sec, eta_str, line_str);
+      printf("%s | ply2 %d/%d | %.0fk nps | %s | t0_line %s | "
+             "live_pv val=%d %s\n",
+             prefix, ply2_done, ply2_total, knodes_per_sec, eta_str, line_str,
+             live_pv_value, pv_str);
     } else {
       if (per_root_calls == 0) {
-        printf("%s | per_root: 0 calls | %.0fk nps | %s | t0_line %s\n", prefix,
-               knodes_per_sec, eta_str, line_str);
+        printf("%s | per_root: 0 calls | %.0fk nps | %s | t0_line %s | "
+               "live_pv val=%d %s\n",
+               prefix, knodes_per_sec, eta_str, line_str, live_pv_value,
+               pv_str);
       } else {
         printf("%s | per_root: %d calls, last d%d idx=%d val=%d tiny=0x%llx | "
-               "%.0fk nps | %s | t0_line %s\n",
+               "%.0fk nps | %s | t0_line %s | live_pv val=%d %s\n",
                prefix, per_root_calls, last_root_depth, last_root_idx,
                last_root_value, (unsigned long long)last_root_tiny,
-               knodes_per_sec, eta_str, line_str);
+               knodes_per_sec, eta_str, line_str, live_pv_value, pv_str);
       }
     }
     (void)fflush(stdout);
@@ -1278,9 +1319,9 @@ void test_endgame_progress_stream(void) {
       cpthread_join(reader);
 
       printf("  [done] frames_printed=%d final_completed_depth=%d "
-             "per_root_calls=%d\n",
+             "per_root_calls=%d live_pv_changes=%d\n",
              stream.frames_printed, stream.last_completed_depth,
-             stream.per_root_calls);
+             stream.per_root_calls, stream.live_pv_change_count);
       assert(stream.frames_printed > 0);
       assert(stream.seen_initial);
       if (mode == STREAM_MODE_CALLBACK_PER_ROOT) {

--- a/test/endgame_test.c
+++ b/test/endgame_test.c
@@ -1049,11 +1049,13 @@ static void *stream_reader_thread(void *arg) {
     uint64_t nodes = 0;
     uint64_t line[MAX_SEARCH_DEPTH];
     int line_len = 0;
+    double eta_fraction = -1.0;
     if (ctx != NULL) {
       endgame_ctx_get_progress(ctx, &cur_depth, &done, &total, &ply2_done,
                                &ply2_total);
       nodes = endgame_ctx_get_nodes_searched(ctx);
       line_len = endgame_ctx_get_current_line(ctx, 0, line, MAX_SEARCH_DEPTH);
+      eta_fraction = endgame_ctx_get_current_depth_eta_fraction(ctx);
     }
     const int64_t now_ns = ctimer_monotonic_ns();
     double knodes_per_sec = 0.0;
@@ -1103,19 +1105,26 @@ static void *stream_reader_thread(void *arg) {
     // from worker thread 0. Either alone is enough to prove the engine
     // is alive during a long single-root subtree where no other signal
     // updates.
+    char eta_str[32];
+    if (eta_fraction < 0.0) {
+      snprintf(eta_str, sizeof(eta_str), "depth_eta=--");
+    } else {
+      snprintf(eta_str, sizeof(eta_str), "depth_eta=%2.0f%%",
+               eta_fraction * 100.0);
+    }
     if (s->mode == STREAM_MODE_POLL_PLY2) {
-      printf("%s | ply2 %d/%d | %.0fk nps | t0_line %s\n", prefix, ply2_done,
-             ply2_total, knodes_per_sec, line_str);
+      printf("%s | ply2 %d/%d | %.0fk nps | %s | t0_line %s\n", prefix,
+             ply2_done, ply2_total, knodes_per_sec, eta_str, line_str);
     } else {
       if (per_root_calls == 0) {
-        printf("%s | per_root: 0 calls | %.0fk nps | t0_line %s\n", prefix,
-               knodes_per_sec, line_str);
+        printf("%s | per_root: 0 calls | %.0fk nps | %s | t0_line %s\n", prefix,
+               knodes_per_sec, eta_str, line_str);
       } else {
         printf("%s | per_root: %d calls, last d%d idx=%d val=%d tiny=0x%llx | "
-               "%.0fk nps | t0_line %s\n",
+               "%.0fk nps | %s | t0_line %s\n",
                prefix, per_root_calls, last_root_depth, last_root_idx,
                last_root_value, (unsigned long long)last_root_tiny,
-               knodes_per_sec, line_str);
+               knodes_per_sec, eta_str, line_str);
       }
     }
     (void)fflush(stdout);

--- a/test/endgame_test.c
+++ b/test/endgame_test.c
@@ -985,6 +985,11 @@ static void stream_before_search_cb(const Game *game,
   cpthread_mutex_lock(&s->mutex);
   s->seen_initial = true;
   s->initial_move_count = initial_move_count;
+  // Start the elapsed-time clock here. Per-iteration setup before this
+  // point (TT memset, KWG pruning, worker pool spinup) is bookkeeping
+  // the user doesn't care about; only "time spent on actual estimates
+  // and search" is interesting to display.
+  s->solve_start_ns = ctimer_monotonic_ns();
   cpthread_mutex_unlock(&s->mutex);
 }
 
@@ -1031,6 +1036,7 @@ static void *stream_reader_thread(void *arg) {
     const int32_t last_root_value = s->last_root_value;
     const uint64_t last_root_tiny = s->last_root_tiny;
     const int per_root_calls = s->per_root_calls;
+    const int64_t solve_start_ns = s->solve_start_ns;
     cpthread_mutex_unlock(&s->mutex);
 
     int cur_depth = 0;
@@ -1042,24 +1048,29 @@ static void *stream_reader_thread(void *arg) {
       endgame_ctx_get_progress(ctx, &cur_depth, &done, &total, &ply2_done,
                                &ply2_total);
     }
-    const double elapsed_ms =
-        (double)(ctimer_monotonic_ns() - s->solve_start_ns) / 1.0e6;
 
     // Common prefix: timing + d=0 status + last completed depth + root
-    // counter. Mode-specific suffix appended below.
+    // counter. Mode-specific suffix appended below.  Pre-d=0 frames have
+    // no meaningful elapsed value (the timer is started by the d=0
+    // callback to exclude setup overhead like TT allocation).
     char prefix[160];
     if (!seen_initial) {
-      snprintf(prefix, sizeof(prefix), "  [%6.0fms] (waiting for d=0 callback)",
-               elapsed_ms);
-    } else if (last_depth == 0) {
       snprintf(prefix, sizeof(prefix),
-               "  [%6.0fms] d=0 published (n=%d) cur_depth=%d searching %d/%d",
-               elapsed_ms, initial_count, cur_depth, done, total);
+               "  [    --ms] (waiting for d=0 callback)");
     } else {
-      snprintf(prefix, sizeof(prefix),
-               "  [%6.0fms] last_completed=d%d val=%d "
-               "cur_depth=%d searching %d/%d",
-               elapsed_ms, last_depth, last_val, cur_depth, done, total);
+      const double elapsed_ms =
+          (double)(ctimer_monotonic_ns() - solve_start_ns) / 1.0e6;
+      if (last_depth == 0) {
+        snprintf(
+            prefix, sizeof(prefix),
+            "  [%6.0fms] d=0 published (n=%d) cur_depth=%d searching %d/%d",
+            elapsed_ms, initial_count, cur_depth, done, total);
+      } else {
+        snprintf(prefix, sizeof(prefix),
+                 "  [%6.0fms] last_completed=d%d val=%d "
+                 "cur_depth=%d searching %d/%d",
+                 elapsed_ms, last_depth, last_val, cur_depth, done, total);
+      }
     }
 
     if (s->mode == STREAM_MODE_POLL_PLY2) {
@@ -1119,6 +1130,46 @@ void test_endgame_progress_stream(void) {
   // exercises every combination.)
   XoshiroPRNG *prng = prng_create((uint64_t)ctime_get_current_time());
 
+  // Allocate the EndgameCtx (and its transposition table) once, outside
+  // the iteration loop. Subsequent iterations reuse it, so the
+  // ~200ms one-off TT memset doesn't get counted into per-iteration
+  // streaming output. The elapsed-time clock in each iteration is
+  // started by stream_before_search_cb, so even the first iteration's
+  // streaming numbers exclude setup overhead.
+  EndgameCtx *ctx = NULL;
+  {
+    // Warmup: one quick solve with eplies=1 to force ctx + TT allocation.
+    // Its stream output is suppressed (no reader thread); we just care
+    // about getting the TT on the heap.
+    Config *warmup_config = config_create_or_die("set -s1 score -s2 score");
+    char warmup_cmd[1024];
+    snprintf(warmup_cmd, sizeof(warmup_cmd), "cgp %s -lex %s", positions[0].cgp,
+             positions[0].lex);
+    load_and_exec_config_or_die(warmup_config, warmup_cmd);
+    EndgameArgs warmup_args = {0};
+    warmup_args.thread_control = config_get_thread_control(warmup_config);
+    warmup_args.game = config_get_game(warmup_config);
+    warmup_args.plies = 1;
+    warmup_args.tt_fraction_of_mem =
+        config_get_tt_fraction_of_mem(warmup_config);
+    warmup_args.initial_small_move_arena_size =
+        DEFAULT_INITIAL_SMALL_MOVE_ARENA_SIZE;
+    warmup_args.num_threads = 1;
+    warmup_args.num_top_moves = 1;
+    warmup_args.use_heuristics = true;
+    warmup_args.forced_pass_bypass = true;
+    warmup_args.enable_iterative_deepening = true;
+    warmup_args.enable_pv_display = true;
+    warmup_args.seed = 1;
+    EndgameResults *warmup_results = config_get_endgame_results(warmup_config);
+    ErrorStack *warmup_err = error_stack_create();
+    endgame_solve(&ctx, &warmup_args, warmup_results, warmup_err);
+    assert(error_stack_is_empty(warmup_err));
+    error_stack_destroy(warmup_err);
+    config_destroy(warmup_config);
+    printf("(warmup complete; TT pre-allocated)\n");
+  }
+
   const int kIterations = npos * nmodes;
   int iter = 0;
   for (int pos_idx = 0; pos_idx < npos; pos_idx++) {
@@ -1138,13 +1189,12 @@ void test_endgame_progress_stream(void) {
           iter, kIterations, pos_idx, mode_labels[mode_idx], threads,
           positions[pos_idx].eplies, positions[pos_idx].lex);
 
-      EndgameCtx *ctx = NULL;
       ProgressStream stream = {0};
       cpthread_mutex_init(&stream.mutex);
       atomic_store(&stream.should_stop, 0);
       stream.ctx_pp = &ctx;
       stream.mode = mode;
-      stream.solve_start_ns = ctimer_monotonic_ns();
+      // solve_start_ns will be filled in by stream_before_search_cb.
 
       EndgameArgs args = {0};
       args.thread_control = config_get_thread_control(config);
@@ -1194,11 +1244,11 @@ void test_endgame_progress_stream(void) {
         assert(stream.per_root_calls >= stream.last_completed_depth);
       }
 
-      endgame_ctx_destroy(ctx);
       error_stack_destroy(error_stack);
       config_destroy(config);
     }
   }
+  endgame_ctx_destroy(ctx);
   prng_destroy(prng);
 }
 

--- a/test/endgame_test.c
+++ b/test/endgame_test.c
@@ -1024,6 +1024,8 @@ static void stream_per_root_cb(int depth, int root_index,
 
 static void *stream_reader_thread(void *arg) {
   ProgressStream *s = (ProgressStream *)arg;
+  uint64_t prev_nodes = 0;
+  int64_t prev_nodes_ns = 0;
   while (!atomic_load(&s->should_stop)) {
     const EndgameCtx *ctx = *s->ctx_pp;
     cpthread_mutex_lock(&s->mutex);
@@ -1044,10 +1046,23 @@ static void *stream_reader_thread(void *arg) {
     int total = 0;
     int ply2_done = 0;
     int ply2_total = 0;
+    uint64_t nodes = 0;
+    uint64_t line[MAX_SEARCH_DEPTH];
+    int line_len = 0;
     if (ctx != NULL) {
       endgame_ctx_get_progress(ctx, &cur_depth, &done, &total, &ply2_done,
                                &ply2_total);
+      nodes = endgame_ctx_get_nodes_searched(ctx);
+      line_len = endgame_ctx_get_current_line(ctx, 0, line, MAX_SEARCH_DEPTH);
     }
+    const int64_t now_ns = ctimer_monotonic_ns();
+    double knodes_per_sec = 0.0;
+    if (prev_nodes_ns > 0 && now_ns > prev_nodes_ns && nodes >= prev_nodes) {
+      knodes_per_sec = (double)(nodes - prev_nodes) /
+                       ((double)(now_ns - prev_nodes_ns) / 1.0e6);
+    }
+    prev_nodes = nodes;
+    prev_nodes_ns = now_ns;
 
     // Common prefix: timing + d=0 status + last completed depth + root
     // counter. Mode-specific suffix appended below.  Pre-d=0 frames have
@@ -1058,8 +1073,7 @@ static void *stream_reader_thread(void *arg) {
       snprintf(prefix, sizeof(prefix),
                "  [    --ms] (waiting for d=0 callback)");
     } else {
-      const double elapsed_ms =
-          (double)(ctimer_monotonic_ns() - solve_start_ns) / 1.0e6;
+      const double elapsed_ms = (double)(now_ns - solve_start_ns) / 1.0e6;
       if (last_depth == 0) {
         snprintf(
             prefix, sizeof(prefix),
@@ -1073,21 +1087,35 @@ static void *stream_reader_thread(void *arg) {
       }
     }
 
+    // Format the live current-line as comma-separated tiny_moves.
+    char line_str[256];
+    int written = 0;
+    written += snprintf(line_str + written, sizeof(line_str) - written, "[");
+    for (int i = 0; i < line_len && written < (int)sizeof(line_str) - 32; i++) {
+      written +=
+          snprintf(line_str + written, sizeof(line_str) - written, "%s0x%llx",
+                   i == 0 ? "" : ",", (unsigned long long)line[i]);
+    }
+    snprintf(line_str + written, sizeof(line_str) - written, "]");
+
+    // Always-on signals appended to every frame: nodes/sec (smoothed
+    // across the last poll interval) and the live current-line snapshot
+    // from worker thread 0. Either alone is enough to prove the engine
+    // is alive during a long single-root subtree where no other signal
+    // updates.
     if (s->mode == STREAM_MODE_POLL_PLY2) {
-      // Sub-progress under root #1: child A out of L children.
-      // Reset by the engine each time root #1's depth begins.
-      printf("%s | ply2 %d/%d\n", prefix, ply2_done, ply2_total);
+      printf("%s | ply2 %d/%d | %.0fk nps | t0_line %s\n", prefix, ply2_done,
+             ply2_total, knodes_per_sec, line_str);
     } else {
-      // Per-root callback: cumulative count + last root completion seen.
-      // last_root_idx is the position in the *currently sorted* root_moves
-      // array at the time of completion, which can swap as values come in.
       if (per_root_calls == 0) {
-        printf("%s | per_root: 0 calls\n", prefix);
+        printf("%s | per_root: 0 calls | %.0fk nps | t0_line %s\n", prefix,
+               knodes_per_sec, line_str);
       } else {
-        printf("%s | per_root: %d calls, last d%d idx=%d val=%d "
-               "tiny=0x%llx\n",
+        printf("%s | per_root: %d calls, last d%d idx=%d val=%d tiny=0x%llx | "
+               "%.0fk nps | t0_line %s\n",
                prefix, per_root_calls, last_root_depth, last_root_idx,
-               last_root_value, (unsigned long long)last_root_tiny);
+               last_root_value, (unsigned long long)last_root_tiny,
+               knodes_per_sec, line_str);
       }
     }
     (void)fflush(stdout);
@@ -1257,6 +1285,60 @@ void test_endgame_progress_stream(void) {
   }
   endgame_ctx_destroy(ctx);
   prng_destroy(prng);
+}
+
+// Tight, search-bound benchmark: run the kue position at depth 4 N
+// times in a row on a single warmed EndgameCtx.  Prints wall-clock and
+// nodes/sec.  Used to measure the cost of always-on engine
+// instrumentation (node counter + current-line) by comparing builds
+// with and without it.
+void test_endgame_bench_kue(void) {
+  static const int kIterations = 5;
+  static const int kPlies = 4;
+
+  Config *config = config_create_or_die("set -s1 score -s2 score");
+  load_and_exec_config_or_die(
+      config, "cgp 6MOO1VIRLS/1EJECTA6A1/2I2AEON4R1/2BAH6X1N1/2SLID4GIFTS/"
+              "4DONG1OR1R1i/7HOURLY1Z/FE4DINT1A2Y/RECLINE2I1N3/"
+              "EW1ATAP2E1G3/M10U3/D3PATOOTIE3/15/15/15 "
+              "?AEEKSU/BEIQUVW 276/321 0 -lex NWL23");
+
+  EndgameCtx *ctx = NULL;
+  EndgameArgs args = {0};
+  args.thread_control = config_get_thread_control(config);
+  args.game = config_get_game(config);
+  args.plies = kPlies;
+  args.tt_fraction_of_mem = config_get_tt_fraction_of_mem(config);
+  args.initial_small_move_arena_size = DEFAULT_INITIAL_SMALL_MOVE_ARENA_SIZE;
+  args.num_threads = 4;
+  args.num_top_moves = 1;
+  args.use_heuristics = true;
+  args.forced_pass_bypass = true;
+  args.enable_iterative_deepening = true;
+  args.enable_pv_display = false;
+  args.seed = 42;
+
+  EndgameResults *results = config_get_endgame_results(config);
+  ErrorStack *error_stack = error_stack_create();
+
+  // Warmup so the TT is allocated outside the timed iterations.
+  endgame_solve(&ctx, &args, results, error_stack);
+  assert(error_stack_is_empty(error_stack));
+
+  for (int i = 0; i < kIterations; i++) {
+    endgame_ctx_clear_transposition_table(ctx);
+    const int64_t t0 = ctimer_monotonic_ns();
+    endgame_solve(&ctx, &args, results, error_stack);
+    assert(error_stack_is_empty(error_stack));
+    const int64_t t1 = ctimer_monotonic_ns();
+    const double elapsed_s = (double)(t1 - t0) / 1.0e9;
+    printf("BENCH iter=%d plies=%d threads=%d elapsed=%.3fs\n", i, kPlies,
+           args.num_threads, elapsed_s);
+  }
+
+  endgame_ctx_destroy(ctx);
+  error_stack_destroy(error_stack);
+  config_destroy(config);
 }
 
 void test_endgame(void) {

--- a/test/endgame_test.c
+++ b/test/endgame_test.c
@@ -937,15 +937,36 @@ void test_before_search_callback(void) {
 // On-demand: streaming-progress test
 // ---------------------------------------------------------------------------
 
+// Two streaming modes for the on-demand demo. Both share the same
+// reader/printer thread; the difference is which signal source the
+// reader includes in each frame.
+typedef enum {
+  // Poll the ply2 atomics that are already exposed by
+  // endgame_ctx_get_progress. Adds intra-root sub-progress for the
+  // first root move's children.
+  STREAM_MODE_POLL_PLY2,
+  // Use the per_root_move_callback to track the last root completed.
+  // Gives per-root resolution across the whole top level, so the
+  // reader can describe live root-by-root completions.
+  STREAM_MODE_CALLBACK_PER_ROOT,
+} StreamMode;
+
 // Shared state between the main solver thread and the reader/printer thread.
 // All cross-thread fields are either atomic_* or guarded by `mutex`.
 typedef struct ProgressStream {
   EndgameCtx **ctx_pp;        // populated by endgame_solve when it creates ctx
-  cpthread_mutex_t mutex;     // guards completed-depth snapshot fields below
+  StreamMode mode;            // selects which signal the reader prints
+  cpthread_mutex_t mutex;     // guards the snapshot fields below
   bool seen_initial;          // before_search_callback has fired
   int last_completed_depth;   // most recent per_ply_callback's depth (0 = none)
   int32_t last_completed_val; // and value
   int initial_move_count;     // from before_search_callback
+  // Per-root callback snapshot (mode == STREAM_MODE_CALLBACK_PER_ROOT)
+  int last_root_depth;
+  int last_root_idx;
+  int32_t last_root_value;
+  uint64_t last_root_tiny;
+  int per_root_calls;
   int64_t solve_start_ns;
   atomic_int should_stop; // main thread sets to 1 when endgame_solve returns
   int frames_printed;     // bumped by the reader; used so we can verify
@@ -983,6 +1004,19 @@ static void stream_per_ply_cb(int depth, int32_t value,
   cpthread_mutex_unlock(&s->mutex);
 }
 
+static void stream_per_root_cb(int depth, int root_index,
+                               const struct SmallMove *move, int32_t value,
+                               void *user_data) {
+  ProgressStream *s = (ProgressStream *)user_data;
+  cpthread_mutex_lock(&s->mutex);
+  s->last_root_depth = depth;
+  s->last_root_idx = root_index;
+  s->last_root_value = value;
+  s->last_root_tiny = move->tiny_move;
+  s->per_root_calls++;
+  cpthread_mutex_unlock(&s->mutex);
+}
+
 static void *stream_reader_thread(void *arg) {
   ProgressStream *s = (ProgressStream *)arg;
   while (!atomic_load(&s->should_stop)) {
@@ -992,29 +1026,58 @@ static void *stream_reader_thread(void *arg) {
     const int last_depth = s->last_completed_depth;
     const int32_t last_val = s->last_completed_val;
     const int initial_count = s->initial_move_count;
+    const int last_root_depth = s->last_root_depth;
+    const int last_root_idx = s->last_root_idx;
+    const int32_t last_root_value = s->last_root_value;
+    const uint64_t last_root_tiny = s->last_root_tiny;
+    const int per_root_calls = s->per_root_calls;
     cpthread_mutex_unlock(&s->mutex);
 
     int cur_depth = 0;
     int done = 0;
     int total = 0;
-    int dummy_a = 0;
-    int dummy_b = 0;
+    int ply2_done = 0;
+    int ply2_total = 0;
     if (ctx != NULL) {
-      endgame_ctx_get_progress(ctx, &cur_depth, &done, &total, &dummy_a,
-                               &dummy_b);
+      endgame_ctx_get_progress(ctx, &cur_depth, &done, &total, &ply2_done,
+                               &ply2_total);
     }
     const double elapsed_ms =
         (double)(ctimer_monotonic_ns() - s->solve_start_ns) / 1.0e6;
+
+    // Common prefix: timing + d=0 status + last completed depth + root
+    // counter. Mode-specific suffix appended below.
+    char prefix[160];
     if (!seen_initial) {
-      printf("  [%6.0fms] (waiting for d=0 callback)\n", elapsed_ms);
+      snprintf(prefix, sizeof(prefix), "  [%6.0fms] (waiting for d=0 callback)",
+               elapsed_ms);
     } else if (last_depth == 0) {
-      printf("  [%6.0fms] d=0 published (n=%d) "
-             "cur_depth=%d searching %d/%d\n",
-             elapsed_ms, initial_count, cur_depth, done, total);
+      snprintf(prefix, sizeof(prefix),
+               "  [%6.0fms] d=0 published (n=%d) cur_depth=%d searching %d/%d",
+               elapsed_ms, initial_count, cur_depth, done, total);
     } else {
-      printf("  [%6.0fms] last_completed=d%d val=%d "
-             "cur_depth=%d searching %d/%d\n",
-             elapsed_ms, last_depth, last_val, cur_depth, done, total);
+      snprintf(prefix, sizeof(prefix),
+               "  [%6.0fms] last_completed=d%d val=%d "
+               "cur_depth=%d searching %d/%d",
+               elapsed_ms, last_depth, last_val, cur_depth, done, total);
+    }
+
+    if (s->mode == STREAM_MODE_POLL_PLY2) {
+      // Sub-progress under root #1: child A out of L children.
+      // Reset by the engine each time root #1's depth begins.
+      printf("%s | ply2 %d/%d\n", prefix, ply2_done, ply2_total);
+    } else {
+      // Per-root callback: cumulative count + last root completion seen.
+      // last_root_idx is the position in the *currently sorted* root_moves
+      // array at the time of completion, which can swap as values come in.
+      if (per_root_calls == 0) {
+        printf("%s | per_root: 0 calls\n", prefix);
+      } else {
+        printf("%s | per_root: %d calls, last d%d idx=%d val=%d "
+               "tiny=0x%llx\n",
+               prefix, per_root_calls, last_root_depth, last_root_idx,
+               last_root_value, (unsigned long long)last_root_tiny);
+      }
     }
     (void)fflush(stdout);
     s->frames_printed++;
@@ -1046,70 +1109,95 @@ void test_endgame_progress_stream(void) {
        "CSW21", 5},
   };
   static const int npos = (int)(sizeof(positions) / sizeof(positions[0]));
-  static const int kIterations = 4;
+  static const StreamMode modes[] = {STREAM_MODE_POLL_PLY2,
+                                     STREAM_MODE_CALLBACK_PER_ROOT};
+  static const int nmodes = (int)(sizeof(modes) / sizeof(modes[0]));
+  static const char *mode_labels[] = {"poll_ply2", "callback_per_root"};
 
-  // Use system time for "random". Each run picks a different
-  // (position, threads, plies) tuple per iteration.
+  // Use system time as the RNG seed only for choosing thread counts.
+  // (Position and mode are cycled deterministically so the test always
+  // exercises every combination.)
   XoshiroPRNG *prng = prng_create((uint64_t)ctime_get_current_time());
 
-  for (int iter = 0; iter < kIterations; iter++) {
-    const int pos_idx = (int)prng_get_random_number(prng, (uint64_t)npos);
-    const int threads = 2 + (int)prng_get_random_number(prng, 5); // 2..6
+  const int kIterations = npos * nmodes;
+  int iter = 0;
+  for (int pos_idx = 0; pos_idx < npos; pos_idx++) {
+    for (int mode_idx = 0; mode_idx < nmodes; mode_idx++) {
+      iter++;
+      const int threads = 2 + (int)prng_get_random_number(prng, 5); // 2..6
+      const StreamMode mode = modes[mode_idx];
 
-    Config *config = config_create_or_die("set -s1 score -s2 score");
-    char cmd[1024];
-    snprintf(cmd, sizeof(cmd), "cgp %s -lex %s", positions[pos_idx].cgp,
-             positions[pos_idx].lex);
-    load_and_exec_config_or_die(config, cmd);
+      Config *config = config_create_or_die("set -s1 score -s2 score");
+      char cmd[1024];
+      snprintf(cmd, sizeof(cmd), "cgp %s -lex %s", positions[pos_idx].cgp,
+               positions[pos_idx].lex);
+      load_and_exec_config_or_die(config, cmd);
 
-    printf("\n=== iter %d/%d: pos=%d threads=%d plies=%d lex=%s ===\n",
-           iter + 1, kIterations, pos_idx, threads, positions[pos_idx].eplies,
-           positions[pos_idx].lex);
+      printf(
+          "\n=== iter %d/%d: pos=%d mode=%s threads=%d plies=%d lex=%s ===\n",
+          iter, kIterations, pos_idx, mode_labels[mode_idx], threads,
+          positions[pos_idx].eplies, positions[pos_idx].lex);
 
-    EndgameCtx *ctx = NULL;
-    ProgressStream stream = {0};
-    cpthread_mutex_init(&stream.mutex);
-    atomic_store(&stream.should_stop, 0);
-    stream.ctx_pp = &ctx;
-    stream.solve_start_ns = ctimer_monotonic_ns();
+      EndgameCtx *ctx = NULL;
+      ProgressStream stream = {0};
+      cpthread_mutex_init(&stream.mutex);
+      atomic_store(&stream.should_stop, 0);
+      stream.ctx_pp = &ctx;
+      stream.mode = mode;
+      stream.solve_start_ns = ctimer_monotonic_ns();
 
-    EndgameArgs args = {0};
-    args.thread_control = config_get_thread_control(config);
-    args.game = config_get_game(config);
-    args.plies = positions[pos_idx].eplies;
-    args.tt_fraction_of_mem = config_get_tt_fraction_of_mem(config);
-    args.initial_small_move_arena_size = DEFAULT_INITIAL_SMALL_MOVE_ARENA_SIZE;
-    args.num_threads = threads;
-    args.num_top_moves = 5;
-    args.use_heuristics = true;
-    args.forced_pass_bypass = true;
-    args.enable_iterative_deepening = true;
-    args.enable_pv_display = true;
-    args.seed = 42;
-    args.before_search_callback = stream_before_search_cb;
-    args.before_search_callback_data = &stream;
-    args.per_ply_callback = stream_per_ply_cb;
-    args.per_ply_callback_data = &stream;
+      EndgameArgs args = {0};
+      args.thread_control = config_get_thread_control(config);
+      args.game = config_get_game(config);
+      args.plies = positions[pos_idx].eplies;
+      args.tt_fraction_of_mem = config_get_tt_fraction_of_mem(config);
+      args.initial_small_move_arena_size =
+          DEFAULT_INITIAL_SMALL_MOVE_ARENA_SIZE;
+      args.num_threads = threads;
+      args.num_top_moves = 5;
+      args.use_heuristics = true;
+      args.forced_pass_bypass = true;
+      args.enable_iterative_deepening = true;
+      args.enable_pv_display = true;
+      args.seed = 42;
+      args.before_search_callback = stream_before_search_cb;
+      args.before_search_callback_data = &stream;
+      args.per_ply_callback = stream_per_ply_cb;
+      args.per_ply_callback_data = &stream;
+      // Only install the per-root callback when the mode actually wants it,
+      // so each mode runs with only its own signal active and the comparison
+      // is honest.
+      if (mode == STREAM_MODE_CALLBACK_PER_ROOT) {
+        args.per_root_move_callback = stream_per_root_cb;
+        args.per_root_move_callback_data = &stream;
+      }
 
-    cpthread_t reader;
-    cpthread_create(&reader, stream_reader_thread, &stream);
+      cpthread_t reader;
+      cpthread_create(&reader, stream_reader_thread, &stream);
 
-    EndgameResults *results = config_get_endgame_results(config);
-    ErrorStack *error_stack = error_stack_create();
-    endgame_solve(&ctx, &args, results, error_stack);
-    assert(error_stack_is_empty(error_stack));
+      EndgameResults *results = config_get_endgame_results(config);
+      ErrorStack *error_stack = error_stack_create();
+      endgame_solve(&ctx, &args, results, error_stack);
+      assert(error_stack_is_empty(error_stack));
 
-    atomic_store(&stream.should_stop, 1);
-    cpthread_join(reader);
+      atomic_store(&stream.should_stop, 1);
+      cpthread_join(reader);
 
-    printf("  [done] frames_printed=%d final_completed_depth=%d\n",
-           stream.frames_printed, stream.last_completed_depth);
-    assert(stream.frames_printed > 0);
-    assert(stream.seen_initial);
+      printf("  [done] frames_printed=%d final_completed_depth=%d "
+             "per_root_calls=%d\n",
+             stream.frames_printed, stream.last_completed_depth,
+             stream.per_root_calls);
+      assert(stream.frames_printed > 0);
+      assert(stream.seen_initial);
+      if (mode == STREAM_MODE_CALLBACK_PER_ROOT) {
+        // Should fire at least once per completed depth.
+        assert(stream.per_root_calls >= stream.last_completed_depth);
+      }
 
-    endgame_ctx_destroy(ctx);
-    error_stack_destroy(error_stack);
-    config_destroy(config);
+      endgame_ctx_destroy(ctx);
+      error_stack_destroy(error_stack);
+      config_destroy(config);
+    }
   }
   prng_destroy(prng);
 }

--- a/test/endgame_test.h
+++ b/test/endgame_test.h
@@ -10,5 +10,6 @@ void test_monster_q(void);
 void test_topk50_overflow_repro(void);
 void test_topk_no_duplicates(void);
 void test_endgame_progress_stream(void);
+void test_endgame_bench_kue(void);
 
 #endif

--- a/test/endgame_test.h
+++ b/test/endgame_test.h
@@ -9,5 +9,6 @@ void test_eldar_v_stick(void);
 void test_monster_q(void);
 void test_topk50_overflow_repro(void);
 void test_topk_no_duplicates(void);
+void test_endgame_progress_stream(void);
 
 #endif

--- a/test/test.c
+++ b/test/test.c
@@ -144,6 +144,7 @@ static TestEntry on_demand_test_table[] = {
     {"monsterq", test_monster_q},
     {"topk50repro", test_topk50_overflow_repro},
     {"topk_dup_repro", test_topk_no_duplicates},
+    {"endgame_stream", test_endgame_progress_stream},
     {"simbench", test_sim_benchmark},
     {"ap_rit", test_autoplay_rit_correctness},
     {NULL, NULL} // Sentinel value to mark end of array

--- a/test/test.c
+++ b/test/test.c
@@ -145,6 +145,7 @@ static TestEntry on_demand_test_table[] = {
     {"topk50repro", test_topk50_overflow_repro},
     {"topk_dup_repro", test_topk_no_duplicates},
     {"endgame_stream", test_endgame_progress_stream},
+    {"endgame_bench_kue", test_endgame_bench_kue},
     {"simbench", test_sim_benchmark},
     {"ap_rit", test_autoplay_rit_correctness},
     {NULL, NULL} // Sentinel value to mark end of array


### PR DESCRIPTION
## Summary

- Adds `EndgameBeforeSearchCallback` to `EndgameArgs`. Fires once from worker thread 0 right after its initial movegen and before any depth-1 negamax. Provides the d=0 root-move list (sorted descending by static estimate from `assign_estimates_and_sort`) plus initial spread + solving player.
- `root_moves_total` is now stored at the same point, so the existing `endgame_ctx_get_progress` atomics agree with the callback's view continuously instead of briefly showing `total=0` between the callback firing and depth-1 entry.

This is the engine-side groundwork for a forthcoming TUI live-progress patch: lets clients render an initial leaderboard within the first render frame instead of staring at stale data until depth-1 completes.

The post-solve etopk walk-down re-search is intentionally untouched.

### Stacking

Branched off `etopk_full_solve` (#530); PR base is set to that branch so the diff shows only this change. Will rebase onto main once #530 lands.

## Test plan

New tests:

- **`test_before_search_callback`** (in `test_endgame()`, ~0.4s): asserts the callback fires exactly once per solve, `initial_move_count > 0`, sorted descending by `estimated_value`, `solving_player == 0`, and that `endgame_ctx_get_progress` polled from inside the callback returns `(depth=0, completed=0, total=initial_move_count)` — i.e. UI-visible state agrees with callback args at the same moment in time.

- **`test_endgame_progress_stream`** (on-demand: `./bin/magpie_test endgame_stream`, ~3s): runs 4 random multithreaded solves with a separate reader/printer pthread polling `endgame_ctx_get_progress` at ~60fps. Per-frame stdout output:

  ```
  === iter 1/4: pos=0 threads=2 plies=6 lex=NWL20 ===
    [     0ms] (waiting for d=0 callback)
    [    24ms] (waiting for d=0 callback)
    ...
    [   277ms] d=0 published (n=63) cur_depth=1 searching 63/63
    [   314ms] last_completed=d1 val=14 cur_depth=2 searching 17/63
    [   338ms] last_completed=d1 val=14 cur_depth=2 searching 63/63
    [   362ms] last_completed=d2 val=11 cur_depth=3 searching 63/63
    ...
    [done] frames_printed=25 final_completed_depth=5
  ```

  Demonstrates the streaming-progress contract end-to-end: the reader sees \"waiting for d=0\" first, then the callback's snapshot, then per-depth advances and the polled completion fraction inside each depth — all from a separate thread.

- [x] `make magpie_test BUILD=release` clean
- [x] `./bin/magpie_test endgame` (full suite, 13.1s, includes new CI test)
- [x] `./bin/magpie_test endgame_stream` (on-demand, 2.7s, 126 progress frames printed)
- [x] `python3 format.py --write` clean
- [x] `./cppcheck.sh` clean
- [x] `python3 find_circ_deps.py` no cycles
- [x] `./tidy.sh` no new warnings on touched files (pre-existing macOS env errors only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)