### PR TITLE
Allow fractional -tlim (sim time budget in seconds)

### DIFF
--- a/src/def/bai_defs.h
+++ b/src/def/bai_defs.h
@@ -26,7 +26,7 @@ typedef struct BAIOptions {
   double delta;
   uint64_t sample_limit;
   uint64_t sample_minimum;
-  uint64_t time_limit_seconds;
+  double time_limit_seconds;
   int num_threads;
   int parent_worker_thread_index;
   double cutoff;

--- a/src/ent/bai_result.c
+++ b/src/ent/bai_result.c
@@ -11,11 +11,11 @@ struct BAIResult {
   bai_result_status_t status;
   int best_arm;
   Timer timer;
-  uint64_t time_limit_seconds;
+  double time_limit_seconds;
   cpthread_mutex_t mutex;
 };
 
-void bai_result_reset(BAIResult *bai_result, uint64_t time_limit_seconds) {
+void bai_result_reset(BAIResult *bai_result, double time_limit_seconds) {
   bai_result->status = BAI_RESULT_STATUS_NONE;
   bai_result->best_arm = -1;
   bai_result->time_limit_seconds = time_limit_seconds;
@@ -49,7 +49,7 @@ void bai_result_stop_timer(BAIResult *bai_result) {
   ctimer_stop(&bai_result->timer);
 }
 
-uint64_t bai_result_get_time_limit_seconds(const BAIResult *bai_result) {
+double bai_result_get_time_limit_seconds(const BAIResult *bai_result) {
   return bai_result->time_limit_seconds;
 }
 
@@ -62,7 +62,7 @@ bai_result_status_t bai_result_set_and_get_status(BAIResult *bai_result,
       bai_result->status = BAI_RESULT_STATUS_USER_INTERRUPT;
     } else if (bai_result->time_limit_seconds > 0 &&
                bai_result_get_elapsed_seconds(bai_result) >=
-                   (double)bai_result->time_limit_seconds) {
+                   bai_result->time_limit_seconds) {
       bai_result->status = BAI_RESULT_STATUS_TIMEOUT;
     }
   }

--- a/src/ent/bai_result.h
+++ b/src/ent/bai_result.h
@@ -15,7 +15,7 @@ typedef enum {
 
 typedef struct BAIResult BAIResult;
 
-void bai_result_reset(BAIResult *bai_result, uint64_t time_limit_seconds);
+void bai_result_reset(BAIResult *bai_result, double time_limit_seconds);
 BAIResult *bai_result_create(void);
 void bai_result_destroy(BAIResult *bai_result);
 void bai_result_set_best_arm(BAIResult *bai_result, int best_arm);
@@ -27,6 +27,6 @@ bai_result_status_t bai_result_set_and_get_status(BAIResult *bai_result,
                                                   bool user_interrupt);
 double bai_result_get_elapsed_seconds(const BAIResult *bai_result);
 void bai_result_stop_timer(BAIResult *bai_result);
-uint64_t bai_result_get_time_limit_seconds(const BAIResult *bai_result);
+double bai_result_get_time_limit_seconds(const BAIResult *bai_result);
 
 #endif

--- a/src/ent/sim_args.h
+++ b/src/ent/sim_args.h
@@ -41,7 +41,7 @@ sim_args_fill(const int num_plies, const MoveList *move_list,
               const int max_num_display_plays, const int max_num_display_plies,
               const uint64_t seed, const uint64_t max_iterations,
               const uint64_t min_play_iterations, const double scond,
-              const bai_threshold_t threshold, const int time_limit_seconds,
+              const bai_threshold_t threshold, const double time_limit_seconds,
               const bai_sampling_rule_t sampling_rule, const double cutoff,
               const InferenceArgs *inference_args, SimArgs *sim_args) {
   sim_args->num_plies = num_plies;

--- a/src/impl/config.c
+++ b/src/impl/config.c
@@ -266,7 +266,7 @@ struct Config {
   char *record_filepath;
   char *settings_filename;
   double tt_fraction_of_mem;
-  int time_limit_seconds;
+  double time_limit_seconds;
   int num_threads;
   int print_interval;
   uint64_t seed;
@@ -285,8 +285,8 @@ struct Config {
   uint64_t p2_min_play_iterations;
   bool p1_sim_with_inference;
   bool p2_sim_with_inference;
-  int p1_time_limit_seconds;
-  int p2_time_limit_seconds;
+  double p1_time_limit_seconds;
+  double p2_time_limit_seconds;
   bai_threshold_t p1_threshold;
   bai_threshold_t p2_threshold;
   bai_sampling_rule_t p1_sampling_rule;
@@ -1602,8 +1602,9 @@ void add_help_arg_to_string_builder(const Config *config, int token,
     case ARG_TOKEN_TIME_LIMIT:
       usages[0] = "<time_limit>";
       examples[0] = "10";
-      examples[1] = "30";
-      text = "Specifies the time limit in seconds for simulations.";
+      examples[1] = "0.05";
+      text = "Specifies the time limit in seconds for simulations. "
+             "Fractional values (e.g. 0.05 for 50 ms) are supported.";
       break;
     case ARG_TOKEN_SAMPLING_RULE:
       usages[0] = "<sampling_rule>";
@@ -1777,7 +1778,7 @@ void add_help_arg_to_string_builder(const Config *config, int token,
     case ARG_TOKEN_P2_TIME_LIMIT:
       usages[0] = "<time_limit_seconds>";
       text = "Specifies the time limit in seconds for simulation for player "
-             "1 or 2 during autoplay.";
+             "1 or 2 during autoplay. Fractional values supported.";
       break;
     case ARG_TOKEN_P1_THRESHOLD:
     case ARG_TOKEN_P2_THRESHOLD:
@@ -6164,8 +6165,8 @@ void config_load_data(Config *config, ErrorStack *error_stack) {
     return;
   }
 
-  config_load_int(config, ARG_TOKEN_TIME_LIMIT, 0, INT_MAX,
-                  &config->time_limit_seconds, error_stack);
+  config_load_double(config, ARG_TOKEN_TIME_LIMIT, 0, 1e9,
+                     &config->time_limit_seconds, error_stack);
   if (!error_stack_is_empty(error_stack)) {
     return;
   }
@@ -6651,13 +6652,13 @@ void config_load_data(Config *config, ErrorStack *error_stack) {
     config->p1_time_limit_seconds = config->time_limit_seconds;
     config->p2_time_limit_seconds = config->time_limit_seconds;
   }
-  config_load_int(config, ARG_TOKEN_P1_TIME_LIMIT, 0, INT_MAX,
-                  &config->p1_time_limit_seconds, error_stack);
+  config_load_double(config, ARG_TOKEN_P1_TIME_LIMIT, 0, 1e9,
+                     &config->p1_time_limit_seconds, error_stack);
   if (!error_stack_is_empty(error_stack)) {
     return;
   }
-  config_load_int(config, ARG_TOKEN_P2_TIME_LIMIT, 0, INT_MAX,
-                  &config->p2_time_limit_seconds, error_stack);
+  config_load_double(config, ARG_TOKEN_P2_TIME_LIMIT, 0, 1e9,
+                     &config->p2_time_limit_seconds, error_stack);
   if (!error_stack_is_empty(error_stack)) {
     return;
   }
@@ -8131,16 +8132,16 @@ void config_add_settings_to_string_builder(const Config *config,
                                                   config->tt_fraction_of_mem);
       break;
     case ARG_TOKEN_TIME_LIMIT:
-      config_add_int_setting_to_string_builder(config, sb, arg_token,
-                                               config->time_limit_seconds);
+      config_add_double_setting_to_string_builder(config, sb, arg_token,
+                                                  config->time_limit_seconds);
       break;
     case ARG_TOKEN_P1_TIME_LIMIT:
-      config_add_int_setting_to_string_builder(config, sb, arg_token,
-                                               config->p1_time_limit_seconds);
+      config_add_double_setting_to_string_builder(
+          config, sb, arg_token, config->p1_time_limit_seconds);
       break;
     case ARG_TOKEN_P2_TIME_LIMIT:
-      config_add_int_setting_to_string_builder(config, sb, arg_token,
-                                               config->p2_time_limit_seconds);
+      config_add_double_setting_to_string_builder(
+          config, sb, arg_token, config->p2_time_limit_seconds);
       break;
     case ARG_TOKEN_SAMPLING_RULE:
       string_builder_add_formatted_string(sb, " -%s ",

--- a/src/impl/config.c
+++ b/src/impl/config.c
@@ -726,7 +726,7 @@ void config_load_double(const Config *config, arg_token_t arg_token, double min,
                          config_get_parg_name(config, arg_token), double_str));
     return;
   }
-  if (new_value < min || new_value > max) {
+  if (!isfinite(new_value) || new_value < min || new_value > max) {
     error_stack_push(
         error_stack, ERROR_STATUS_CONFIG_LOAD_DOUBLE_ARG_OUT_OF_BOUNDS,
         get_formatted_string(


### PR DESCRIPTION
## Summary

Promotes the BAI time budget through-line from `uint64_t / int` to `double` so `-tlim` accepts fractional values. Motivated by short-budget A/B benchmarks where 1-second resolution is too coarse (e.g. 50 ms-per-turn matches that are useful for parameter sweeps).

Behavior at integer values is unchanged: `-tlim 1` still produces the same elapsed-second threshold it did before. The internal comparison in `bai_result_set_and_get_status` was already casting to `double`, so dropping the cast is a no-op.

## What changes

| location | from | to |
|---|---|---|
| `BAIOptions.time_limit_seconds` (`src/def/bai_defs.h`) | `uint64_t` | `double` |
| `BAIResult` internal field + getter (`src/ent/bai_result.{c,h}`) | `uint64_t` | `double` |
| `sim_args_fill` signature parameter (`src/ent/sim_args.h`) | `const int` | `const double` |
| `Config.time_limit_seconds`, `p1_time_limit_seconds`, `p2_time_limit_seconds` | `int` | `double` |
| CLI parse `-tlim / -tl1 / -tl2` | `config_load_int(..., 0, INT_MAX, ...)` | `config_load_double(..., 0, 1e9, ...)` |
| CLI serialize `-tlim / -tl1 / -tl2` | `config_add_int_setting_to_string_builder` | `config_add_double_setting_to_string_builder` |
| `-tlim` help text | — | now mentions fractional values are supported |

## Test plan

- [x] `make magpie BUILD=release` and `make magpie_test BUILD=release` clean
- [x] `./bin/magpie_test` full suite at `BOARD_DIM=15` — all pass
- [x] `./bin/magpie set -tlim 0.05` parses cleanly
- [x] `./bin/magpie set -tlim -1` rejected with the expected error
- [x] `./bin/magpie set -tlim abc` rejected with the expected error
- [x] `./bin/magpie set -tlim 1` works as before
- [x] `python3 format.py --write` — no changes after commit
- [x] `./cppcheck.sh` — no errors
- [x] `python3 find_circ_deps.py` — no cycles

## Notes

Draft because this is a small enabler that I extracted from a larger A/B-benchmarking workflow; happy to flip to ready-for-review on request. No new tests added — the change is a pure type promotion that the existing sim/BAI tests cover by running through the modified API path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)