### PR TITLE
move_gen: per-thread MoveGen pool (enables concurrent solves, no leak/regression)

### DIFF
--- a/src/compat/cpthread.h
+++ b/src/compat/cpthread.h
@@ -104,4 +104,29 @@ static inline void cpthread_cancel(cpthread_t thread) {
   }
 }
 
+static inline void cpthread_key_create(cpthread_key_t *key,
+                                       void (*destructor)(void *)) {
+  if (pthread_key_create(key, destructor)) {
+    log_fatal("thread key create failed");
+  }
+}
+
+static inline void cpthread_once(cpthread_once_t *once_control,
+                                 void (*init_routine)(void)) {
+  if (pthread_once(once_control, init_routine)) {
+    log_fatal("thread once failed");
+  }
+}
+
+static inline void *cpthread_getspecific(cpthread_key_t key) {
+  return pthread_getspecific(key);
+}
+
+static inline void cpthread_setspecific(cpthread_key_t key,
+                                        const void *value) {
+  if (pthread_setspecific(key, value)) {
+    log_fatal("thread setspecific failed");
+  }
+}
+
 #endif

--- a/src/def/cpthread_defs.h
+++ b/src/def/cpthread_defs.h
@@ -6,5 +6,9 @@
 typedef pthread_t cpthread_t;
 typedef pthread_mutex_t cpthread_mutex_t;
 typedef pthread_cond_t cpthread_cond_t;
+typedef pthread_key_t cpthread_key_t;
+typedef pthread_once_t cpthread_once_t;
+
+#define CPTHREAD_ONCE_INIT PTHREAD_ONCE_INIT
 
 #endif

--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -2,6 +2,7 @@
 
 #include "../compat/cpthread.h"
 #include "../def/board_defs.h"
+#include "../def/cpthread_defs.h"
 #include "../def/cross_set_defs.h"
 #include "../def/equity_defs.h"
 #include "../def/game_defs.h"
@@ -48,7 +49,12 @@
 // be expensive. The infer and sim functions
 // don't have this problem since they are
 // only called once per command.
+// Pool of reusable MoveGens. cached_gens[slot] is allocated lazily and kept
+// for the whole process (freed only at shutdown) so the expensive MoveGen
+// allocation is amortized across solves; slot_in_use[slot] marks whether a
+// live thread currently owns that slot. See get_movegen below.
 static MoveGen *cached_gens[MAX_THREADS];
+static bool slot_in_use[MAX_THREADS];
 static cpthread_mutex_t cache_mutex = PTHREAD_MUTEX_INITIALIZER; // NOLINT
 
 #ifdef ANCHOR_CACHE_ENABLE
@@ -117,20 +123,101 @@ void generator_destroy(MoveGen *gen) {
   free(gen);
 }
 
-MoveGen *get_movegen(int thread_index) {
-  if (!cached_gens[thread_index]) {
-    cached_gens[thread_index] = calloc_or_die(1, sizeof(MoveGen));
+// MoveGen pool keyed by a per-thread slot, not by the caller-supplied
+// thread_index. Each live pthread acquires a distinct free slot on its first
+// generate_moves and holds it for the thread's lifetime, so two threads can
+// never share a MoveGen and corrupt each other's state — regardless of what
+// thread_index they pass. This lets callers run many concurrent solves without
+// having to partition thread_index ranges (the previous
+// cached_gens[thread_index] scheme handed two callers that passed the same
+// index the same gen).
+//
+// A slot's MoveGen is allocated lazily and reused for the whole process, so the
+// expensive allocation is amortized across solves exactly as the old
+// thread_index-keyed cache did. The pthread key's destructor only *releases the
+// slot* on thread exit (it does not free the gen), so a future thread reuses
+// both the slot and its already-allocated gen — bounded memory, no per-thread
+// reallocation, and no leak. All gens are freed once at shutdown.
+//
+// A reused gen carries stale per-call scratch, which is fine: generate_moves
+// resets the state it reads each call and the anchor cache validates by key —
+// the same reuse the old cross-solve slot sharing relied on.
+static cpthread_key_t gen_key;
+static cpthread_once_t gen_key_once = CPTHREAD_ONCE_INIT;
+
+// Thread-exit destructor: return this thread's slot to the pool (keep the gen).
+static void gen_release_slot(void *ptr) {
+  if (ptr == NULL) {
+    return;
   }
-  return cached_gens[thread_index];
+  cpthread_mutex_lock(&cache_mutex);
+  for (int i = 0; i < MAX_THREADS; i++) {
+    if (cached_gens[i] == ptr) {
+      slot_in_use[i] = false;
+      break;
+    }
+  }
+  cpthread_mutex_unlock(&cache_mutex);
+}
+
+static void gen_key_init(void) {
+  cpthread_key_create(&gen_key, gen_release_slot);
+}
+
+MoveGen *get_movegen(int thread_index) {
+  // thread_index is vestigial: each live thread owns a distinct slot.
+  (void)thread_index;
+  cpthread_once(&gen_key_once, gen_key_init);
+  MoveGen *gen = cpthread_getspecific(gen_key);
+  if (gen != NULL) {
+    return gen;
+  }
+  // First touch on this thread: acquire a free slot, reusing its gen if one was
+  // allocated by an earlier thread that has since released the slot.
+  cpthread_mutex_lock(&cache_mutex);
+  int slot = -1;
+  for (int i = 0; i < MAX_THREADS; i++) {
+    if (!slot_in_use[i]) {
+      slot = i;
+      slot_in_use[i] = true;
+      break;
+    }
+  }
+  if (slot < 0) {
+    cpthread_mutex_unlock(&cache_mutex);
+    log_fatal("movegen pool exhausted: more than %d concurrent threads",
+              MAX_THREADS);
+  }
+  // cppcheck-suppress negativeIndex ; slot >= 0 here (log_fatal above is
+  // noreturn)
+  gen = cached_gens[slot];
+  if (gen == NULL) {
+    gen = calloc_or_die(1, sizeof(MoveGen));
+    cached_gens[slot] = gen;
+  }
+  cpthread_mutex_unlock(&cache_mutex);
+  cpthread_setspecific(gen_key, gen);
+  return gen;
 }
 
 void gen_destroy_cache(void) {
+  // May run mid-process, not only at shutdown: caches_destroy() calls this
+  // after a CLI command completes (and again at exit). It runs on a single
+  // thread after every worker has been joined, so no slot-release destructor
+  // can race it.
   cpthread_mutex_lock(&cache_mutex);
   for (int i = 0; i < (MAX_THREADS); i++) {
     generator_destroy(cached_gens[i]);
     cached_gens[i] = NULL;
+    slot_in_use[i] = false;
   }
   cpthread_mutex_unlock(&cache_mutex);
+  // The calling thread's key still points at the gen we just freed (key
+  // destructors don't fire for a thread that keeps running), so clear it.
+  // Otherwise the next get_movegen on this thread takes the fast path and
+  // returns that dangling pointer instead of acquiring a fresh slot/gen.
+  cpthread_once(&gen_key_once, gen_key_init);
+  cpthread_setspecific(gen_key, NULL);
 }
 
 // Cache getter functions


### PR DESCRIPTION
## Motivation

The global `cached_gens[thread_index]` MoveGen cache requires callers to hand out non-overlapping `thread_index` ranges so concurrent solves don't collide on the same gen. That coordination is awkward for PEG, which runs many nested endgame solves concurrently. This replaces the index-keyed cache with a **slot pool**: each live thread acquires a free slot on its first `get_movegen` (via a `pthread_key`), keeps it for the thread's lifetime, and a thread-exit destructor returns the slot to the pool **keeping the gen for reuse**. So:

- concurrent solves get distinct gens with **no `thread_index` coordination**,
- **no per-thread reallocation** (gens are reused via released slots — preserves the allocation amortization the cache exists for),
- **no leak** (bounded to `MAX_THREADS` gens, all freed once in `gen_destroy_cache`).

`thread_index` is now vestigial.

## Correctness fix found while getting this in shape

`caches_destroy()` → `gen_destroy_cache()` can run **mid-process**, not only at exit (e.g. after a CLI command completes, exercised by `command_test`). Freeing the gens left the calling thread's `pthread_key` pointing at freed memory, so the next `get_movegen` took the `getspecific` fast path and returned a **dangling pointer** (use-after-free → SIGBUS in a later test). The old `cached_gens[thread_index]` model re-checked the slot and reallocated, so it was safe; the pool's fast path is not unless the key is cleared. Fixed by clearing the calling thread's key in `gen_destroy_cache` (which runs single-threaded after workers are joined).

## Other changes
- Adds `cpthread` wrappers (`cpthread_key_create`/`once`/`getspecific`/`setspecific`) so move_gen uses the compat layer instead of raw `pthread` (matches the rest of the codebase; also clears the clang-tidy include-cleaner warnings).
- Rebased onto current `main` (composes with the #542 fingerprint cache invalidation).

## Verification
- Full test suite **30/30** clean (release); `sim` heavily.
- **TSAN**: no races in the pool — the `get_movegen` slow path and the slot-release destructor are both under `cache_mutex`. (TSAN's pre-existing reports are in `command_test`'s async `error_stack` handling, unrelated to this change.)
- Composes with #542.

🤖 Generated with [Claude Code](https://claude.com/claude-code)