### PR TITLE
Fix movegen cache ABA crash over reused WMP/KLV addresses

### DIFF
--- a/src/ent/klv.h
+++ b/src/ent/klv.h
@@ -36,6 +36,25 @@ typedef struct KLV {
 
 static inline const char *klv_get_name(const KLV *klv) { return klv->name; }
 
+// A value unique to this loaded KLV instance: a hash of the base addresses and
+// size of its freshly-allocated leave_values/word_counts arrays. Two different
+// loads (even of the same lexicon) produce different fingerprints, so MoveGen
+// caches that hold leave-derived data can detect that the backing KLV has been
+// replaced even when a new KLV is allocated at a freed one's address (ABA),
+// which the pointer comparison cannot see.
+static inline uint64_t klv_get_instance_fingerprint(const KLV *klv) {
+  uint64_t hash = 1469598103934665603ULL;
+  const uintptr_t parts[] = {(uintptr_t)klv->leave_values,
+                             (uintptr_t)klv->word_counts,
+                             (uintptr_t)klv->kwg,
+                             (uintptr_t)klv->number_of_leaves};
+  for (size_t i = 0; i < sizeof(parts) / sizeof(parts[0]); i++) {
+    hash ^= (uint64_t)parts[i];
+    hash *= 1099511628211ULL;
+  }
+  return hash;
+}
+
 static inline const KWG *klv_get_kwg(const KLV *klv) { return klv->kwg; }
 
 static inline uint32_t klv_get_number_of_leaves(const KLV *klv) {

--- a/src/ent/klv.h
+++ b/src/ent/klv.h
@@ -5,6 +5,7 @@
 #include "../def/klv_defs.h"
 #include "../ent/kwg.h"
 #include "../util/fileproxy.h"
+#include "../util/fnv.h"
 #include "../util/io_util.h"
 #include "../util/string_util.h"
 #include "data_filepaths.h"
@@ -43,15 +44,11 @@ static inline const char *klv_get_name(const KLV *klv) { return klv->name; }
 // replaced even when a new KLV is allocated at a freed one's address (ABA),
 // which the pointer comparison cannot see.
 static inline uint64_t klv_get_instance_fingerprint(const KLV *klv) {
-  uint64_t hash = 1469598103934665603ULL;
-  const uintptr_t parts[] = {(uintptr_t)klv->leave_values,
-                             (uintptr_t)klv->word_counts,
-                             (uintptr_t)klv->kwg,
-                             (uintptr_t)klv->number_of_leaves};
-  for (size_t i = 0; i < sizeof(parts) / sizeof(parts[0]); i++) {
-    hash ^= (uint64_t)parts[i];
-    hash *= 1099511628211ULL;
-  }
+  uint64_t hash = FNV_64_OFFSET_BASIS;
+  hash = fnv64a_step(hash, (uintptr_t)klv->leave_values);
+  hash = fnv64a_step(hash, (uintptr_t)klv->word_counts);
+  hash = fnv64a_step(hash, (uintptr_t)klv->kwg);
+  hash = fnv64a_step(hash, (uint64_t)klv->number_of_leaves);
   return hash;
 }
 

--- a/src/ent/wmp.h
+++ b/src/ent/wmp.h
@@ -501,7 +501,12 @@ static inline const char *wmp_get_name(const WMP *wmp) { return wmp->name; }
 // struct address as a freed one (ABA), which a pointer comparison cannot see.
 static inline uint64_t wmp_get_instance_fingerprint(const WMP *wmp) {
   uint64_t hash = FNV_64_OFFSET_BASIS;
-  for (int len = 0; len <= BOARD_DIM; len++) {
+  // Only lengths 2..board_dim hold loaded map data (see read_wmp_for_length);
+  // wfls[0]/wfls[1] are never populated and are indeterminate for WMPs built
+  // with make_wmp_from_words (which mallocs the struct), so skip them rather
+  // than hash uninitialized memory. board_dim is validated to equal BOARD_DIM
+  // at load.
+  for (int len = 2; len <= wmp->board_dim; len++) {
     const WMPForLength *wfl = &wmp->wfls[len];
     hash = fnv64a_step(hash, (uintptr_t)wfl->word_map_entries);
     hash = fnv64a_step(hash, (uint64_t)wfl->num_word_entries);

--- a/src/ent/wmp.h
+++ b/src/ent/wmp.h
@@ -491,6 +491,29 @@ wfl_get_double_blank_entry(const WMPForLength *wfl, const BitRack *bit_rack) {
 
 static inline const char *wmp_get_name(const WMP *wmp) { return wmp->name; }
 
+// A value that is unique to this loaded WMP instance: a hash of the base
+// addresses and entry counts of its freshly-allocated internal maps. Two
+// different loads of even the same lexicon produce different fingerprints
+// (their maps are malloc'd separately), so callers that cache pointers into a
+// WMP (e.g. the move_gen subrack cache) can detect that the WMP backing those
+// pointers has been replaced -- even when a new WMP is allocated at the same
+// struct address as a freed one (ABA), which a pointer comparison cannot see.
+static inline uint64_t wmp_get_instance_fingerprint(const WMP *wmp) {
+  uint64_t hash = 1469598103934665603ULL;
+  for (int len = 0; len <= BOARD_DIM; len++) {
+    const WMPForLength *wfl = &wmp->wfls[len];
+    const uintptr_t parts[] = {
+        (uintptr_t)wfl->word_map_entries, (uintptr_t)wfl->num_word_entries,
+        (uintptr_t)wfl->blank_map_entries,
+        (uintptr_t)wfl->double_blank_map_entries};
+    for (size_t i = 0; i < sizeof(parts) / sizeof(parts[0]); i++) {
+      hash ^= (uint64_t)parts[i];
+      hash *= 1099511628211ULL;
+    }
+  }
+  return hash;
+}
+
 static inline const WMPEntry *
 wmp_get_word_entry(const WMP *wmp, const BitRack *bit_rack, int word_length) {
   const WMPForLength *wfl = &wmp->wfls[word_length];

--- a/src/ent/wmp.h
+++ b/src/ent/wmp.h
@@ -6,6 +6,7 @@
 #include "../def/wmp_defs.h"
 #include "../ent/bit_rack.h"
 #include "../util/fileproxy.h"
+#include "../util/fnv.h"
 #include "../util/io_util.h"
 #include "../util/string_util.h"
 #include "data_filepaths.h"
@@ -499,17 +500,13 @@ static inline const char *wmp_get_name(const WMP *wmp) { return wmp->name; }
 // pointers has been replaced -- even when a new WMP is allocated at the same
 // struct address as a freed one (ABA), which a pointer comparison cannot see.
 static inline uint64_t wmp_get_instance_fingerprint(const WMP *wmp) {
-  uint64_t hash = 1469598103934665603ULL;
+  uint64_t hash = FNV_64_OFFSET_BASIS;
   for (int len = 0; len <= BOARD_DIM; len++) {
     const WMPForLength *wfl = &wmp->wfls[len];
-    const uintptr_t parts[] = {
-        (uintptr_t)wfl->word_map_entries, (uintptr_t)wfl->num_word_entries,
-        (uintptr_t)wfl->blank_map_entries,
-        (uintptr_t)wfl->double_blank_map_entries};
-    for (size_t i = 0; i < sizeof(parts) / sizeof(parts[0]); i++) {
-      hash ^= (uint64_t)parts[i];
-      hash *= 1099511628211ULL;
-    }
+    hash = fnv64a_step(hash, (uintptr_t)wfl->word_map_entries);
+    hash = fnv64a_step(hash, (uint64_t)wfl->num_word_entries);
+    hash = fnv64a_step(hash, (uintptr_t)wfl->blank_map_entries);
+    hash = fnv64a_step(hash, (uintptr_t)wfl->double_blank_map_entries);
   }
   return hash;
 }

--- a/src/ent/wmp.h
+++ b/src/ent/wmp.h
@@ -506,7 +506,9 @@ static inline uint64_t wmp_get_instance_fingerprint(const WMP *wmp) {
     hash = fnv64a_step(hash, (uintptr_t)wfl->word_map_entries);
     hash = fnv64a_step(hash, (uint64_t)wfl->num_word_entries);
     hash = fnv64a_step(hash, (uintptr_t)wfl->blank_map_entries);
+    hash = fnv64a_step(hash, (uint64_t)wfl->num_blank_entries);
     hash = fnv64a_step(hash, (uintptr_t)wfl->double_blank_map_entries);
+    hash = fnv64a_step(hash, (uint64_t)wfl->num_double_blank_entries);
   }
   return hash;
 }

--- a/src/impl/exec.c
+++ b/src/impl/exec.c
@@ -101,7 +101,7 @@ async_token_t parse_async_command(const char *command, StringBuilder *sb) {
   async_token_t token = NUMBER_OF_ASYNC_COMMAND_TOKENS;
   string_builder_clear(sb);
   for (async_token_t i = 0; i < NUMBER_OF_ASYNC_COMMAND_TOKENS; i++) {
-    const char *token_to_eval_string;
+    const char *token_to_eval_string = NULL;
     switch (i) {
     case ASYNC_STOP_COMMAND_TOKEN:
       token_to_eval_string = ASYNC_STOP_COMMAND_STRING;

--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -2736,14 +2736,19 @@ void gen_load_position(MoveGen *gen, const MoveGenArgs *args) {
   const KLV *new_klv = player_get_klv(player);
   const uint64_t new_klv_mutation_counter =
       (new_klv != NULL) ? klv_get_mutation_counter(new_klv) : 0;
-  // Invalidate when the KLV pointer changes (player swap, lexicon change)
-  // OR the same KLV's leave_values have been mutated in place. The
-  // mutation-counter path catches test-only set_klv_leave_value calls
-  // between generate_moves invocations, which would otherwise leave stale
-  // leave_values cached in the subrack cache and anchor-cache upper-bound
-  // entries.
+  const uint64_t new_klv_instance_fp =
+      (new_klv != NULL) ? klv_get_instance_fingerprint(new_klv) : 0;
+  // Invalidate when the KLV pointer changes (player swap, lexicon change), the
+  // KLV instance fingerprint changes (catches a reloaded KLV the allocator
+  // placed at the freed KLV's address -- ABA -- which the pointer comparison
+  // misses because the move_gen cache outlives the Config that owned the old
+  // KLV), OR the same KLV's leave_values have been mutated in place. The
+  // mutation-counter path catches test-only set_klv_leave_value calls between
+  // generate_moves invocations, which would otherwise leave stale leave_values
+  // cached in the subrack cache and anchor-cache upper-bound entries.
   const bool klv_changed =
       (new_klv != gen->klv) ||
+      (new_klv_instance_fp != gen->klv_instance_fp_at_load) ||
       (new_klv_mutation_counter != gen->klv_mutation_counter_at_load);
   if (klv_changed) {
     for (int i = 0; i < MOVEGEN_SUBRACK_CACHE_SIZE; i++) {
@@ -2763,6 +2768,7 @@ void gen_load_position(MoveGen *gen, const MoveGenArgs *args) {
   }
   gen->klv = new_klv;
   gen->klv_mutation_counter_at_load = new_klv_mutation_counter;
+  gen->klv_instance_fp_at_load = new_klv_instance_fp;
   const RackInfoTable *new_rit = player_get_rack_info_table(player);
   if (new_rit != gen->rack_info_table) {
     memset(gen->rit_cache_valid, 0, sizeof(gen->rit_cache_valid));
@@ -2800,13 +2806,24 @@ void gen_load_position(MoveGen *gen, const MoveGenArgs *args) {
     // the override).
     gen->wmp_move_gen.wmp = NULL;
   }
-  // The subrack cache holds wmp_entry pointers derived from the WMP; a
-  // WMP swap (e.g., different player's lexicon) would make those stale.
-  if (gen->wmp_move_gen.wmp != previous_wmp) {
+  // The subrack cache holds wmp_entry pointers derived from the WMP; a WMP
+  // swap (different lexicon) makes those stale -- and "stale" means dangling,
+  // since the old WMP's Config may have been freed. Invalidate on a WMP
+  // pointer change OR an instance-fingerprint change. The fingerprint catches
+  // a reloaded WMP (even of the same lexicon) that the allocator placed at the
+  // freed WMP's struct address (ABA) but whose internal maps are at new
+  // addresses -- a pointer comparison alone would miss it because the move_gen
+  // cache outlives the Config that owned the old WMP.
+  const WMP *new_wmp = gen->wmp_move_gen.wmp;
+  const uint64_t new_wmp_instance_fp =
+      (new_wmp != NULL) ? wmp_get_instance_fingerprint(new_wmp) : 0;
+  if (new_wmp != previous_wmp ||
+      new_wmp_instance_fp != gen->wmp_instance_fp_at_load) {
     for (int i = 0; i < MOVEGEN_SUBRACK_CACHE_SIZE; i++) {
       gen->subrack_cache[i].valid = false;
     }
   }
+  gen->wmp_instance_fp_at_load = new_wmp_instance_fp;
 
   gen->bingo_bonus = game_get_bingo_bonus(game);
   gen->number_of_tiles_in_bag = bag_get_letters(game_get_bag(game));

--- a/src/impl/move_gen.h
+++ b/src/impl/move_gen.h
@@ -230,6 +230,17 @@ typedef struct MoveGen {
   // cache, anchor cache upper bounds) must be invalidated even though the
   // KLV pointer is unchanged.
   uint64_t klv_mutation_counter_at_load;
+  // Instance fingerprints of the KLV and WMP captured at the last
+  // gen_load_position call. The MoveGen cache is pooled per thread and
+  // outlives the Configs the engine creates and destroys; when a Config is
+  // freed and another loaded, the allocator can hand the new KLV/WMP the freed
+  // one's struct address (ABA) -- even for the same lexicon -- while its
+  // internal arrays are reallocated elsewhere. A KLV/WMP pointer (or lexicon
+  // name) comparison reads "unchanged" and keeps stale leave_values / dangling
+  // wmp_entry pointers cached. The fingerprint hashes the internal array
+  // addresses, so it changes whenever the backing data is reloaded.
+  uint64_t klv_instance_fp_at_load;
+  uint64_t wmp_instance_fp_at_load;
   const RackInfoTable *rack_info_table;
   // RIT entry for the current player_rack, looked up once in
   // gen_look_up_leaves_and_record_exchanges and cached here for the duration

--- a/src/util/fnv.h
+++ b/src/util/fnv.h
@@ -1,0 +1,20 @@
+#ifndef FNV_H
+#define FNV_H
+
+#include <stdint.h>
+
+// 64-bit FNV-1a hash constants (the standard offset basis and prime). These
+// are too large to be enumeration constants (enumerators have type int), so
+// they are named #defines rather than an enum.
+#define FNV_64_OFFSET_BASIS 14695981039346656037ULL
+#define FNV_64_PRIME 1099511628211ULL
+
+// One FNV-1a step: fold a 64-bit value into the running hash. Seed the running
+// hash with FNV_64_OFFSET_BASIS before the first step.
+static inline uint64_t fnv64a_step(uint64_t hash, uint64_t value) {
+  hash ^= value;
+  hash *= FNV_64_PRIME;
+  return hash;
+}
+
+#endif

--- a/test/move_gen_test.c
+++ b/test/move_gen_test.c
@@ -1601,7 +1601,45 @@ void wmp_blank_possibilities_bananas_5(void) {
   config_destroy(config);
 }
 
+// Regression guard for the move_gen subrack/KLV cache ABA fix (PR #542). A
+// loaded WMP/KLV exposes an instance fingerprint that gen_load_position uses to
+// invalidate the per-thread caches when a Config's WMP/KLV is freed and a new
+// one is loaded at the same struct address -- a pointer or lexicon-name
+// comparison cannot detect that reuse. The fingerprint must therefore (a) be
+// stable across calls for one instance and (b) differ between two independent
+// loads of the *same* lexicon. This is deterministic on every platform because
+// both instances are alive at once, so their internal arrays are necessarily
+// at distinct addresses; if the fingerprint were ever reverted to a
+// pointer/name basis, the distinct-instance assertions below would fail. (The
+// end-to-end crash this protects against reproduces only on macOS, where the
+// allocator hands a freed WMP's address straight back to the next load; see
+// the PR description.)
+void test_move_gen_instance_fingerprint(void) {
+  ErrorStack *error_stack = error_stack_create();
+
+  WMP *wmp_a = wmp_create(DEFAULT_TEST_DATA_PATH, "CSW21", error_stack);
+  WMP *wmp_b = wmp_create(DEFAULT_TEST_DATA_PATH, "CSW21", error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(wmp_a != NULL && wmp_b != NULL);
+  const uint64_t wmp_fp_a = wmp_get_instance_fingerprint(wmp_a);
+  assert(wmp_fp_a == wmp_get_instance_fingerprint(wmp_a));
+  assert(wmp_fp_a != wmp_get_instance_fingerprint(wmp_b));
+  wmp_destroy(wmp_a);
+  wmp_destroy(wmp_b);
+
+  KLV *klv_a = klv_create_or_die(DEFAULT_TEST_DATA_PATH, "CSW21");
+  KLV *klv_b = klv_create_or_die(DEFAULT_TEST_DATA_PATH, "CSW21");
+  const uint64_t klv_fp_a = klv_get_instance_fingerprint(klv_a);
+  assert(klv_fp_a == klv_get_instance_fingerprint(klv_a));
+  assert(klv_fp_a != klv_get_instance_fingerprint(klv_b));
+  klv_destroy(klv_a);
+  klv_destroy(klv_b);
+
+  error_stack_destroy(error_stack);
+}
+
 void test_move_gen(void) {
+  test_move_gen_instance_fingerprint();
   leave_lookup_test();
   unfound_leave_lookup_test();
   macondo_tests();

--- a/test/move_gen_test.c
+++ b/test/move_gen_test.c
@@ -1602,8 +1602,8 @@ void wmp_blank_possibilities_bananas_5(void) {
   config_destroy(config);
 }
 
-// Regression guard for the move_gen subrack/KLV cache ABA fix (PR #542). A
-// loaded WMP/KLV exposes an instance fingerprint that gen_load_position uses to
+// Regression guard for the move_gen subrack/KLV cache invalidation. A loaded
+// WMP/KLV exposes an instance fingerprint that gen_load_position uses to
 // invalidate the per-thread caches when a Config's WMP/KLV is freed and a new
 // one is loaded at the same struct address -- a pointer or lexicon-name
 // comparison cannot detect that reuse. The fingerprint must therefore (a) be
@@ -1611,10 +1611,7 @@ void wmp_blank_possibilities_bananas_5(void) {
 // loads of the *same* lexicon. This is deterministic on every platform because
 // both instances are alive at once, so their internal arrays are necessarily
 // at distinct addresses; if the fingerprint were ever reverted to a
-// pointer/name basis, the distinct-instance assertions below would fail. (The
-// end-to-end crash this protects against reproduces only on macOS, where the
-// allocator hands a freed WMP's address straight back to the next load; see
-// the PR description.)
+// pointer/name basis, the distinct-instance assertions below would fail.
 void test_move_gen_instance_fingerprint(void) {
   ErrorStack *error_stack = error_stack_create();
 

--- a/test/move_gen_test.c
+++ b/test/move_gen_test.c
@@ -24,6 +24,7 @@
 #include "test_util.h"
 #include <assert.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
## Summary

`./bin/magpie_test sim` crashes nondeterministically (~80% of runs **on macOS** release) with SIGBUS/SIGSEGV or an `equity is not an integer` assertion, always via a wild dereference in `update_best_move_or_insert_into_movelist` on a worker thread. This fixes the root cause.

## Root cause: ABA in the move_gen caches

The per-thread move_gen pool (`cached_gens[thread_index]`) is **process-global and outlives the `Config`s** the engine creates and destroys. Two of its caches hold lexicon-derived state:

- the **subrack cache**, which stores `wmp_entry` **pointers**, and
- the **KLV-leaves cache**, which stores leave values.

Both were invalidated only by comparing the **WMP/KLV struct pointer** (plus the KLV mutation counter). When a `Config` is destroyed and another loaded — **even of the same lexicon** — the allocator can hand the new WMP/KLV the freed struct's address (**ABA**), while its internal arrays are malloc'd elsewhere. The struct-pointer comparison then reports "unchanged" and keeps the stale cache, so a cached `wmp_entry` points into the **freed** arrays. Dereferencing it during move recording faults (SIGBUS/SIGSEGV), or yields a garbage equity that trips the `equity is not an integer` assertion.

This was:
- **nondeterministic** (depends on allocator address reuse),
- present from **`-O1`** up (not an optimizer artifact), and
- **invisible to ASan/UBSan/TSAN** — it's intra-instance pointer reuse, not a data race or an out-of-object overflow.

A lexicon-name comparison does **not** help, because the name matches when the same lexicon is reloaded.

## Why this only *crashes* on macOS (the bug is live everywhere)

The crash is allocator-dependent, but **not** because the ABA condition is macOS-only — I measured it on both platforms with a one-off probe over a single `sim` run:

| | macOS (`libmalloc`) | Linux / CI (`glibc`) |
|---|---|---|
| freed WMP struct reused by the *next* same-size alloc (MRU) | 47% | 26% |
| times a gen's WMP pointer was reused for a **different instance** (the exact stale-cache condition) | 54 | **26** |
| `sim` outcome | crashes ~80% of runs | passes — CI always green |

So the stale-cache condition fires **26 times per `sim` run on glibc too** — without this fix, Linux was silently serving stale cache entries; it just never crashed. The platform difference is only in what dereferencing the stale `wmp_entry` (a pointer into the *old* WMP's now-freed internal map arrays) does:

- **macOS**: `libmalloc` recycles/unmaps freed regions readily, so the stale read faults — SIGBUS, or it reads wild garbage that trips the `equity is not an integer` assert.
- **Linux/glibc**: freed small allocations are retained mapped in the arena (glibc rarely returns them to the OS), so the same stale read returns in-bounds bytes instead of faulting — wrong at worst, never a crash. The `sim` assertions don't catch it, so CI stays green.

Net: the bug is real and actively triggered on every platform; only macOS's allocator turns it into a hard crash. That's why `main`'s CI never went red despite the bug being present.

## Fix

Identify a loaded WMP/KLV by an **instance fingerprint** — an FNV hash of its internal array base addresses and entry counts (`wmp_get_instance_fingerprint` / `klv_get_instance_fingerprint`). The fingerprint is unique per load (ABA-proof, since a reloaded instance gets fresh allocations) but **constant within a stable lexicon**, so the caches keep hitting and there is **no performance regression**. `gen_load_position` now invalidates the subrack and KLV caches when the fingerprint changes, in addition to the existing pointer/mutation-counter checks.

Also initializes `token_to_eval_string` in `parse_async_command` to clear a `-Wsometimes-uninitialized -Werror` that broke the `BUILD=thread` build (the `NUMBER_OF_ASYNC_COMMAND_TOKENS` switch case is unreachable inside the loop, so this is benign at runtime — but it's needed to compile the thread/TSAN build).

## Regression test

`test_move_gen_instance_fingerprint` (run as part of `movegen`) is a **deterministic, platform-independent** guard: two independent loads of the same lexicon must produce **different** instance fingerprints (their internal arrays are at distinct addresses while both are alive), and one instance's fingerprint must be **stable** across calls. It fails if the fingerprint is ever reverted to a pointer- or name-based identity — verified to have teeth (stubbing the WMP fingerprint to a name-only hash makes `movegen` abort on the distinct-instance assertion).

A *crash-reproduction* test can't serve as a portable CI guard, since the trigger depends on the allocator reusing a freed address (see above); the end-to-end repro remains `sim` on macOS.

## Verification

| Check | Before | After |
|---|---|---|
| release `sim` (macOS) | ~80% crash | 40+/40+ clean |
| full release suite ×3 | — | clean |
| dev/ASan (sim, movegen, wmp, autoplay) | — | clean |
| TSAN `sim` ×3 (incl. single-vs-multithreaded determinism asserts) | — | clean, no races |
| `test_move_gen_instance_fingerprint` | fails (name-only stub) | passes |

cppcheck is clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
