### PR TITLE
endgame: dynamic ABDADA worker injection

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -91,7 +91,7 @@ jobs:
           - shard: sim
             tests: "sim endgame klv"
           - shard: eldar_v
-            tests: "eldar_v"
+            tests: "eldar_v endgameinject"
           - shard: analyze_sim
             tests: "analyze_sim"
           - shard: config

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -171,8 +171,17 @@ struct EndgameCtx {
   // bag_copy into incompatibly-sized allocations.
   EndgameCtxWorker **workers;
   cpthread_t *worker_ids;
-  int cap_workers; // allocated size of workers[] and worker_ids[]
+  int cap_workers; // number of created worker structs (workers[0..cap_workers))
+  int arr_cap; // allocated length of workers[]/worker_ids[] (>= cap_workers)
   const LetterDistribution *workers_ld;
+  // Dynamic worker injection (endgame_add_worker): grow an in-flight solve's
+  // worker count up to arr_cap as cores free up. All guarded by add_mutex.
+  int max_workers;           // ceiling for live_workers; 0 => no growth
+  uint64_t worker_base_seed; // ABDADA jitter seed, reused for late workers
+  atomic_int live_workers;   // worker threads spawned this solve (initial+late)
+  atomic_int adding_closed; // 1 = injection window shut (between/ending solves)
+  _Atomic int64_t window_open_ns; // monotonic ns when the window last opened
+  cpthread_mutex_t add_mutex; // serializes add vs the close+snapshot in solve
 };
 
 struct EndgameCtxWorker {
@@ -551,6 +560,12 @@ void endgame_ctx_reset(EndgameCtx *es, EndgameResults *results,
   if (es->threads < 1) {
     es->threads = 1;
   }
+  es->max_workers = endgame_args->max_workers;
+  // Injection window starts shut: endgame_solve opens it once the initial
+  // workers are spawned, and shuts it again before the join. live_workers
+  // counts the initial set until adds bump it.
+  atomic_store(&es->adding_closed, 1);
+  atomic_store(&es->live_workers, es->threads);
   es->requested_plies = endgame_args->plies;
   es->solving_player = game_get_player_on_turn_index(endgame_args->game);
   es->initial_small_move_arena_size =
@@ -671,8 +686,13 @@ void endgame_ctx_reset(EndgameCtx *es, EndgameResults *results,
   }
 }
 
-static EndgameCtx *endgame_ctx_create(void) {
-  return calloc_or_die(1, sizeof(EndgameCtx));
+EndgameCtx *endgame_ctx_create(void) {
+  EndgameCtx *solver = calloc_or_die(1, sizeof(EndgameCtx));
+  cpthread_mutex_init(&solver->add_mutex);
+  // Closed until a solve opens the window; otherwise a never-solved ctx (calloc
+  // zeroes adding_closed) would look injectable to an external monitor.
+  atomic_store(&solver->adding_closed, 1);
+  return solver;
 }
 
 const TranspositionTable *
@@ -795,6 +815,8 @@ static void endgame_ctx_prepare_workers(EndgameCtx *solver,
                                         uint64_t base_seed) {
   const LetterDistribution *ld = game_get_ld(solver->game);
 
+  solver->worker_base_seed = base_seed;
+
   // If the letter distribution changed (e.g., different lexicon), the worker
   // game copies have incompatibly-sized bags/racks. Destroy and rebuild.
   if (solver->workers_ld != NULL && solver->workers_ld != ld) {
@@ -806,18 +828,35 @@ static void endgame_ctx_prepare_workers(EndgameCtx *solver,
     solver->workers = NULL;
     solver->worker_ids = NULL;
     solver->cap_workers = 0;
+    solver->arr_cap = 0;
   }
   solver->workers_ld = ld;
 
-  if (solver->cap_workers < solver->threads) {
-    solver->workers = realloc_or_die(
-        solver->workers, sizeof(EndgameCtxWorker *) * solver->threads);
-    solver->worker_ids = realloc_or_die(solver->worker_ids,
-                                        sizeof(cpthread_t) * solver->threads);
-    for (int idx = solver->cap_workers; idx < solver->threads; idx++) {
-      solver->workers[idx] =
-          endgame_ctx_create_worker(solver, idx, base_seed, solver->game);
+  // Size the arrays to the injection ceiling so endgame_add_worker can append
+  // late workers without reallocating the arrays while threads are running.
+  const int needed_cap = solver->max_workers > solver->threads
+                             ? solver->max_workers
+                             : solver->threads;
+  if (solver->arr_cap < needed_cap) {
+    solver->workers = realloc_or_die(solver->workers,
+                                     sizeof(EndgameCtxWorker *) * needed_cap);
+    solver->worker_ids =
+        realloc_or_die(solver->worker_ids, sizeof(cpthread_t) * needed_cap);
+    for (int idx = solver->arr_cap; idx < needed_cap; idx++) {
+      solver->workers[idx] = NULL;
     }
+    solver->arr_cap = needed_cap;
+  }
+  // Create the initial worker structs lazily (reused across solves). Late
+  // workers beyond solver->threads are created on demand by endgame_add_worker.
+  // needed_cap >= threads above, so whenever this loop runs (threads > 0) the
+  // array was allocated; assert it for the static analyzer and as a guard.
+  assert(solver->threads == 0 || solver->workers != NULL);
+  for (int idx = solver->cap_workers; idx < solver->threads; idx++) {
+    solver->workers[idx] =
+        endgame_ctx_create_worker(solver, idx, base_seed, solver->game);
+  }
+  if (solver->cap_workers < solver->threads) {
     solver->cap_workers = solver->threads;
   }
   // Cached workers persist across solves; the ordinal is the array position and
@@ -2726,8 +2765,30 @@ void endgame_solve_inline(EndgameCtx **ctx, const EndgameArgs *endgame_args,
   // Suppress stuck-tile log to avoid localtime thread safety issues.
   atomic_store(&solver->stuck_tile_logged, 1);
 
+  // Open the injection window so helpers can be added mid-search via
+  // endgame_add_worker while this thread runs the master (ordinal 0). The
+  // calling thread is the master, so unlike endgame_solve there is no spawned
+  // thread for ordinal 0 — only injected helpers (ordinals > 0) are joined.
+  if (solver->max_workers > solver->threads) {
+    cpthread_mutex_lock(&solver->add_mutex);
+    atomic_store(&solver->window_open_ns, ctimer_monotonic_ns());
+    atomic_store(&solver->adding_closed, 0);
+    cpthread_mutex_unlock(&solver->add_mutex);
+  }
+
   // Run IDS directly in the calling thread.
   iterative_deepening(solver->workers[0], solver->requested_plies);
+
+  // Shut the window and join any injected helpers. live_workers counts the
+  // in-thread master (solver->threads, normally 1) plus any added workers, so
+  // the spawned pthreads are [solver->threads, live_workers).
+  cpthread_mutex_lock(&solver->add_mutex);
+  atomic_store(&solver->adding_closed, 1);
+  const int total_workers = atomic_load(&solver->live_workers);
+  cpthread_mutex_unlock(&solver->add_mutex);
+  for (int idx = solver->threads; idx < total_workers; idx++) {
+    cpthread_join(solver->worker_ids[idx]);
+  }
 
   const PVLine *best_pv =
       endgame_results_get_pvline(results, ENDGAME_RESULT_BEST);
@@ -2777,8 +2838,30 @@ void endgame_solve(EndgameCtx **ctx, const EndgameArgs *endgame_args,
                     solver->workers[thread_index]);
   }
 
-  // Wait for all threads to complete
+  // Open the injection window now that the initial workers exist and the solve
+  // state is fully published. endgame_add_worker may now grow the worker count.
+  if (solver->max_workers > solver->threads) {
+    cpthread_mutex_lock(&solver->add_mutex);
+    atomic_store(&solver->window_open_ns, ctimer_monotonic_ns());
+    atomic_store(&solver->adding_closed, 0);
+    cpthread_mutex_unlock(&solver->add_mutex);
+  }
+
+  // Wait for the initial workers. The master (ordinal 0) drives completion, so
+  // once these exit the search has finished (or interrupted/timed out).
   for (int thread_index = 0; thread_index < solver->threads; thread_index++) {
+    cpthread_join(solver->worker_ids[thread_index]);
+  }
+
+  // Shut the injection window and join any workers added mid-search. Under the
+  // lock so no add is half-spawned when we snapshot the count; late workers
+  // also exit on search_complete, so they are done or finishing.
+  cpthread_mutex_lock(&solver->add_mutex);
+  atomic_store(&solver->adding_closed, 1);
+  const int total_workers = atomic_load(&solver->live_workers);
+  cpthread_mutex_unlock(&solver->add_mutex);
+  for (int thread_index = solver->threads; thread_index < total_workers;
+       thread_index++) {
     cpthread_join(solver->worker_ids[thread_index]);
   }
 
@@ -2810,8 +2893,8 @@ void endgame_solve(EndgameCtx **ctx, const EndgameArgs *endgame_args,
       // arena.
       int best_thread = 0;
       int best_depth = solver->workers[0]->completed_depth;
-      for (int thread_index = 1; thread_index < solver->threads;
-           thread_index++) {
+      const int live = atomic_load(&solver->live_workers);
+      for (int thread_index = 1; thread_index < live; thread_index++) {
         int thread_depth = solver->workers[thread_index]->completed_depth;
         if (thread_depth > best_depth) {
           best_depth = thread_depth;
@@ -2832,4 +2915,51 @@ void endgame_solve(EndgameCtx **ctx, const EndgameArgs *endgame_args,
       results, NULL, endgame_results_get_solving_player(results),
       endgame_results_get_max_depth(results));
   endgame_results_unlock(results, ENDGAME_RESULT_DISPLAY);
+}
+
+int endgame_live_workers(const EndgameCtx *ctx) {
+  return atomic_load(&ctx->live_workers);
+}
+
+bool endgame_injecting(const EndgameCtx *ctx) {
+  return atomic_load(&ctx->adding_closed) == 0;
+}
+
+int64_t endgame_window_open_ns(const EndgameCtx *ctx) {
+  return atomic_load(&ctx->window_open_ns);
+}
+
+bool endgame_add_worker(EndgameCtx *solver) {
+  cpthread_mutex_lock(&solver->add_mutex);
+  // Decline if the window is shut (between solves, or the join has begun) or
+  // the max_workers ceiling (== arr_cap) is reached.
+  if (atomic_load(&solver->adding_closed)) {
+    cpthread_mutex_unlock(&solver->add_mutex);
+    return false;
+  }
+  const int ordinal = atomic_load(&solver->live_workers);
+  if (ordinal >= solver->arr_cap) {
+    cpthread_mutex_unlock(&solver->add_mutex);
+    return false;
+  }
+
+  // Create the worker struct on first use at this ordinal; reuse it on later
+  // solves. Either way, stamp this solve's ordinal. The worker's MoveGen cache
+  // slot is assigned on demand by get_movegen() when it first generates moves.
+  if (ordinal >= solver->cap_workers) {
+    solver->workers[ordinal] = endgame_ctx_create_worker(
+        solver, ordinal, solver->worker_base_seed, solver->game);
+    solver->cap_workers = ordinal + 1;
+  } else {
+    solver->workers[ordinal]->ordinal = ordinal;
+  }
+  // Prep the late worker's game from the read-only root inputs (solver->game +
+  // pruned KWGs + fresh cross-sets) — NOT from worker 0, whose game_copy is
+  // mid-traversal. Seeds the worker PRNG by its ordinal.
+  endgame_ctx_reset_worker_and_game(solver, solver->worker_base_seed, ordinal);
+  cpthread_create(&solver->worker_ids[ordinal], solver_worker_start,
+                  solver->workers[ordinal]);
+  atomic_store(&solver->live_workers, ordinal + 1);
+  cpthread_mutex_unlock(&solver->add_mutex);
+  return true;
 }

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -560,12 +560,24 @@ void endgame_ctx_reset(EndgameCtx *es, EndgameResults *results,
   if (es->threads < 1) {
     es->threads = 1;
   }
+  // Normalize the injection ceiling so later logic has one interpretation:
+  // clamp to MAX_THREADS (injected workers draw MoveGen slots from a pool
+  // capped there, and the worker arrays are sized to it), and treat any
+  // ceiling <= threads as "no growth" (0).
   es->max_workers = endgame_args->max_workers;
+  if (es->max_workers > MAX_THREADS) {
+    es->max_workers = MAX_THREADS;
+  }
+  if (es->max_workers <= es->threads) {
+    es->max_workers = 0;
+  }
   // Injection window starts shut: endgame_solve opens it once the initial
   // workers are spawned, and shuts it again before the join. live_workers
-  // counts the initial set until adds bump it.
+  // counts the initial set until adds bump it. Clear window_open_ns so a
+  // monitor can't read a stale timestamp from a previous solve.
   atomic_store(&es->adding_closed, 1);
   atomic_store(&es->live_workers, es->threads);
+  atomic_store(&es->window_open_ns, (int64_t)0);
   es->requested_plies = endgame_args->plies;
   es->solving_player = game_get_player_on_turn_index(endgame_args->game);
   es->initial_small_move_arena_size =
@@ -2756,6 +2768,13 @@ void endgame_solve_inline(EndgameCtx **ctx, const EndgameArgs *endgame_args,
   EndgameCtx *solver = *ctx;
 
   endgame_ctx_reset(solver, results, endgame_args);
+  // The inline master runs in the calling thread, so the base worker count is
+  // always 1 regardless of the caller's num_threads — only injected helpers
+  // (ordinals > 0) are spawned. Force threads/live_workers to 1 so injection
+  // ordinals and join ranges stay consistent (otherwise helpers would start at
+  // ordinal == num_threads, leaving gaps).
+  solver->threads = 1;
+  atomic_store(&solver->live_workers, 1);
 
   uint64_t base_seed = endgame_args->seed != 0
                            ? endgame_args->seed

--- a/src/impl/endgame.h
+++ b/src/impl/endgame.h
@@ -88,24 +88,26 @@ typedef struct EndgameArgs {
 void pvline_extend_from_tt(PVLine *pv_line, Game *game_copy,
                            TranspositionTable *tt, int solving_player,
                            int max_depth);
-// Allocate an empty endgame context (reused across solves). Lets a caller
-// pre-create per-worker contexts so their pointers are stable before any
-// concurrent observer (e.g. an injection monitor) reads them.
+// Allocate an empty endgame context (reused across solves). Returns a single
+// EndgameCtx; pre-creating it lets a caller hold a stable pointer before any
+// concurrent observer (e.g. an injection monitor) reads it.
 EndgameCtx *endgame_ctx_create(void);
 void endgame_ctx_destroy(EndgameCtx *ctx);
 void endgame_solve(EndgameCtx **ctx, const EndgameArgs *endgame_args,
                    EndgameResults *results, ErrorStack *error_stack);
-// Inject one additional ABDADA worker into an in-flight multithreaded
-// endgame_solve. Intended to be called from another thread while endgame_solve
-// is blocked in its join phase — e.g. a pool that lends an idle core to a
-// long-running leaf solve. The new worker gets the next free ordinal (> 0,
-// never the root master), its own ABDADA jitter from that ordinal, a game copy
-// from the (read-only) root inputs, and a MoveGen cache slot assigned on demand
-// by get_movegen(); it cooperates with the running workers purely through the
-// shared TT and self-exits when the search completes. Returns true if a worker
-// was spawned, false if the injection window is shut or the max_workers ceiling
-// is reached. Only valid against a ctx whose current solve was launched with
-// max_workers > num_threads.
+// Inject one additional ABDADA worker into an in-flight solve. Works against
+// both entry points: endgame_solve (spawned master) and endgame_solve_inline
+// (the calling thread is the master). It may be called from another thread
+// (e.g. a pool lending an idle core) or from the solving thread itself — the
+// injection test drives it from the master's per_ply_callback. The new worker
+// gets the next free ordinal (> 0, never the root master), its own ABDADA
+// jitter from that ordinal, a game copy from the (read-only) root inputs, and a
+// MoveGen cache slot assigned on demand by get_movegen(); it cooperates with
+// the running workers purely through the shared TT and self-exits when the
+// search completes. Returns true if a worker was spawned, false if the
+// injection window is shut or the max_workers ceiling is reached. Only valid
+// against a ctx whose current solve was launched with max_workers enabling
+// growth (max_workers > effective thread count after reset normalization).
 bool endgame_add_worker(EndgameCtx *ctx);
 
 // Number of worker threads currently live in this solve (master + injected

--- a/src/impl/endgame.h
+++ b/src/impl/endgame.h
@@ -67,6 +67,13 @@ typedef struct EndgameArgs {
   // own. The caller is responsible for the lifetime of the shared TT.
   // tt_fraction_of_mem is ignored when shared_tt is set.
   TranspositionTable *shared_tt;
+  // Ceiling on the worker count for dynamic injection. When > num_threads the
+  // solve starts with num_threads workers but endgame_add_worker may grow it
+  // up to max_workers mid-search (e.g. a pool lending cores as they free up).
+  // The workers[]/worker_ids[] arrays are sized to this ceiling so growth
+  // never reallocates them out from under the running threads. 0 (or <=
+  // num_threads) disables growth — the solve runs with exactly num_threads.
+  int max_workers;
   // First-win optimization: search a narrow [-1, +1] window so the solver
   // returns only win/loss/draw rather than exact spread. Faster (more
   // alpha-beta cutoffs) but exact spread is unknown when set.
@@ -81,9 +88,35 @@ typedef struct EndgameArgs {
 void pvline_extend_from_tt(PVLine *pv_line, Game *game_copy,
                            TranspositionTable *tt, int solving_player,
                            int max_depth);
+// Allocate an empty endgame context (reused across solves). Lets a caller
+// pre-create per-worker contexts so their pointers are stable before any
+// concurrent observer (e.g. an injection monitor) reads them.
+EndgameCtx *endgame_ctx_create(void);
 void endgame_ctx_destroy(EndgameCtx *ctx);
 void endgame_solve(EndgameCtx **ctx, const EndgameArgs *endgame_args,
                    EndgameResults *results, ErrorStack *error_stack);
+// Inject one additional ABDADA worker into an in-flight multithreaded
+// endgame_solve. Intended to be called from another thread while endgame_solve
+// is blocked in its join phase — e.g. a pool that lends an idle core to a
+// long-running leaf solve. The new worker gets the next free ordinal (> 0,
+// never the root master), its own ABDADA jitter from that ordinal, a game copy
+// from the (read-only) root inputs, and a MoveGen cache slot assigned on demand
+// by get_movegen(); it cooperates with the running workers purely through the
+// shared TT and self-exits when the search completes. Returns true if a worker
+// was spawned, false if the injection window is shut or the max_workers ceiling
+// is reached. Only valid against a ctx whose current solve was launched with
+// max_workers > num_threads.
+bool endgame_add_worker(EndgameCtx *ctx);
+
+// Number of worker threads currently live in this solve (master + injected
+// helpers). Lets an injection monitor cap total threads near the core count.
+int endgame_live_workers(const EndgameCtx *ctx);
+// True while the solve is accepting injected workers (window open).
+bool endgame_injecting(const EndgameCtx *ctx);
+// Monotonic-ns timestamp when the injection window last opened. Lets a monitor
+// inject only into endgames that have run long enough to be worth helping
+// (skipping the many sub-millisecond leaf solves).
+int64_t endgame_window_open_ns(const EndgameCtx *ctx);
 // Single-threaded endgame solve that runs in the calling thread (no
 // cpthread_create). Safe for use from concurrent PEG decomp threads, which
 // cooperate through the per-thread MoveGen pool (get_movegen auto-assigns a

--- a/test/endgame_test.c
+++ b/test/endgame_test.c
@@ -312,15 +312,16 @@ static void inject_worker_per_ply(int depth, int32_t value,
 // Dynamic worker injection: a solve started with one thread must absorb extra
 // ABDADA workers injected mid-search (as cores free up) and still return the
 // exact single-threaded value. ABDADA is value-deterministic regardless of
-// thread count or when workers join, so the result must equal the known -74.
+// thread count or when workers join, so the result must equal the known -63.
 // Exercised for both endgame_solve (master is a spawned thread) and
 // endgame_solve_inline (master runs in the calling thread — the path PEG uses,
 // where injected helpers cooperate while the caller's own core keeps solving).
-// 4 plies keeps it cheap enough for CI while still injecting one worker per IDS
-// depth; the value-determinism property is what matters, not the search depth.
+// 6 plies is the shallowest depth that reaches the converged -63 (5 gives -60),
+// and still injects one worker per IDS depth — the value-determinism property
+// is what the test checks, not the search depth.
 static void run_injection_case(bool use_inline) {
   Config *config =
-      config_create_or_die("set -s1 score -s2 score -threads 1 -eplies 4");
+      config_create_or_die("set -s1 score -s2 score -threads 1 -eplies 6");
   load_and_exec_config_or_die(
       config,
       "cgp "
@@ -367,7 +368,7 @@ static void run_injection_case(bool use_inline) {
 
   printf("dynamic-worker-injection (%s): value=%d workers_added=%d\n",
          use_inline ? "inline" : "spawned", value, injector.added);
-  assert(value == -74);
+  assert(value == -63);
   assert(injector.added > 0); // at least one helper joined mid-search
 
   error_stack_destroy(error_stack);

--- a/test/endgame_test.c
+++ b/test/endgame_test.c
@@ -276,6 +276,104 @@ void test_pass_first(void) {
       0);
 }
 
+// Drives endgame_add_worker from inside the running solve: the per-ply
+// callback fires on the master worker after each completed depth, and injects
+// one extra ABDADA worker per ply (up to max_attempts) — modeling a pool that
+// lends idle cores mid-search. Each injected worker draws its own MoveGen cache
+// slot from get_movegen() (per-pthread), so the injector hands out no slots.
+typedef struct WorkerInjector {
+  EndgameCtx **solver_ptr; // address of the caller's ctx (set by endgame_solve)
+  int max_attempts;        // cap on injection attempts (one per ply)
+  int attempts;            // attempts made so far
+  int added;               // successful injections
+} WorkerInjector;
+
+static void inject_worker_per_ply(int depth, int32_t value,
+                                  const PVLine *pv_line, const Game *game,
+                                  const PVLine *ranked_pvs, int num_ranked_pvs,
+                                  void *user_data) {
+  (void)depth;
+  (void)value;
+  (void)pv_line;
+  (void)game;
+  (void)ranked_pvs;
+  (void)num_ranked_pvs;
+  WorkerInjector *injector = (WorkerInjector *)user_data;
+  EndgameCtx *solver = *injector->solver_ptr;
+  if (solver == NULL || injector->attempts >= injector->max_attempts) {
+    return;
+  }
+  if (endgame_add_worker(solver)) {
+    injector->added++;
+  }
+  injector->attempts++;
+}
+
+// Dynamic worker injection: a solve started with one thread must absorb extra
+// ABDADA workers injected mid-search (as cores free up) and still return the
+// exact single-threaded value. ABDADA is value-deterministic regardless of
+// thread count or when workers join, so the result must equal the known -63.
+// Exercised for both endgame_solve (master is a spawned thread) and
+// endgame_solve_inline (master runs in the calling thread — the path PEG uses,
+// where injected helpers cooperate while the caller's own core keeps solving).
+static void run_injection_case(bool use_inline) {
+  Config *config =
+      config_create_or_die("set -s1 score -s2 score -threads 1 -eplies 7");
+  load_and_exec_config_or_die(
+      config,
+      "cgp "
+      "GATELEGs1POGOED/R4MOOLI3X1/AA10U2/YU4BREDRIN2/1TITULE3E1IN1/1E4N3c1BOK/"
+      "1C2O4CHARD1/QI1FLAWN2E1OE1/IS2E1HIN1A1W2/1MOTIVATE1T1S2/1S2N5S4/"
+      "3PERJURY5/15/15/15 FV/AADIZ 442/388 0 -lex CSW21");
+
+  Game *game = config_get_game(config);
+  EndgameResults *results = config_get_endgame_results(config);
+
+  EndgameCtx *ctx = NULL;
+  // Model a pool lending up to 4 idle cores mid-search (one per ply).
+  WorkerInjector injector = {
+      .solver_ptr = &ctx, .max_attempts = 4, .attempts = 0, .added = 0};
+
+  EndgameArgs args = {0};
+  args.thread_control = config_get_thread_control(config);
+  args.game = game;
+  args.plies = config_get_endgame_plies(config);
+  args.tt_fraction_of_mem = config_get_tt_fraction_of_mem(config);
+  args.initial_small_move_arena_size = DEFAULT_INITIAL_SMALL_MOVE_ARENA_SIZE;
+  args.num_threads = 1; // start single-threaded...
+  args.max_workers = 5; // ...and allow growth to 1 + 4 injected
+  args.use_heuristics = true;
+  args.forced_pass_bypass = true;
+  args.num_top_moves = 1;
+  args.seed = 42;
+  args.per_ply_callback = inject_worker_per_ply;
+  args.per_ply_callback_data = &injector;
+
+  ErrorStack *error_stack = error_stack_create();
+  if (use_inline) {
+    endgame_solve_inline(&ctx, &args, results);
+  } else {
+    endgame_solve(&ctx, &args, results, error_stack);
+  }
+  assert(error_stack_is_empty(error_stack));
+  const int32_t value =
+      endgame_results_get_pvline(results, ENDGAME_RESULT_BEST)->score;
+
+  printf("dynamic-worker-injection (%s): value=%d workers_added=%d\n",
+         use_inline ? "inline" : "spawned", value, injector.added);
+  assert(value == -63);
+  assert(injector.added > 0); // at least one helper joined mid-search
+
+  error_stack_destroy(error_stack);
+  endgame_ctx_destroy(ctx);
+  config_destroy(config);
+}
+
+void test_endgame_dynamic_worker_injection(void) {
+  run_injection_case(/*use_inline=*/false);
+  run_injection_case(/*use_inline=*/true);
+}
+
 void test_nonempty_bag(void) {
   // The solver should return an error if the bag is not empty.
   test_single_endgame("set -s1 score -s2 score -threads 6 -eplies 4",

--- a/test/endgame_test.c
+++ b/test/endgame_test.c
@@ -312,13 +312,15 @@ static void inject_worker_per_ply(int depth, int32_t value,
 // Dynamic worker injection: a solve started with one thread must absorb extra
 // ABDADA workers injected mid-search (as cores free up) and still return the
 // exact single-threaded value. ABDADA is value-deterministic regardless of
-// thread count or when workers join, so the result must equal the known -63.
+// thread count or when workers join, so the result must equal the known -74.
 // Exercised for both endgame_solve (master is a spawned thread) and
 // endgame_solve_inline (master runs in the calling thread — the path PEG uses,
 // where injected helpers cooperate while the caller's own core keeps solving).
+// 4 plies keeps it cheap enough for CI while still injecting one worker per IDS
+// depth; the value-determinism property is what matters, not the search depth.
 static void run_injection_case(bool use_inline) {
   Config *config =
-      config_create_or_die("set -s1 score -s2 score -threads 1 -eplies 7");
+      config_create_or_die("set -s1 score -s2 score -threads 1 -eplies 4");
   load_and_exec_config_or_die(
       config,
       "cgp "
@@ -338,7 +340,11 @@ static void run_injection_case(bool use_inline) {
   args.thread_control = config_get_thread_control(config);
   args.game = game;
   args.plies = config_get_endgame_plies(config);
-  args.tt_fraction_of_mem = config_get_tt_fraction_of_mem(config);
+  // Tiny TT (clamps to the 2^24 minimum) instead of the 0.25 default: this
+  // small endgame needs almost no TT, and allocating + zeroing a multi-GB
+  // table twice (once per case) dominated the test's runtime. The solved value
+  // is exact regardless of TT size, so this only affects speed.
+  args.tt_fraction_of_mem = 0.0001;
   args.initial_small_move_arena_size = DEFAULT_INITIAL_SMALL_MOVE_ARENA_SIZE;
   args.num_threads = 1; // start single-threaded...
   args.max_workers = 5; // ...and allow growth to 1 + 4 injected
@@ -361,7 +367,7 @@ static void run_injection_case(bool use_inline) {
 
   printf("dynamic-worker-injection (%s): value=%d workers_added=%d\n",
          use_inline ? "inline" : "spawned", value, injector.added);
-  assert(value == -63);
+  assert(value == -74);
   assert(injector.added > 0); // at least one helper joined mid-search
 
   error_stack_destroy(error_stack);

--- a/test/endgame_test.h
+++ b/test/endgame_test.h
@@ -11,5 +11,6 @@ void test_via_mover_must_bingo_every_depth(void);
 void test_via_mover_bingo_one_ply(void);
 void test_via_opp_must_block_every_depth(void);
 void test_via_interrupted_reasonable_under_time_pressure(void);
+void test_endgame_dynamic_worker_injection(void);
 
 #endif

--- a/test/test.c
+++ b/test/test.c
@@ -134,6 +134,7 @@ static TestEntry on_demand_test_table[] = {
     {"ap_wmp", test_autoplay_wmp_correctness},
     {"ap_rest", test_autoplay_remaining},
     {"endgame_wasm", test_endgame_wasm},
+    {"endgameinject", test_endgame_dynamic_worker_injection},
     {"viamover", test_via_mover_must_bingo_every_depth},
     {"viaopp", test_via_opp_must_block_every_depth},
     {"viastress", test_via_interrupted_reasonable_under_time_pressure},


### PR DESCRIPTION
The remaining endgame-infra PR (its predecessor #544 is merged). Adds **dynamic worker injection**: a solve can grow its worker count mid-search, so a thread pool can lend idle cores to a long-running leaf endgame — the mechanism PEG uses to keep cores busy. Now based directly on `main`.

## What's here

- **`endgame_add_worker(ctx)`** — inject one more ABDADA worker into an in-flight solve, against **both** entry points: `endgame_solve` (spawned master) and `endgame_solve_inline` (the calling thread is the master). Callable from another thread (a pool lending a core) or from the solving thread itself (the test drives it from the master's `per_ply_callback`). The late worker takes the next ordinal (never 0/root-master), gets its own ABDADA jitter and a game copy from the read-only root inputs, draws its MoveGen cache slot on demand from `get_movegen()` (per-pthread, via #541's pool), and self-exits when the search completes. Returns `false` if the window is shut or the `max_workers` ceiling is reached.
- **`EndgameArgs.max_workers`** — growth ceiling, normalized at reset: clamped to `MAX_THREADS` (workers draw slots from a pool capped there, and the worker arrays are sized to it) and treated as `0` (no growth) when `<= threads`, so all later logic has one interpretation. `workers[]`/`worker_ids[]` are pre-sized to it (`arr_cap` vs `cap_workers`) so injection never reallocates arrays out from under running threads.
- **Injection window** — opened after the initial workers spawn (or before IDS in the inline path), shut before the join, guarded by `add_mutex` + an `adding_closed` flag; `live_workers`/`window_open_ns` are atomics, both reset per solve (no stale timestamps).
- **Inline master is always single-threaded** — `endgame_solve_inline` forces `threads`/`live_workers` to 1 after reset (the master runs in the calling thread), so injected helpers always start at ordinal 1 with no gaps regardless of the caller's `num_threads`.
- **Observers for a monitor** — `endgame_live_workers`, `endgame_injecting`, `endgame_window_open_ns` (lets a monitor skip helping sub-millisecond leaves).

A worker's only per-solve identity is its **ordinal** (stable across solves; drives ABDADA jitter and the root-master role). ABDADA is value-deterministic regardless of thread count or when helpers join, so an injected worker's MoveGen slot — assigned on demand by the per-thread pool — doesn't affect the result.

## Test (runs in CI)

- `endgameinject` (`test_endgame_dynamic_worker_injection`) injects 4 workers one-per-ply into both the threaded master and the inline master; ABDADA value-determinism means both must return the exact **−63**, and `workers_added > 0` confirms helpers actually joined mid-search.
- Wired into the `eldar_v` unit-test shard so the injection path is covered in CI. Tuned to stay cheap: a tiny TT (the default 0.25 fraction was allocating + zeroing a multi-GB table twice for a trivial endgame) and **6 plies** — the shallowest depth that reaches the converged −63 (5 gives −60). ~0.26→0.86s release / ~26s ASan, down from ~1.9s / ~32s.

## Verification

- `endgameinject` + all endgame tests pass; full release suite + `sim` clean.
- **TSAN clean on the injection path** — `endgameinject` runs race-free (0 warnings) for both the spawned and inline masters.
- clang-format-20 + cppcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
