### PR TITLE
bai: per-arm PRNG streams for reproducible synthetic sampling

### DIFF
--- a/src/impl/random_variable.c
+++ b/src/impl/random_variable.c
@@ -167,25 +167,49 @@ void rv_uniform_predetermined_reset(RandomVariables *rvs) {
 }
 
 typedef struct RVNormal {
-  XoshiroPRNG *xoshiro_prng;
+  // One PRNG per arm, each seeded with a non-overlapping subsequence, guarded
+  // by its own mutex. See rv_normal_seed_arm_prngs / rv_normal_sample for why.
+  XoshiroPRNG **xoshiro_prngs;
+  cpthread_mutex_t *mutexes;
+  uint64_t num_arms;
   double *means_and_vars;
-  cpthread_mutex_t mutex;
 } RVNormal;
+
+// Re-seeds every arm's PRNG so arm k draws from the subsequence reached by
+// jumping the base stream k times (2^128 draws apart). Independent per-arm
+// streams make an arm's sample sequence -- hence its running mean/variance
+// after N draws -- a function of N alone, not of how worker threads interleave
+// across arms, which keeps BAI results reproducible across thread counts.
+static void rv_normal_seed_arm_prngs(RVNormal *rv_normal, const uint64_t seed) {
+  for (uint64_t arm = 0; arm < rv_normal->num_arms; arm++) {
+    prng_seed(rv_normal->xoshiro_prngs[arm], seed);
+    for (uint64_t jump = 0; jump < arm; jump++) {
+      prng_jump(rv_normal->xoshiro_prngs[arm]);
+    }
+  }
+}
 
 double rv_normal_sample(RandomVariables *rvs, const uint64_t k,
                         const int __attribute__((unused)) thread_index,
                         const uint64_t __attribute__((unused)) sample_count,
                         BAILogger __attribute__((unused)) * bai_logger) {
-  // Implements the Box-Muller transform
+  // Implements the Box-Muller transform. The arm's mutex is held across the
+  // entire rejection loop so each logical sample consumes a contiguous block
+  // of draws; otherwise concurrent draws on the same arm could re-pair (u, v)
+  // and change the nonlinear result, breaking reproducibility.
   RVNormal *rv_normal = (RVNormal *)rvs->data;
+  XoshiroPRNG *arm_prng = rv_normal->xoshiro_prngs[k];
+  cpthread_mutex_t *arm_mutex = &rv_normal->mutexes[k];
   double u = 0.0;
   double s = 2.0;
+  cpthread_mutex_lock(arm_mutex);
   while (s >= 1.0 || s == 0.0) {
-    u = 2.0 * uniform_sample(rv_normal->xoshiro_prng, &rv_normal->mutex) - 1.0;
+    u = 2.0 * ((double)prng_next(arm_prng) / (double)UINT64_MAX) - 1.0;
     const double v =
-        2.0 * uniform_sample(rv_normal->xoshiro_prng, &rv_normal->mutex) - 1.0;
+        2.0 * ((double)prng_next(arm_prng) / (double)UINT64_MAX) - 1.0;
     s = u * u + v * v;
   }
+  cpthread_mutex_unlock(arm_mutex);
   s = sqrt(-2.0 * log(s) / s);
   return rv_normal->means_and_vars[k * 2] +
          rv_normal->means_and_vars[k * 2 + 1] * u * s;
@@ -206,7 +230,11 @@ bool rv_normal_are_similar(RandomVariables *rvs, const int i, const int j) {
 
 void rv_normal_destroy(RandomVariables *rvs) {
   RVNormal *rv_normal = (RVNormal *)rvs->data;
-  prng_destroy(rv_normal->xoshiro_prng);
+  for (uint64_t arm = 0; arm < rv_normal->num_arms; arm++) {
+    prng_destroy(rv_normal->xoshiro_prngs[arm]);
+  }
+  free(rv_normal->xoshiro_prngs);
+  free(rv_normal->mutexes);
   free(rv_normal->means_and_vars);
   free(rv_normal);
 }
@@ -218,17 +246,25 @@ void rv_normal_create(RandomVariables *rvs, const uint64_t seed,
   rvs->destroy_data_func = rv_normal_destroy;
   rvs->get_best_arm_index_func = rv_unsupported_get_best_arm_index;
   RVNormal *rv_normal = malloc_or_die(sizeof(RVNormal));
-  rv_normal->xoshiro_prng = prng_create(seed);
+  rv_normal->num_arms = rvs->num_rvs;
+  rv_normal->xoshiro_prngs =
+      malloc_or_die(rv_normal->num_arms * sizeof(XoshiroPRNG *));
+  rv_normal->mutexes =
+      malloc_or_die(rv_normal->num_arms * sizeof(cpthread_mutex_t));
+  for (uint64_t arm = 0; arm < rv_normal->num_arms; arm++) {
+    rv_normal->xoshiro_prngs[arm] = prng_create(seed);
+    cpthread_mutex_init(&rv_normal->mutexes[arm]);
+  }
+  rv_normal_seed_arm_prngs(rv_normal, seed);
   rv_normal->means_and_vars = malloc_or_die(rvs->num_rvs * 2 * sizeof(double));
   memcpy(rv_normal->means_and_vars, means_and_vars,
          rvs->num_rvs * 2 * sizeof(double));
-  cpthread_mutex_init(&rv_normal->mutex);
   rvs->data = rv_normal;
 }
 
 void rv_normal_reset(RandomVariables *rvs, const uint64_t seed) {
   RVNormal *rv_normal = (RVNormal *)rvs->data;
-  prng_seed(rv_normal->xoshiro_prng, seed);
+  rv_normal_seed_arm_prngs(rv_normal, seed);
 }
 
 typedef struct RVNormalPredetermined {

--- a/src/impl/random_variable.c
+++ b/src/impl/random_variable.c
@@ -221,8 +221,13 @@ double rv_normal_sample(RandomVariables *rvs, const uint64_t k,
   }
   cpthread_mutex_unlock(arm_mutex);
   s = sqrt(-2.0 * log(s) / s);
-  return rv_normal->means_and_vars[k * 2] +
-         rv_normal->means_and_vars[k * 2 + 1] * u * s;
+  // means_and_vars holds {mean, variance} per arm, so scale the unit normal
+  // (u * s) by the standard deviation. This matches the variance semantics used
+  // by rv_normal_predetermined_sample (which multiplies its unit sample by
+  // sqrt(sigma2)); without the sqrt the arm's variance would be variance^2.
+  const double mean = rv_normal->means_and_vars[k * 2];
+  const double variance = rv_normal->means_and_vars[k * 2 + 1];
+  return mean + sqrt(variance) * u * s;
 }
 
 bool rv_normal_are_similar(RandomVariables *rvs, const int i, const int j) {

--- a/src/impl/random_variable.c
+++ b/src/impl/random_variable.c
@@ -187,11 +187,16 @@ typedef struct RVNormal {
 // after N draws -- a function of N alone, not of how worker threads interleave
 // across arms, which keeps BAI results reproducible across thread counts.
 static void rv_normal_seed_arm_prngs(RVNormal *rv_normal, const uint64_t seed) {
-  for (uint64_t arm = 0; arm < rv_normal->num_arms; arm++) {
-    prng_seed(rv_normal->xoshiro_prngs[arm], seed);
-    for (uint64_t jump = 0; jump < arm; jump++) {
-      prng_jump(rv_normal->xoshiro_prngs[arm]);
-    }
+  if (rv_normal->num_arms == 0) {
+    return;
+  }
+  // Arm k's stream is the base stream jumped k times. Build them in O(num_arms)
+  // jumps by seeding arm 0, then copying the previous arm and advancing it one
+  // jump, rather than re-seeding and jumping k times per arm (O(num_arms^2)).
+  prng_seed(rv_normal->xoshiro_prngs[0], seed);
+  for (uint64_t arm = 1; arm < rv_normal->num_arms; arm++) {
+    prng_copy(rv_normal->xoshiro_prngs[arm], rv_normal->xoshiro_prngs[arm - 1]);
+    prng_jump(rv_normal->xoshiro_prngs[arm]);
   }
 }
 

--- a/src/impl/random_variable.c
+++ b/src/impl/random_variable.c
@@ -46,9 +46,15 @@ struct RandomVariables {
   void *data;
 };
 
+// Draws a uniform value in [0, 1) from prng. Caller must hold whatever mutex
+// guards prng (see uniform_sample for the self-locking variant).
+static inline double uniform_sample_while_locked(XoshiroPRNG *prng) {
+  return (double)prng_next(prng) / ((double)UINT64_MAX);
+}
+
 double uniform_sample(XoshiroPRNG *prng, cpthread_mutex_t *mutex) {
   cpthread_mutex_lock(mutex);
-  double result = (double)prng_next(prng) / ((double)UINT64_MAX);
+  double result = uniform_sample_while_locked(prng);
   cpthread_mutex_unlock(mutex);
   return result;
 }
@@ -204,9 +210,8 @@ double rv_normal_sample(RandomVariables *rvs, const uint64_t k,
   double s = 2.0;
   cpthread_mutex_lock(arm_mutex);
   while (s >= 1.0 || s == 0.0) {
-    u = 2.0 * ((double)prng_next(arm_prng) / (double)UINT64_MAX) - 1.0;
-    const double v =
-        2.0 * ((double)prng_next(arm_prng) / (double)UINT64_MAX) - 1.0;
+    u = 2.0 * uniform_sample_while_locked(arm_prng) - 1.0;
+    const double v = 2.0 * uniform_sample_while_locked(arm_prng) - 1.0;
     s = u * u + v * v;
   }
   cpthread_mutex_unlock(arm_mutex);

--- a/test/bai_test.c
+++ b/test/bai_test.c
@@ -42,7 +42,12 @@ void bai_wrapper(BAIOptions *bai_options, RandomVariables *rvs,
 }
 
 void test_bai_top_two(int num_threads) {
-  const double means_and_vars[] = {0.1, 1, 0.9, 1};
+  // The winning arm's spread is kept small so its empirical mean cannot drift
+  // to >= 1.0, which (with cutoff == 0) would trip an early WIN_PCT_CUTOFF stop
+  // before the GK16 threshold is reached. A variance of 1 here leaves the
+  // initial-phase mean of a 0.9 arm above 1.0 for a meaningful fraction of
+  // sample sequences.
+  const double means_and_vars[] = {0.1, 1, 0.9, 0.05};
   const int num_rvs = (sizeof(means_and_vars)) / (sizeof(double) * 2);
   RandomVariablesArgs rv_args = {
       .type = RANDOM_VARIABLES_NORMAL,


### PR DESCRIPTION
## Problem

`test_bai` flakes occasionally (seen in CI). The synthetic `RVNormal` arms share a single PRNG that is sampled *outside* the BAI sync mutex, so which raw PRNG draws form which logical sample depends on thread interleaving. Each arm's empirical mean — and therefore the identified best arm — is not reproducible across thread counts.

## Fix

Give each arm its own PRNG, seeded from a non-overlapping subsequence of the base stream (arm `k`'s stream is the base stream advanced by `k` `prng_jump`s, 2^128 draws apart), guarded by a **per-arm** mutex held across the **entire** Box-Muller rejection loop. Holding the lock across the whole loop means each logical sample consumes a contiguous block of draws and concurrent draws on the same arm can't re-pair `(u, v)` and change the nonlinear result.

Consequently an arm's sample sequence — hence its running mean/variance after N draws — is a function of N alone, independent of cross-arm thread interleaving. This mirrors how the real-sim path (`RANDOM_VARIABLES_SIMMED_PLAYS`, **untouched**) already achieves thread-count independence via per-play seeds.

**Result:** `test_bai` is now bit-identical at 1 and 11 threads.

## Also in this PR (review follow-ups)

- **`sqrt(variance)` scaling.** `rv_normal_sample` multiplied the unit normal by `means_and_vars[k*2+1]` directly, treating that field as a std-dev, while the rest of the code treats it as a variance (`rv_normal_predetermined_sample` uses `sqrt(sigma2)`; the field is named `…vars`). As written, an arm configured with variance `v` drew from a distribution with variance `v²`. Now scaled by `sqrt(variance)`. Pre-existing bug; arms with variance 1 (most BAI test arms) are unaffected since `sqrt(1) == 1`.
- **O(num_arms) seeding.** The per-arm streams are built by seeding arm 0 and then `prng_copy` + a single `prng_jump` from the previous arm, instead of re-seeding and jumping `k` times per arm (was O(num_arms²)). Bit-identical result.
- **Helper extraction.** The bare `prng_next(...) / UINT64_MAX` draw is factored into `uniform_sample_while_locked`, which the self-locking `uniform_sample` also calls.

## Test change

`test_bai_top_two` tightens the winning arm's variance (`{0.1,1, 0.9,1}` → `{0.1,1, 0.9,0.05}`). With `cutoff == 0`, a variance-1 `N(0.9)` arm's initial-phase empirical mean lands `>= 1.0` for a meaningful fraction of sample sequences, which trips an early `WIN_PCT_CUTOFF` stop before the asserted GK16 threshold — a latent fragility the old (lucky) realization happened to dodge. The 0.8 mean gap is preserved.

## Verification

- `./bin/magpie_test bai` ×40 (release): **0 failures**; top_two output byte-identical across all runs at both thread counts; re-verified deterministic after each follow-up commit.
- `bai`, `rv`, `sim` clean under dev ASan/UBSan — real sims (`SIMMED_PLAYS`) unaffected.
- Full release suite passes.
- `clang-format-20` clean; `cppcheck` (2.17.1) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
