### PR TITLE
tt: fastrange (multiply-shift) indexing for non-power-of-2 tables

### DIFF
--- a/src/ent/transposition_table.h
+++ b/src/ent/transposition_table.h
@@ -19,6 +19,18 @@
 #define TT_MIN_SIZE_POWER 24 // 2^24 minimum (256 MB) for performance
 #endif
 
+// Number of low hash bits stored per entry as a verification tag. fastrange
+// indexing (see tt_bucket_index) derives the bucket from the HIGH hash bits, so
+// the LOW bits are what discriminate distinct positions within a bucket. As
+// long as the table has at least 2^(64 - TT_TAG_BITS) entries, every bucket
+// spans at most 2^TT_TAG_BITS hashes, so two distinct hashes in the same bucket
+// cannot share a tag -- verification is exact, matching the old power-of-2 +
+// index-reconstruction scheme. With TT_TAG_BITS == 40 that threshold is 2^24,
+// i.e. TT_MIN_SIZE_POWER on native builds (WASM's 2^21 minimum loses a few high
+// bits, the same tradeoff the old scheme accepted on small tables).
+#define TT_TAG_BITS 40
+#define TT_TAG_MASK ((UINT64_C(1) << TT_TAG_BITS) - 1)
+
 enum {
   TT_EXACT = 0x01,
   TT_LOWER = 0x02,
@@ -32,9 +44,12 @@ enum {
 };
 
 typedef struct TTEntry {
-  uint32_t top_4_bytes; // Bits [63:32] of hash
+  // top_4_bytes and fifth_byte together hold the 40-bit verification tag: the
+  // low TT_TAG_BITS bits of the hash (top_4_bytes = tag bits [39:8],
+  // fifth_byte = tag bits [7:0]).
+  uint32_t top_4_bytes;
   int16_t score;
-  uint8_t fifth_byte; // Bits [31:24] of hash (40 stored bits total)
+  uint8_t fifth_byte;
   uint8_t flag_and_depth;
   uint64_t tiny_move;
 } TTEntry;
@@ -42,13 +57,17 @@ typedef struct TTEntry {
 static_assert(sizeof(TTEntry) == TTENTRY_SIZE_BYTES,
               "TTEntry must be exactly 16 bytes for lockless hashing");
 
-inline static uint64_t ttentry_full_hash(TTEntry t, uint64_t index,
-                                         int size_power) {
-  // Reconstruct hash from 40 stored bits + index bits.
-  // On large tables (size_power >= 24) all 64 bits are recovered.
-  // On smaller tables a few high bits are lost, which is acceptable.
-  uint64_t stored_hash = ((uint64_t)(t.top_4_bytes) << 8) | t.fifth_byte;
-  return (stored_hash << size_power) | index;
+// The 40-bit verification tag stored in an entry (low TT_TAG_BITS hash bits).
+inline static uint64_t ttentry_tag(TTEntry t) {
+  return ((uint64_t)(t.top_4_bytes) << 8) | t.fifth_byte;
+}
+
+// Lemire's fastrange (multiply-shift) reduction: map a uniformly distributed
+// 64-bit hash into [0, num_entries) without requiring num_entries to be a power
+// of two -- floor(zval * num_entries / 2^64), one 64x64->128 multiply + shift.
+// https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+inline static uint64_t tt_bucket_index(uint64_t zval, uint64_t num_entries) {
+  return (uint64_t)(((__uint128_t)zval * (__uint128_t)num_entries) >> 64);
 }
 
 inline static uint8_t ttentry_flag(TTEntry t) { return t.flag_and_depth >> 6; }
@@ -74,8 +93,10 @@ inline static void ttentry_reset(TTEntry *t) {
 typedef struct TranspositionTable {
   _Atomic uint64_t *table; // Pairs of uint64_t for lockless hashing
   atomic_uchar *nproc; // ABDADA: small table for tracking concurrent searches
-  int size_power_of_2;
-  uint64_t size_mask;
+  // Number of entries; NOT required to be a power of two thanks to fastrange
+  // indexing, so the table fills the requested memory fraction exactly instead
+  // of rounding down to the nearest power of two.
+  uint64_t num_entries;
   Zobrist *zobrist;
   atomic_int created;
   atomic_int hits;
@@ -91,37 +112,35 @@ transposition_table_create(double fraction_of_memory) {
   uint64_t desired_n_elems =
       (uint64_t)(fraction_of_memory *
                  ((double)(total_memory) / (double)TTENTRY_SIZE_BYTES));
-  // find biggest power of 2 lower than desired.
-  int size_required = 0;
-  while (desired_n_elems >>= 1) {
-    size_required++;
+
+  // Platform-specific minimum table size.
+  const uint64_t min_entries = UINT64_C(1) << TT_MIN_SIZE_POWER;
+  if (desired_n_elems < min_entries) {
+    if (desired_n_elems > 0) {
+      log_warn("TT size clamped to minimum: %llu elements (%llu MB)",
+               (unsigned long long)min_entries,
+               (unsigned long long)(min_entries * TTENTRY_SIZE_BYTES /
+                                    (1024 * 1024)));
+    }
+    desired_n_elems = min_entries;
   }
 
-  tt->size_power_of_2 = size_required;
-
-  // Platform-specific minimum table size
-  if (tt->size_power_of_2 < TT_MIN_SIZE_POWER) {
-    tt->size_power_of_2 = TT_MIN_SIZE_POWER;
-    log_warn("TT size clamped to minimum: 2^%d elements (%d MB)",
-             TT_MIN_SIZE_POWER,
-             (1 << TT_MIN_SIZE_POWER) * TTENTRY_SIZE_BYTES / (1024 * 1024));
-  }
-  int num_elems = 1 << tt->size_power_of_2;
-  size_t memory_mb = ((size_t)TTENTRY_SIZE_BYTES * num_elems) / (1024 * 1024);
-  log_info("Creating transposition table. System memory: %llu, TT size: 2^%d "
-           "(elements: %d, memory: %zu MB)",
-           (unsigned long long)total_memory, tt->size_power_of_2, num_elems,
-           memory_mb);
+  tt->num_entries = desired_n_elems;
+  size_t memory_mb =
+      (size_t)(TTENTRY_SIZE_BYTES * tt->num_entries) / (1024 * 1024);
+  log_info("Creating transposition table. System memory: %llu, TT entries: "
+           "%llu (memory: %zu MB)",
+           (unsigned long long)total_memory,
+           (unsigned long long)tt->num_entries, memory_mb);
   tt->table =
-      (_Atomic uint64_t *)malloc_or_die(sizeof(uint64_t) * 2 * num_elems);
-  memset(tt->table, 0, sizeof(uint64_t) * 2 * num_elems);
+      (_Atomic uint64_t *)malloc_or_die(sizeof(uint64_t) * 2 * tt->num_entries);
+  memset(tt->table, 0, sizeof(uint64_t) * 2 * tt->num_entries);
   // ABDADA: allocate smaller nproc table for tracking concurrent searches
   // Using a smaller table (256K vs millions) improves cache locality
   tt->nproc = (atomic_uchar *)malloc_or_die(sizeof(atomic_uchar) * NPROC_SIZE);
   for (int i = 0; i < NPROC_SIZE; i++) {
     atomic_init(&tt->nproc[i], 0);
   }
-  tt->size_mask = num_elems - 1;
   tt->zobrist = zobrist_create(12345); // Fixed seed for determinism
   atomic_init(&tt->created, 0);
   atomic_init(&tt->hits, 0);
@@ -133,8 +152,7 @@ transposition_table_create(double fraction_of_memory) {
 static inline void transposition_table_reset(TranspositionTable *tt) {
   // This function resets the transposition table. If you want to reallocate
   // space for it, destroy and recreate it with the new space.
-  uint64_t num_elems = tt->size_mask + 1;
-  memset(tt->table, 0, sizeof(uint64_t) * 2 * num_elems);
+  memset(tt->table, 0, sizeof(uint64_t) * 2 * tt->num_entries);
   // ABDADA: reset nproc counters (smaller table)
   for (int i = 0; i < NPROC_SIZE; i++) {
     atomic_store_explicit(&tt->nproc[i], 0, memory_order_relaxed);
@@ -147,7 +165,7 @@ static inline void transposition_table_reset(TranspositionTable *tt) {
 
 static inline TTEntry transposition_table_lookup(TranspositionTable *tt,
                                                  uint64_t zval) {
-  uint64_t idx = zval & tt->size_mask;
+  uint64_t idx = tt_bucket_index(zval, tt->num_entries);
   atomic_fetch_add(&tt->lookups, 1);
 
   // Lockless hashing (Hyatt 1999): each TTEntry is stored as two 8-byte
@@ -165,8 +183,7 @@ static inline TTEntry transposition_table_lookup(TranspositionTable *tt,
   memcpy(&entry, &key_half, 8);
   entry.tiny_move = data;
 
-  uint64_t full_hash = ttentry_full_hash(entry, idx, tt->size_power_of_2);
-  if (full_hash != zval) {
+  if (ttentry_tag(entry) != (zval & TT_TAG_MASK)) {
     if (ttentry_valid(entry)) {
       // There is another unrelated node at this position. This is a
       // type 2 collision.
@@ -185,11 +202,12 @@ static inline TTEntry transposition_table_lookup(TranspositionTable *tt,
 
 static inline void transposition_table_store(TranspositionTable *tt,
                                              uint64_t zval, TTEntry tentry) {
-  uint64_t idx = zval & tt->size_mask;
-  // Store top 40 bits of hash (shift right by size_power to remove index bits)
-  uint64_t stored_hash = zval >> tt->size_power_of_2;
-  tentry.top_4_bytes = (uint32_t)(stored_hash >> 8);
-  tentry.fifth_byte = (uint8_t)(stored_hash & 0xFF);
+  uint64_t idx = tt_bucket_index(zval, tt->num_entries);
+  // Store the low TT_TAG_BITS of the hash as the verification tag (the high
+  // bits are encoded by the bucket index under fastrange).
+  uint64_t tag = zval & TT_TAG_MASK;
+  tentry.top_4_bytes = (uint32_t)(tag >> 8);
+  tentry.fifth_byte = (uint8_t)(tag & 0xFF);
   atomic_fetch_add(&tt->created, 1);
 
   // Lockless hashing: XOR key half with data half so torn reads

--- a/src/ent/transposition_table.h
+++ b/src/ent/transposition_table.h
@@ -98,10 +98,12 @@ typedef struct TranspositionTable {
   // of rounding down to the nearest power of two.
   uint64_t num_entries;
   Zobrist *zobrist;
-  atomic_int created;
-  atomic_int hits;
-  atomic_int lookups;
-  atomic_int t2_collisions;
+  // 64-bit so they don't overflow on long searches (a deep solve can do
+  // billions of lookups, well past the old atomic_int range).
+  atomic_uint_fast64_t created;
+  atomic_uint_fast64_t hits;
+  atomic_uint_fast64_t lookups;
+  atomic_uint_fast64_t t2_collisions;
 } TranspositionTable;
 
 static inline TranspositionTable *

--- a/test/benchmark_endgame_test.c
+++ b/test/benchmark_endgame_test.c
@@ -14,6 +14,7 @@
 #include "../src/ent/player.h"
 #include "../src/ent/rack.h"
 #include "../src/ent/thread_control.h"
+#include "../src/ent/transposition_table.h"
 #include "../src/impl/cgp.h"
 #include "../src/impl/config.h"
 #include "../src/impl/endgame.h"
@@ -457,6 +458,120 @@ static void run_ab_benchmark(const char *cgp_file, const char *label,
   endgame_results_destroy(results);
   endgame_ctx_destroy(solver_old);
   endgame_ctx_destroy(solver_new);
+  config_destroy(config);
+}
+
+// Transposition-table benchmark: solve a batch of endgame positions against a
+// single reused (warm) TT and report cumulative TT activity -- lookups (~ nodes
+// visited), hit rate, type-2 collision rate -- plus nodes/sec. Used to compare
+// TT indexing schemes (power-of-2 mask vs fastrange multiply-shift) and the
+// effect of the resulting table size on hit rate. Reads CGPs from a file;
+// configure via env: TT_BENCH_FILE, TT_BENCH_PLIES, TT_BENCH_FRACTION,
+// TT_BENCH_MAX. Only uses TT stat fields common to both indexing schemes so the
+// same test compiles on either branch for an A/B.
+void test_tt_benchmark(void) {
+  log_set_level(LOG_FATAL);
+  const char *cgp_file = getenv("TT_BENCH_FILE");
+  if (!cgp_file) {
+    cgp_file = "/tmp/nonstuck_cgps.txt";
+  }
+  const char *plies_env = getenv("TT_BENCH_PLIES");
+  const int plies = plies_env ? atoi(plies_env) : 4;
+  const char *frac_env = getenv("TT_BENCH_FRACTION");
+  const double ttfraction = frac_env ? atof(frac_env) : 0.05;
+  const char *max_env = getenv("TT_BENCH_MAX");
+  const int max_positions = max_env ? atoi(max_env) : 200;
+
+  FILE *fp = fopen(cgp_file, "re");
+  if (!fp) {
+    printf("No CGP file at %s — run gennonstuck first.\n", cgp_file);
+    return;
+  }
+
+  Config *config =
+      config_create_or_die("set -lex CSW21 -threads 6 -s1 score -s2 score");
+  exec_config_quiet(config, "new");
+  Game *game = config_get_game(config);
+  EndgameResults *results = endgame_results_create();
+  EndgameCtx *solver = NULL;
+
+  char (*cgp_lines)[4096] = malloc((size_t)max_positions * 4096);
+  assert(cgp_lines);
+  int num_cgps = 0;
+  while (num_cgps < max_positions && fgets(cgp_lines[num_cgps], 4096, fp)) {
+    size_t len = strlen(cgp_lines[num_cgps]);
+    if (len > 0 && cgp_lines[num_cgps][len - 1] == '\n') {
+      cgp_lines[num_cgps][len - 1] = '\0';
+    }
+    if (strlen(cgp_lines[num_cgps]) > 0) {
+      num_cgps++;
+    }
+  }
+  (void)fclose(fp);
+
+  Timer timer;
+  ctimer_start(&timer);
+  int solved = 0;
+  for (int ci = 0; ci < num_cgps; ci++) {
+    ErrorStack *err = error_stack_create();
+    game_load_cgp(game, cgp_lines[ci], err);
+    if (!error_stack_is_empty(err)) {
+      error_stack_destroy(err);
+      continue;
+    }
+    error_stack_destroy(err);
+
+    EndgameArgs args = {.game = game,
+                        .thread_control = config_get_thread_control(config),
+                        .plies = plies,
+                        .tt_fraction_of_mem = ttfraction,
+                        .initial_small_move_arena_size =
+                            DEFAULT_INITIAL_SMALL_MOVE_ARENA_SIZE,
+                        .num_threads = 8,
+                        .num_top_moves = 1,
+                        .use_heuristics = true,
+                        .forced_pass_bypass = true,
+                        .enable_pv_display = false,
+                        .seed = 42};
+    err = error_stack_create();
+    endgame_solve(&solver, &args, results, err);
+    assert(error_stack_is_empty(err));
+    error_stack_destroy(err);
+    solved++;
+  }
+  const double elapsed = ctimer_elapsed_seconds(&timer);
+
+  // Cumulative TT stats (atomic_int; reinterpret as uint32 so counts up to 2^32
+  // are exact -- keep TT_BENCH_MAX/plies modest to avoid wrapping past that).
+  const TranspositionTable *tt =
+      solver ? endgame_ctx_get_transposition_table(solver) : NULL;
+  const uint64_t lookups =
+      tt ? (uint32_t)atomic_load(&tt->lookups) : (uint64_t)0;
+  const uint64_t hits = tt ? (uint32_t)atomic_load(&tt->hits) : (uint64_t)0;
+  const uint64_t created =
+      tt ? (uint32_t)atomic_load(&tt->created) : (uint64_t)0;
+  const uint64_t t2 =
+      tt ? (uint32_t)atomic_load(&tt->t2_collisions) : (uint64_t)0;
+
+  printf("\n=== TT benchmark ===\n");
+  printf("  positions:         %d (plies=%d, ttfraction=%.4f, threads=8)\n",
+         solved, plies, ttfraction);
+  printf("  wall time:         %.3fs\n", elapsed);
+  if (lookups > 0 && elapsed > 0) {
+    printf("  TT lookups (~nodes): %llu  (%.2f M lookups/s)\n",
+           (unsigned long long)lookups, (double)lookups / elapsed / 1e6);
+    printf("  TT hit rate:       %.2f%%  (%llu hits)\n",
+           100.0 * (double)hits / (double)lookups, (unsigned long long)hits);
+    printf("  TT stores:         %llu\n", (unsigned long long)created);
+    printf("  type-2 collisions: %llu  (%.4f%% of lookups)\n",
+           (unsigned long long)t2, 100.0 * (double)t2 / (double)lookups);
+  }
+  printf("====================\n");
+  (void)fflush(stdout);
+
+  free(cgp_lines);
+  endgame_results_destroy(results);
+  endgame_ctx_destroy(solver);
   config_destroy(config);
 }
 

--- a/test/benchmark_endgame_test.c
+++ b/test/benchmark_endgame_test.c
@@ -541,17 +541,16 @@ void test_tt_benchmark(void) {
   }
   const double elapsed = ctimer_elapsed_seconds(&timer);
 
-  // Cumulative TT stats (atomic_int; reinterpret as uint32 so counts up to 2^32
-  // are exact -- keep TT_BENCH_MAX/plies modest to avoid wrapping past that).
+  // Cumulative TT stats (64-bit counters).
   const TranspositionTable *tt =
       solver ? endgame_ctx_get_transposition_table(solver) : NULL;
   const uint64_t lookups =
-      tt ? (uint32_t)atomic_load(&tt->lookups) : (uint64_t)0;
-  const uint64_t hits = tt ? (uint32_t)atomic_load(&tt->hits) : (uint64_t)0;
+      tt ? (uint64_t)atomic_load(&tt->lookups) : (uint64_t)0;
+  const uint64_t hits = tt ? (uint64_t)atomic_load(&tt->hits) : (uint64_t)0;
   const uint64_t created =
-      tt ? (uint32_t)atomic_load(&tt->created) : (uint64_t)0;
+      tt ? (uint64_t)atomic_load(&tt->created) : (uint64_t)0;
   const uint64_t t2 =
-      tt ? (uint32_t)atomic_load(&tt->t2_collisions) : (uint64_t)0;
+      tt ? (uint64_t)atomic_load(&tt->t2_collisions) : (uint64_t)0;
 
   printf("\n=== TT benchmark ===\n");
   printf("  positions:         %d (plies=%d, ttfraction=%.4f, threads=8)\n",

--- a/test/benchmark_endgame_test.c
+++ b/test/benchmark_endgame_test.c
@@ -476,11 +476,11 @@ void test_tt_benchmark(void) {
     cgp_file = "/tmp/nonstuck_cgps.txt";
   }
   const char *plies_env = getenv("TT_BENCH_PLIES");
-  const int plies = plies_env ? atoi(plies_env) : 4;
+  const int plies = plies_env ? (int)strtol(plies_env, NULL, 10) : 4;
   const char *frac_env = getenv("TT_BENCH_FRACTION");
-  const double ttfraction = frac_env ? atof(frac_env) : 0.05;
+  const double ttfraction = frac_env ? strtod(frac_env, NULL) : 0.05;
   const char *max_env = getenv("TT_BENCH_MAX");
-  const int max_positions = max_env ? atoi(max_env) : 200;
+  const int max_positions = max_env ? (int)strtol(max_env, NULL, 10) : 200;
 
   FILE *fp = fopen(cgp_file, "re");
   if (!fp) {

--- a/test/benchmark_endgame_test.h
+++ b/test/benchmark_endgame_test.h
@@ -7,5 +7,6 @@ void test_generate_nonstuck_cgps2(void);
 void test_benchmark_forced_pass(void);
 void test_benchmark_nonstuck(void);
 void test_benchmark_nonstuck_3v3(void);
+void test_tt_benchmark(void);
 
 #endif

--- a/test/test.c
+++ b/test/test.c
@@ -141,6 +141,7 @@ static TestEntry on_demand_test_table[] = {
     {"benchfp", test_benchmark_forced_pass},
     {"benchns", test_benchmark_nonstuck},
     {"benchns3v3", test_benchmark_nonstuck_3v3},
+    {"ttbench", test_tt_benchmark},
     {"multipv", test_multi_pv},
     {"kue", test_kue},
     {"monsterq", test_monster_q},

--- a/test/transposition_table_test.c
+++ b/test/transposition_table_test.c
@@ -6,10 +6,8 @@
 void test_transposition_table(void) {
   // Passing 0 clamps to the platform minimum: 2^24 native, 2^21 WASM.
   TranspositionTable *tt = transposition_table_create(0);
-  assert(tt->size_power_of_2 == TT_MIN_SIZE_POWER);
+  assert(tt->num_entries == (UINT64_C(1) << TT_MIN_SIZE_POWER));
 
-  // Use a hash < 2^61 so all stored bits survive the round-trip on both
-  // native (size_power=24, 0 bits lost) and WASM (size_power=21, 3 bits lost).
   const uint64_t base_hash = 1234567890123456789ULL;
 
   TTEntry entry;
@@ -24,9 +22,13 @@ void test_transposition_table(void) {
   assert(ttentry_score(lu_entry) == 12);
 
   assert(atomic_load(&tt->t2_collisions) == 0);
-  // Create a type-2 collision: same index bits, different stored hash.
-  // Offset by 2^size_power so the index wraps to the same slot.
-  const uint64_t collision_hash = base_hash + (1ULL << tt->size_power_of_2);
+  // Type-2 collision: a hash that lands in the same fastrange bucket (shared
+  // high bits) but carries a different verification tag (low bits). For a
+  // power-of-two table fastrange(zval) == zval >> (64 - TT_MIN_SIZE_POWER), so
+  // bumping only the low bits keeps the bucket and changes the tag.
+  const uint64_t collision_hash = base_hash + 1;
+  assert(tt_bucket_index(collision_hash, tt->num_entries) ==
+         tt_bucket_index(base_hash, tt->num_entries));
   TTEntry te = transposition_table_lookup(tt, collision_hash);
   assert(te.fifth_byte == 0);
   assert(te.top_4_bytes == 0);
@@ -35,8 +37,12 @@ void test_transposition_table(void) {
   assert(te.tiny_move == 0);
   assert(atomic_load(&tt->t2_collisions) == 1);
 
-  // Another lookup, but not a collision (different index).
-  TTEntry te2 = transposition_table_lookup(tt, base_hash + 1);
+  // A lookup that lands in a different (empty) bucket is not a collision.
+  // Adding 2^TT_TAG_BITS changes the high (index) bits.
+  const uint64_t other_hash = base_hash + (UINT64_C(1) << TT_TAG_BITS);
+  assert(tt_bucket_index(other_hash, tt->num_entries) !=
+         tt_bucket_index(base_hash, tt->num_entries));
+  TTEntry te2 = transposition_table_lookup(tt, other_hash);
   assert(te2.fifth_byte == 0);
   assert(te2.top_4_bytes == 0);
   assert(te2.flag_and_depth == 0);

--- a/test/transposition_table_test.c
+++ b/test/transposition_table_test.c
@@ -38,8 +38,10 @@ void test_transposition_table(void) {
   assert(atomic_load(&tt->t2_collisions) == 1);
 
   // A lookup that lands in a different (empty) bucket is not a collision.
-  // Adding 2^TT_TAG_BITS changes the high (index) bits.
-  const uint64_t other_hash = base_hash + (UINT64_C(1) << TT_TAG_BITS);
+  // Flipping the top hash bit moves the fastrange bucket by ~num_entries/2 for
+  // any table size (the index is a function of the high bits), so this holds on
+  // both the native 2^24 and WASM 2^21 minimums.
+  const uint64_t other_hash = base_hash ^ (UINT64_C(1) << 63);
   assert(tt_bucket_index(other_hash, tt->num_entries) !=
          tt_bucket_index(base_hash, tt->num_entries));
   TTEntry te2 = transposition_table_lookup(tt, other_hash);


### PR DESCRIPTION
Trying out the suggestion from Discord (RightBehindYou): index the transposition table with Lemire's multiply-shift ("fastrange") reduction instead of masking to a power of two, so the table can fill the requested memory fraction exactly.

Ref: https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/

## Change

- **Index:** `zval & size_mask` → `(uint64_t)(((__uint128_t)zval * num_entries) >> 64)` (one 64×64→128 multiply + shift). `num_entries` no longer needs to be a power of two.
- **Sizing:** `transposition_table_create` now uses the full `fraction_of_memory * total / 16` entry count (clamped to the platform minimum), instead of rounding **down** to the nearest power of two — which wasted up to ~50% of the budget. Bigger table within the same memory → better hit rate.

## The verification subtlety

The old scheme stored only 40 hash bits and reconstructed the full 64-bit hash from `40 stored bits + the index bits` — which worked because the index *was* the low `size_power` bits of the hash. fastrange derives the index from the **high** bits, so that no longer holds.

Fix: store the **low 40 bits** of the hash as a verification tag and compare directly on lookup. For any table with `≥ 2^(64−40) = 2^24` entries (the native minimum, `TT_MIN_SIZE_POWER`), each bucket spans `≤ 2^40` hashes, so two distinct hashes in the same bucket **cannot** share a tag — verification is exact, same as before. (WASM's `2^21` minimum loses a few high bits — the same tradeoff the old code already documented for small tables.)

The lockless (Hyatt 1999) key/data XOR torn-read detection and the separate power-of-2 `nproc` ABDADA table are unchanged.

## Validation

- `tt` test rewritten for the new scheme (asserts the bucket-index relationships directly); passes.
- **Endgame correctness** — `endgame` (multithreaded, 6 threads) and `eldar_v` exact-value solves pass, so TT pruning is unaffected.
- Clean under **ASan/UBSan** (new `malloc` sizing + the `__uint128` multiply).
- clang-format-20 + cppcheck clean. `__uint128_t` is already used in `bit_rack.h`, so it builds on all CI targets incl. WASM.

## Note

The tests clamp the TT to the `2^24` minimum (a power of two), so they don't exercise a non-power-of-2 size directly — the memory-utilization win shows up only with a real `-ttfraction`. Happy to add an endgame benchmark comparing hit rate / nodes-per-second before vs after if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)