### PR TITLE
movegen: read blankless word lists directly from WMP storage

### DIFF
--- a/src/ent/wmp.h
+++ b/src/ent/wmp.h
@@ -360,6 +360,22 @@ static inline int wmp_entry_write_uninlined_blankless_words_to_buffer(
   return bytes_written;
 }
 
+// Returns a pointer to the contiguous word list for a blankless entry
+// (no copying) and writes the word count to num_words_out. Valid for
+// entries whose subrack contains no blanks; blank entries assemble their
+// words from multiple lookups and require a caller buffer instead.
+static inline const MachineLetter *
+wmp_entry_get_blankless_words(const WMPEntry *entry, const WMPForLength *wfl,
+                              int word_length, int *num_words_out) {
+  if (wmp_entry_is_inlined(entry)) {
+    *num_words_out =
+        wmp_entry_number_of_inlined_bytes(entry, word_length) / word_length;
+    return entry->bucket_or_inline;
+  }
+  *num_words_out = (int)entry->num_words;
+  return wfl->word_letters + entry->word_start;
+}
+
 static inline int
 wmp_entry_write_blankless_words_to_buffer(const WMPEntry *entry,
                                           const WMPForLength *wfl,

--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -995,8 +995,8 @@ void wordmap_gen(MoveGen *gen, const Anchor *anchor) {
         rack_reset(&gen->leave);
       }
       for (int bingo_idx = 0; bingo_idx < num_bingos; bingo_idx++) {
-        // Point the WMP buffer at the inline word.
-        memcpy(wgen->buffer, gen->rit_entry->bingo_words[bingo_idx], RACK_SIZE);
+        // Point the word list at the RIT's inline word (no copy).
+        wgen->words = gen->rit_entry->bingo_words[bingo_idx];
         wgen->num_words = 1;
         for (int start_col = anchor->leftmost_start_col;
              start_col <= anchor->rightmost_start_col; start_col++) {

--- a/src/impl/wmp_move_gen.h
+++ b/src/impl/wmp_move_gen.h
@@ -62,6 +62,10 @@ typedef struct WMPMoveGen {
   int playthrough_blocks_copy;
 
   MachineLetter buffer[WMP_RESULT_BUFFER_SIZE];
+  // Points at the current subrack's contiguous word list: directly into the
+  // WMP's storage for blankless subracks (zero copy), or at `buffer` when
+  // blank designation required assembling the words.
+  const MachineLetter *words;
   int tiles_to_play;
   int word_length;
   int num_words;
@@ -635,12 +639,24 @@ static inline bool wmp_move_gen_get_subrack_words(WMPMoveGen *wmp_move_gen,
   assert(wmp_move_gen->word_length >= MINIMUM_WORD_LENGTH);
   assert(wmp_move_gen->word_length <= BOARD_DIM);
 
+  if (bit_rack_get_letter(&subrack_info->subrack, BLANK_MACHINE_LETTER) == 0) {
+    // Blankless: point directly at the WMP's contiguous word storage
+    // instead of copying the words into the buffer.
+    wmp_move_gen->words = wmp_entry_get_blankless_words(
+        subrack_info->wmp_entry,
+        &wmp_move_gen->wmp->wfls[wmp_move_gen->word_length],
+        wmp_move_gen->word_length, &wmp_move_gen->num_words);
+    assert(wmp_move_gen->num_words > 0);
+    return true;
+  }
+
   const int result_bytes = wmp_entry_write_words_to_buffer(
       subrack_info->wmp_entry, wmp_move_gen->wmp, &subrack_info->subrack,
       wmp_move_gen->word_length, wmp_move_gen->buffer);
   assert(result_bytes > 0);
   assert(result_bytes % wmp_move_gen->word_length == 0);
   wmp_move_gen->num_words = result_bytes / wmp_move_gen->word_length;
+  wmp_move_gen->words = wmp_move_gen->buffer;
   return true;
 }
 
@@ -675,7 +691,7 @@ static inline void wmp_move_gen_add_anchors(WMPMoveGen *wmp_move_gen, int row,
 
 static inline const MachineLetter *
 wmp_move_gen_get_word(const WMPMoveGen *wmp_move_gen, int word_idx) {
-  return wmp_move_gen->buffer + word_idx * wmp_move_gen->word_length;
+  return wmp_move_gen->words + word_idx * wmp_move_gen->word_length;
 }
 
 static inline Equity wmp_move_gen_get_leave_value(WMPMoveGen *wmp_move_gen,


### PR DESCRIPTION
Part of a series of independently-benchmarked movegen optimizations (with #551 and #553; together they measure +4.9% on simbench: 17,670/17,583 vs 16,890/16,713 iters/sec interleaved). Each PR is standalone off `main`.

## Motivation

In simbench profiles (`BUILD=profile`, `sample`, 10 threads, CSW24 wmp+rit), `wordmap_gen` is the largest consumer of sim CPU (~11,450 of ~23,600 busy samples inclusive), and `_platform_memmove` shows ~220 samples attributed to `wordmap_gen` plus ~570 in `wmp_entry_write_blanks_to_buffer`. Every candidate word list was being memcpy'd into a per-thread buffer before a single word was checked against the board — including word lists that fail every playthrough/cross check.

## Changes

For blankless subracks (the common case), the WMP already stores each entry's words contiguously: either inlined in the entry itself or as a slice of the per-length `word_letters` array. `wmp_move_gen_get_subrack_words` now points a new `WMPMoveGen.words` pointer directly at that storage via `wmp_entry_get_blankless_words` instead of copying. The RIT inline-bingo fast path similarly points at the RIT entry's word instead of memcpying it. Only subracks containing blanks still assemble their designated-blank word lists into the buffer (`words` then points at the buffer), since those genuinely require multiple lookups.

`wmp_move_gen_get_word` reads through `words`, so consumers are unchanged.

## Benchmarks

simbench on-demand test (fixed game trajectory, per-turn timed sims: `-tlim 2`, 10 threads, plies 2, CSW24, `-wmp true -rit true`), Apple Silicon 10-core, release build, interleaved A/B vs `main` (consecutive runs drift ~2-3% thermally; only interleaved pairs are compared).

| run | main (iters/sec) | this PR (iters/sec) |
|---|---|---|
| 1 | 16,726 | 16,960 |
| 2 | 16,566 | 16,808 |

**+1.4%** (ahead in both pairs).

## Validation

- `movegen`, `shadow`, `wmg`, `sim`, `gameplay` tests pass on this branch.
- As part of the combined optimization tree: full test suite, `ap_wmp` (1000 game pairs per lexicon, WMP-vs-KWG move equivalence), cppcheck, clang-format, circular-dependency check all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
