### PR TITLE
movegen: read board lanes through a pointer instead of copying 14 KB per call

### DIFF
--- a/src/ent/board.h
+++ b/src/ent/board.h
@@ -848,6 +848,17 @@ static inline void board_load_lanes_cache(const Board *b, int ci,
          sizeof(Square) * 2 * BOARD_DIM * BOARD_DIM);
 }
 
+// Returns a pointer to the contiguous block of both directions' lanes for
+// the given cross index, usable with board_get_row_cache without copying
+// the whole board. The pointer is only valid while the board is alive, not
+// transposed, and not mutated.
+static inline const Square *board_get_readonly_lanes(const Board *b, int ci) {
+  if (b->transposed) {
+    log_fatal("cannot get lanes pointer while board is transposed");
+  }
+  return board_get_readonly_square(b, 0, 0, 0, ci);
+}
+
 static inline void board_copy_row_cache(const Square *lanes_cache,
                                         Square *row_cache, int row_or_col,
                                         int dir) {

--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -2949,7 +2949,7 @@ void gen_load_position(MoveGen *gen, const MoveGenArgs *args) {
 
   board_load_number_of_row_anchors_cache(gen->board,
                                          gen->row_number_of_anchors_cache);
-  board_load_lanes_cache(gen->board, gen->cross_index, gen->lanes_cache);
+  gen->lanes_cache = board_get_readonly_lanes(gen->board, gen->cross_index);
 
   board_copy_opening_penalties(gen->board, gen->opening_move_penalties);
 

--- a/src/impl/move_gen.h
+++ b/src/impl/move_gen.h
@@ -148,7 +148,9 @@ typedef struct MoveGen {
   Rack bingo_alpha_rack_shadow_right_copy;
   Rack opponent_rack;
   Rack leave;
-  Square lanes_cache[BOARD_DIM * BOARD_DIM * 2];
+  // Read-only view into the board's lanes for the current cross index;
+  // refreshed by gen_load_position each call.
+  const Square *lanes_cache;
   Square row_cache[BOARD_DIM];
   uint8_t row_number_of_anchors_cache[(BOARD_DIM) * 2];
   Equity opening_move_penalties[(BOARD_DIM) * 2];


### PR DESCRIPTION
Part of a series of independently-benchmarked movegen optimizations (with #551 and #552; together they measure +4.9% on simbench: 17,670/17,583 vs 16,890/16,713 iters/sec interleaved). Each PR is standalone off `main`.

## Motivation

`gen_load_position` memcpy'd the entire lanes block for the player's cross index — 2 directions × 225 squares × 32 bytes = **14.4 KB — on every `generate_moves` call**, only for `board_copy_row_cache` to copy individual rows back out of that buffer. In simbench profiles, `gen_load_position` accounts for ~260 of ~1,240 `_platform_memmove` leaf samples. At sim rollout rates (~45k movegen calls/sec across 10 threads) that is ~650 MB/s of pure copy traffic.

## Changes

The board is `const` for the duration of move generation and the lanes block is already contiguous per cross index (that layout is exactly why `board_load_lanes_cache` could do a single memcpy), so `MoveGen.lanes_cache` becomes a `const Square *` into the board, obtained via a new `board_get_readonly_lanes` (which keeps the existing not-transposed check). `board_copy_row_cache` already took a `const Square *` source, so the per-row copies are unchanged — they now just read directly from the board. This also shrinks `MoveGen` by 14.4 KB per thread.

## Benchmarks

simbench on-demand test (fixed game trajectory, per-turn timed sims: `-tlim 2`, 10 threads, plies 2, CSW24, `-wmp true -rit true`), Apple Silicon 10-core, release build, interleaved A/B vs `main` (consecutive runs drift ~2-3% thermally; only interleaved pairs are compared).

| run | main (iters/sec) | this PR (iters/sec) |
|---|---|---|
| 1 | 16,559 | 16,678 |
| 2 | 16,501 | 16,683 |

**+0.9%** (ahead in both pairs).

## Validation

- `movegen`, `shadow`, `wmg`, `sim`, `gameplay` tests pass on this branch.
- As part of the combined optimization tree: full test suite, `ap_wmp` (1000 game pairs per lexicon, WMP-vs-KWG move equivalence), cppcheck, clang-format, circular-dependency check all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
