### PR TITLE
endgame: 10% faster solves — tracked cross-set undo, lazy move ordering, single-tile scan reorder

### DIFF
--- a/src/ent/board.h
+++ b/src/ent/board.h
@@ -511,6 +511,14 @@ static inline bool board_is_letter_allowed_in_cross_set(uint64_t cross_set,
   return (cross_set & ((uint64_t)1 << letter)) != 0;
 }
 
+// Returns true if the cross set permits at least one non-blank letter.
+// Bit 0 is the blank marker, not a letter, so it is shifted out: in an
+// intersection of cross sets the blank bit can survive even when no common
+// letter does.
+static inline bool board_cross_set_allows_any_letter(uint64_t cross_set) {
+  return (cross_set >> 1) != 0;
+}
+
 static inline bool board_is_dir_vertical(int dir) {
   return dir == BOARD_VERTICAL_DIRECTION;
 }

--- a/src/ent/move_undo.h
+++ b/src/ent/move_undo.h
@@ -13,10 +13,13 @@
 // block endgame support for 8+ tile racks, so larger support is not needed.
 // A 7-tile move can affect:
 // - 7 tiles × 4 sub-boards for letters + is_cross_word = ~84
-// - Cross sets: ~30 squares × specific dir/ci = ~60
 // - Anchors: ~30 squares × 2 directions = ~60
-// Total: ~200, round up to 256 for safety
-#define MAX_UNDO_SQUARE_CHANGES 256
+// - Lazy cross-set updates (saved into the same undo so unplay restores
+//   them): cross-set + extension-set squares around each tile's cross word
+//   plus the word's own row, ~60 per cross index — doubled when the players
+//   use different lexicons (both cross indices are regenerated): ~120
+// Total: ~265 worst case, round up to 384 for safety
+#define MAX_UNDO_SQUARE_CHANGES 384
 
 typedef struct SquareChange {
   int16_t index; // flat index into Board.squares

--- a/src/ent/move_undo.h
+++ b/src/ent/move_undo.h
@@ -19,6 +19,16 @@
 // squares a single lazy update touches. Sizing the array to that count makes
 // overflow impossible by construction (the assert below is unreachable).
 // Typical endgame moves save ~150; this is the hard ceiling, not the norm.
+//
+// Memory: sizeof(MoveUndo) is ~35 KB at BOARD_DIM=15 (900 SquareChange slots
+// of 40 bytes each). An endgame worker holds 2*(MAX_SEARCH_DEPTH+1) undos, so
+// ~1.9 MB/worker — negligible beside the multi-hundred-MB transposition table.
+// The unused tail of square_changes[] is never written or read (move_undo_reset
+// clears only the bitmap, not the array; restore walks only num_square_changes
+// entries), so the working set tracks actual usage (~150), not the capacity —
+// the larger array does not change cache behavior, and measured solve times are
+// unchanged. A tight bound that beat this one would need to model the dedup
+// across overlapping save sites; not worth the fragility for the memory saved.
 #define MAX_UNDO_SQUARE_CHANGES (2 * 2 * BOARD_DIM * BOARD_DIM)
 
 typedef struct SquareChange {

--- a/src/ent/move_undo.h
+++ b/src/ent/move_undo.h
@@ -8,18 +8,18 @@
 #include "rack.h"
 #include <assert.h>
 
-// Maximum squares that can be modified by a single move.
-// This calculation assumes RACK_SIZE=7. Other factors (SmallMove encoding)
-// block endgame support for 8+ tile racks, so larger support is not needed.
-// A 7-tile move can affect:
-// - 7 tiles × 4 sub-boards for letters + is_cross_word = ~84
-// - Anchors: ~30 squares × 2 directions = ~60
-// - Lazy cross-set updates (saved into the same undo so unplay restores
-//   them): cross-set + extension-set squares around each tile's cross word
-//   plus the word's own row, ~60 per cross index — doubled when the players
-//   use different lexicons (both cross indices are regenerated): ~120
-// Total: ~265 worst case, round up to 384 for safety
-#define MAX_UNDO_SQUARE_CHANGES 384
+// Maximum squares that can be modified by a single move, including the lazy
+// cross-set updates saved into the same undo so unplay can restore them.
+//
+// Provable upper bound: every save goes through move_undo_save_square, which
+// deduplicates via saved_squares_bitmap — one bit per board square, indexed by
+// board_get_square_index() over [0, 2*2*BOARD_DIM*BOARD_DIM). A square is
+// recorded at most once, so num_square_changes can never exceed the number of
+// board squares, regardless of move shape, lexicon mode, or how many cross-set
+// squares a single lazy update touches. Sizing the array to that count makes
+// overflow impossible by construction (the assert below is unreachable).
+// Typical endgame moves save ~150; this is the hard ceiling, not the norm.
+#define MAX_UNDO_SQUARE_CHANGES (2 * 2 * BOARD_DIM * BOARD_DIM)
 
 typedef struct SquareChange {
   int16_t index; // flat index into Board.squares

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -949,6 +949,19 @@ static int generate_single_tile_plays(EndgameCtxWorker *worker) {
           board_get_cross_set(board, row, col, BOARD_VERTICAL_DIRECTION, ci);
       uint64_t combined = h_cs & v_cs;
 
+      // Reject before touching bonus squares or scanning word extents:
+      // most candidate squares fail the cross-set test.
+      if (!is_blank) {
+        if (!(combined & ((uint64_t)1 << tile_ml))) {
+          continue;
+        }
+      } else {
+        // Any non-blank letter permitted by the combined cross-set is valid.
+        if (!(combined >> 1)) {
+          continue;
+        }
+      }
+
       BonusSquare bsq = board_get_bonus_square(board, row, col);
       int lm = bonus_square_get_letter_multiplier(bsq);
       int wm = bonus_square_get_word_multiplier(bsq);
@@ -959,12 +972,24 @@ static int generate_single_tile_plays(EndgameCtxWorker *worker) {
       Equity v_nbr_score = board_get_cross_score(
           board, row, col, BOARD_HORIZONTAL_DIRECTION, ci);
 
+      // Blank has zero face value; its score depends only on position.
+      Equity tile_ls = is_blank ? 0 : ld_get_score(ld, tile_ml) * lm;
+      Equity score = 0;
+      if (has_h_nbrs) {
+        score += (tile_ls + h_nbr_score) * wm;
+      }
+      if (has_v_nbrs) {
+        score += (tile_ls + v_nbr_score) * wm;
+      }
+      if (found && score <= best_score) {
+        continue;
+      }
+
+      // New best: only now compute the word extent (for play_length and
+      // col_start/row_start encoding) and, for a blank, pick its letter.
       // Use vertical direction only when there are vertical neighbors and no
       // horizontal neighbors; otherwise label the play horizontal.
       bool dir_vertical = has_v_nbrs && !has_h_nbrs;
-
-      // Find word extent in the primary direction for play_length and
-      // col_start/row_start encoding.
       int word_start;
       int word_end;
       if (!dir_vertical) {
@@ -994,61 +1019,25 @@ static int generate_single_tile_plays(EndgameCtxWorker *worker) {
         }
         word_end--;
       }
-      int play_length = word_end - word_start + 1;
 
-      if (!is_blank) {
-        if (!(combined & ((uint64_t)1 << tile_ml))) {
-          continue;
-        }
-        Equity tile_ls = ld_get_score(ld, tile_ml) * lm;
-        Equity score = 0;
-        if (has_h_nbrs) {
-          score += (tile_ls + h_nbr_score) * wm;
-        }
-        if (has_v_nbrs) {
-          score += (tile_ls + v_nbr_score) * wm;
-        }
-        if (!found || score > best_score) {
-          found = true;
-          best_score = score;
-          best_row = row;
-          best_col = col;
-          best_dir_vertical = dir_vertical;
-          best_start = word_start;
-          best_play_length = play_length;
-          best_letter = tile_ml;
-        }
-      } else {
-        // Blank has zero face value; score depends only on position.
-        // Any non-blank letter permitted by the combined cross-set is valid.
-        if (!(combined >> 1)) {
-          continue;
-        }
-        Equity score = 0;
-        if (has_h_nbrs) {
-          score += h_nbr_score * wm;
-        }
-        if (has_v_nbrs) {
-          score += v_nbr_score * wm;
-        }
-        if (!found || score > best_score) {
-          MachineLetter letter = 0;
-          for (MachineLetter L = 1; L < (MachineLetter)ld_size; L++) {
-            if ((combined >> L) & 1) {
-              letter = L;
-              break;
-            }
+      MachineLetter letter = tile_ml;
+      if (is_blank) {
+        letter = 0;
+        for (MachineLetter L = 1; L < (MachineLetter)ld_size; L++) {
+          if ((combined >> L) & 1) {
+            letter = L;
+            break;
           }
-          found = true;
-          best_score = score;
-          best_row = row;
-          best_col = col;
-          best_dir_vertical = dir_vertical;
-          best_start = word_start;
-          best_play_length = play_length;
-          best_letter = letter;
         }
       }
+      found = true;
+      best_score = score;
+      best_row = row;
+      best_col = col;
+      best_dir_vertical = dir_vertical;
+      best_start = word_start;
+      best_play_length = word_end - word_start + 1;
+      best_letter = letter;
     }
   }
 

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -1407,10 +1407,9 @@ void assign_estimates(EndgameCtxWorker *worker, int move_count,
 void assign_estimates_and_sort(EndgameCtxWorker *worker, int move_count,
                                uint64_t tt_move, float opp_stuck_frac) {
   assign_estimates(worker, move_count, tt_move, opp_stuck_frac);
-  SmallMove *small_moves =
-      (SmallMove *)(worker->small_move_arena->memory +
-                    worker->small_move_arena->size -
-                    (sizeof(SmallMove) * move_count));
+  SmallMove *small_moves = (SmallMove *)(worker->small_move_arena->memory +
+                                         worker->small_move_arena->size -
+                                         (sizeof(SmallMove) * move_count));
   qsort(small_moves, move_count, sizeof(SmallMove),
         compare_small_moves_by_estimated_value);
 }
@@ -1685,9 +1684,8 @@ static void negamax_tt_store(const EndgameCtxWorker *worker, uint64_t node_key,
 // for non-root nodes (move ordering itself is done lazily by the caller).
 // Updates *opp_stuck_frac. Returns move count, or -1 if interrupted.
 static int negamax_generate_and_estimate_moves(EndgameCtxWorker *worker,
-                                               int depth,
-                                           uint64_t tt_move,
-                                           float *opp_stuck_frac) {
+                                               int depth, uint64_t tt_move,
+                                               float *opp_stuck_frac) {
   int opp_idx = 1 - worker->solver->solving_player;
   uint64_t opp_tiles_bv = 0;
   int nplays;

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -961,9 +961,9 @@ static int generate_single_tile_plays(EndgameCtxWorker *worker) {
           continue;
         }
       } else {
-        // A blank is playable if any non-blank letter is permitted by the
-        // combined cross-set (bit 0 is the blank marker, so shift it out).
-        if (!(combined >> 1)) {
+        // A blank is playable if the combined cross-set permits any
+        // non-blank letter.
+        if (!board_cross_set_allows_any_letter(combined)) {
           continue;
         }
       }

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -926,7 +926,7 @@ static int generate_single_tile_plays(EndgameCtxWorker *worker) {
   bool best_dir_vertical = false;
   int best_start = 0; // leftmost col (H) or topmost row (V) of the word
   int best_play_length = 0;
-  MachineLetter best_letter = 0; // for blank: the letter the blank plays as
+  MachineLetter best_ml = 0; // for blank: the letter the blank plays as
 
   for (int row = 0; row < BOARD_DIM; row++) {
     for (int col = 0; col < BOARD_DIM; col++) {
@@ -1026,12 +1026,12 @@ static int generate_single_tile_plays(EndgameCtxWorker *worker) {
         word_end--;
       }
 
-      MachineLetter letter = tile_ml;
+      MachineLetter chosen_ml = tile_ml;
       if (is_blank) {
-        letter = 0;
+        chosen_ml = 0;
         for (MachineLetter ml = 1; ml < (MachineLetter)ld_size; ml++) {
           if (board_is_letter_allowed_in_cross_set(combined, ml)) {
-            letter = ml;
+            chosen_ml = ml;
             break;
           }
         }
@@ -1043,7 +1043,7 @@ static int generate_single_tile_plays(EndgameCtxWorker *worker) {
       best_dir_vertical = dir_vertical;
       best_start = word_start;
       best_play_length = word_end - word_start + 1;
-      best_letter = letter;
+      best_ml = chosen_ml;
     }
   }
 
@@ -1066,7 +1066,7 @@ static int generate_single_tile_plays(EndgameCtxWorker *worker) {
 
   // Build tiny_move following the same convention as small_move_set_all:
   // for vertical, row_start and col_start are swapped before storing.
-  uint64_t tm = (uint64_t)best_letter << 20;
+  uint64_t tm = (uint64_t)best_ml << 20;
   if (is_blank) {
     tm |= 1ULL << 12; // blank flag for tile index 0
   }
@@ -1134,8 +1134,9 @@ static int compute_played_tiles_face_value(const SmallMove *sm,
   int n = sm->metadata.tiles_played;
   uint64_t tm = sm->tiny_move;
   for (int i = 0; i < n; i++) {
-    MachineLetter tile = (tm >> (20 + 6 * i)) & 63;
-    MachineLetter ml = (tm & (1ULL << (12 + i))) ? BLANK_MACHINE_LETTER : tile;
+    MachineLetter tile_ml = (tm >> (20 + 6 * i)) & 63;
+    MachineLetter ml =
+        (tm & (1ULL << (12 + i))) ? BLANK_MACHINE_LETTER : tile_ml;
     face_value += equity_to_int(ld_get_score(ld, ml));
   }
   return face_value;
@@ -1151,8 +1152,9 @@ static int compute_conservation_bonus(const SmallMove *sm,
   int face_value = 0;
   uint64_t tm = sm->tiny_move;
   for (int i = 0; i < n; i++) {
-    MachineLetter tile = (tm >> (20 + 6 * i)) & 63;
-    MachineLetter ml = (tm & (1ULL << (12 + i))) ? BLANK_MACHINE_LETTER : tile;
+    MachineLetter tile_ml = (tm >> (20 + 6 * i)) & 63;
+    MachineLetter ml =
+        (tm & (1ULL << (12 + i))) ? BLANK_MACHINE_LETTER : tile_ml;
     face_value += equity_to_int(ld_get_score(ld, ml));
   }
   return (int)((float)(CONSERVATION_TILE_WEIGHT * n +
@@ -1291,12 +1293,12 @@ static int *compute_build_chain_values(EndgameCtxWorker *worker, int move_count,
 
       bool tiles_match = true;
       for (int ti = 0; ti < len_a; ti++) {
-        uint8_t tile_a = move_get_tile(&mv_a, ti);
-        if (tile_a == PLAYED_THROUGH_MARKER) {
+        uint8_t ml_a = move_get_tile(&mv_a, ti);
+        if (ml_a == PLAYED_THROUGH_MARKER) {
           continue; // board tile, not placed by A
         }
-        uint8_t tile_b = move_get_tile(&mv_b, ti + offset_in_b);
-        if (tile_a != tile_b) {
+        uint8_t ml_b = move_get_tile(&mv_b, ti + offset_in_b);
+        if (ml_a != ml_b) {
           tiles_match = false;
           break;
         }

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -1029,9 +1029,9 @@ static int generate_single_tile_plays(EndgameCtxWorker *worker) {
       MachineLetter letter = tile_ml;
       if (is_blank) {
         letter = 0;
-        for (MachineLetter L = 1; L < (MachineLetter)ld_size; L++) {
-          if (board_is_letter_allowed_in_cross_set(combined, L)) {
-            letter = L;
+        for (MachineLetter ml = 1; ml < (MachineLetter)ld_size; ml++) {
+          if (board_is_letter_allowed_in_cross_set(combined, ml)) {
+            letter = ml;
             break;
           }
         }

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -1096,7 +1096,7 @@ int generate_stm_plays(EndgameCtxWorker *worker, int depth) {
   if (!board_get_cross_sets_valid(board)) {
     int undo_index = worker->solver->requested_plies - depth - 1;
     if (undo_index >= 0) {
-      const MoveUndo *parent_undo = &worker->move_undos[undo_index];
+      MoveUndo *parent_undo = &worker->move_undos[undo_index];
       if (parent_undo->move_tiles_length > 0) {
         update_cross_set_for_move_from_undo(parent_undo, worker->game_copy);
       }
@@ -1443,7 +1443,7 @@ static int32_t negamax_greedy_leaf_playout(EndgameCtxWorker *worker,
     if (!board_get_cross_sets_valid(leaf_board)) {
       int undo_idx = plies - 1; // last negamax move
       if (undo_idx >= 0) {
-        const MoveUndo *last_undo = &worker->move_undos[undo_idx];
+        MoveUndo *last_undo = &worker->move_undos[undo_idx];
         if (last_undo->move_tiles_length > 0) {
           update_cross_set_for_move_from_undo(last_undo, worker->game_copy);
         }
@@ -1472,7 +1472,7 @@ static int32_t negamax_greedy_leaf_playout(EndgameCtxWorker *worker,
     Board *pb = game_get_board(worker->game_copy);
     if (!board_get_cross_sets_valid(pb)) {
       int undo_idx = plies + playout_depth - 1;
-      const MoveUndo *prev = &worker->move_undos[undo_idx];
+      MoveUndo *prev = &worker->move_undos[undo_idx];
       if (prev->move_tiles_length > 0) {
         update_cross_set_for_move_from_undo(prev, worker->game_copy);
       }
@@ -1621,15 +1621,11 @@ static int32_t negamax_greedy_leaf_playout(EndgameCtxWorker *worker,
       playout_depth < MAX_VARIANT_LENGTH ? playout_depth : MAX_VARIANT_LENGTH;
   pv->negamax_depth = 0;
 
-  // Unplay all playout moves in reverse
+  // Unplay all playout moves in reverse. Lazy cross-set updates were saved
+  // into each move's undo, so the square restore reverts them exactly.
   for (int d = playout_depth - 1; d >= 0; d--) {
     int undo_slot = plies + d;
     unplay_move_incremental(worker->game_copy, &worker->move_undos[undo_slot]);
-    const MoveUndo *undo = &worker->move_undos[undo_slot];
-    if (undo->move_tiles_length > 0) {
-      update_cross_sets_after_unplay_from_undo(undo, worker->game_copy);
-      board_set_cross_sets_valid(game_get_board(worker->game_copy), true);
-    }
   }
 
   if (playout_interrupted) {
@@ -1699,7 +1695,7 @@ static int negamax_generate_and_sort_moves(EndgameCtxWorker *worker, int depth,
     if (!board_get_cross_sets_valid(board)) {
       int undo_index = worker->solver->requested_plies - depth - 1;
       if (undo_index >= 0) {
-        const MoveUndo *parent_undo = &worker->move_undos[undo_index];
+        MoveUndo *parent_undo = &worker->move_undos[undo_index];
         if (parent_undo->move_tiles_length > 0) {
           update_cross_set_for_move_from_undo(parent_undo, worker->game_copy);
         }
@@ -2186,15 +2182,9 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
       }
       unplay_move_incremental(worker->game_copy,
                               &worker->move_undos[undo_index]);
-      // After unplay, if tiles were placed, cross-sets need to be recomputed
-      // for the restored state. Use undo-based function for correct cross-set
-      // update. If it was a pass, cross-sets are unchanged and still valid.
-      const MoveUndo *current_undo = &worker->move_undos[undo_index];
-      if (current_undo->move_tiles_length > 0) {
-        update_cross_sets_after_unplay_from_undo(current_undo,
-                                                 worker->game_copy);
-        board_set_cross_sets_valid(game_get_board(worker->game_copy), true);
-      }
+      // Cross-sets need no recompute here: any lazy cross-set update in the
+      // child's subtree was saved into this undo (or a descendant's undo that
+      // was already restored), so the square restore reverted them exactly.
 
       if (value == ABDADA_INTERRUPTED) {
         all_done = true;

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -68,6 +68,11 @@ enum {
   ABDADA_INTERRUPTED = -(1 << 28),
   // Aspiration window initial size
   ASPIRATION_WINDOW = 25,
+  // Lazy move ordering at interior nodes: selection-pick the best remaining
+  // move for this many indices before sorting the rest once. Beta cutoffs
+  // usually happen within the first few moves, so most nodes never pay for
+  // a full sort of the move list.
+  LAZY_SELECTION_LIMIT = 8,
   // Conservation bonus weights: penalize playing tiles when opponent is stuck
   CONSERVATION_TILE_WEIGHT = 7,
   CONSERVATION_VALUE_WEIGHT = 2,
@@ -1311,8 +1316,11 @@ static int *compute_build_chain_values(EndgameCtxWorker *worker, int move_count,
   return build_values;
 }
 
-void assign_estimates_and_sort(EndgameCtxWorker *worker, int move_count,
-                               uint64_t tt_move, float opp_stuck_frac) {
+// Assign estimated values to the freshly generated moves at the top of the
+// arena. Does not sort: interior nodes order moves lazily in abdada_negamax
+// (selection picks + one tail sort), and the root sorts explicitly.
+void assign_estimates(EndgameCtxWorker *worker, int move_count,
+                      uint64_t tt_move, float opp_stuck_frac) {
   const int player_index = game_get_player_on_turn_index(worker->game_copy);
   const Player *player = game_get_player(worker->game_copy, player_index);
   const Player *opponent = game_get_player(worker->game_copy, 1 - player_index);
@@ -1392,10 +1400,17 @@ void assign_estimates_and_sort(EndgameCtxWorker *worker, int move_count,
     }
   }
   free(build_values);
-  // sort moves by estimated value, from biggest to smallest value. A good move
-  // sorting is instrumental to the performance of ab pruning.
+}
+
+// assign_estimates plus a full sort by estimated value, biggest first.
+// Used for the root move list, which is iterated in full every depth.
+void assign_estimates_and_sort(EndgameCtxWorker *worker, int move_count,
+                               uint64_t tt_move, float opp_stuck_frac) {
+  assign_estimates(worker, move_count, tt_move, opp_stuck_frac);
   SmallMove *small_moves =
-      (SmallMove *)(worker->small_move_arena->memory + arena_offset);
+      (SmallMove *)(worker->small_move_arena->memory +
+                    worker->small_move_arena->size -
+                    (sizeof(SmallMove) * move_count));
   qsort(small_moves, move_count, sizeof(SmallMove),
         compare_small_moves_by_estimated_value);
 }
@@ -1666,9 +1681,11 @@ static void negamax_tt_store(const EndgameCtxWorker *worker, uint64_t node_key,
                             entry_to_store);
 }
 
-// Stuck-tile detection, move generation, logging, and sorting for non-root
-// nodes. Updates *opp_stuck_frac. Returns move count, or -1 if interrupted.
-static int negamax_generate_and_sort_moves(EndgameCtxWorker *worker, int depth,
+// Stuck-tile detection, move generation, logging, and estimate assignment
+// for non-root nodes (move ordering itself is done lazily by the caller).
+// Updates *opp_stuck_frac. Returns move count, or -1 if interrupted.
+static int negamax_generate_and_estimate_moves(EndgameCtxWorker *worker,
+                                               int depth,
                                            uint64_t tt_move,
                                            float *opp_stuck_frac) {
   int opp_idx = 1 - worker->solver->solving_player;
@@ -1736,7 +1753,7 @@ static int negamax_generate_and_sort_moves(EndgameCtxWorker *worker, int depth,
     }
   }
 
-  assign_estimates_and_sort(worker, nplays, tt_move, *opp_stuck_frac);
+  assign_estimates(worker, nplays, tt_move, *opp_stuck_frac);
   return nplays;
 }
 
@@ -1891,8 +1908,8 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
       }
       return ABDADA_INTERRUPTED;
     }
-    nplays = negamax_generate_and_sort_moves(worker, depth, tt_move,
-                                             &opp_stuck_frac);
+    nplays = negamax_generate_and_estimate_moves(worker, depth, tt_move,
+                                                 &opp_stuck_frac);
     if (nplays == -1) {
       // Interrupted during compute_opp_stuck_fraction
       if (abdada_active) {
@@ -2050,6 +2067,13 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
   // Pass 1+: retry only deferred moves without exclusion.
   int pass = 0;
   bool all_done = false;
+  // Freshly generated moves are unsorted (assign_estimates does not sort).
+  // Order them lazily: selection-pick the best remaining move into slot idx
+  // for the first LAZY_SELECTION_LIMIT indices, then sort the tail once if
+  // the node gets that far without a cutoff. Most nodes cut off within the
+  // first few moves and never pay for a full sort. Root move lists
+  // (!arena_alloced) arrive pre-sorted.
+  bool tail_sorted = !arena_alloced;
   while (!all_done) {
     all_done = true;
 
@@ -2058,6 +2082,34 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
       // (they were already successfully searched)
       if (pass > 0 && deferred != NULL && !deferred[idx]) {
         continue;
+      }
+
+      // Lazy move ordering, pass 0 only: later passes revisit positions
+      // recorded in deferred[], so the array must not be reordered then.
+      if (!tail_sorted && pass == 0) {
+        SmallMove *moves_base =
+            (SmallMove *)(worker->small_move_arena->memory + arena_offset);
+        if (idx < LAZY_SELECTION_LIMIT) {
+          int best_est_idx = idx;
+          int32_t best_est = small_move_get_estimated_value(&moves_base[idx]);
+          for (int scan = idx + 1; scan < nplays; scan++) {
+            const int32_t est =
+                small_move_get_estimated_value(&moves_base[scan]);
+            if (est > best_est) {
+              best_est = est;
+              best_est_idx = scan;
+            }
+          }
+          if (best_est_idx != idx) {
+            SmallMove tmp = moves_base[idx];
+            moves_base[idx] = moves_base[best_est_idx];
+            moves_base[best_est_idx] = tmp;
+          }
+        } else {
+          qsort(moves_base + idx, (size_t)(nplays - idx), sizeof(SmallMove),
+                compare_small_moves_by_estimated_value);
+          tail_sorted = true;
+        }
       }
 
       // ABDADA: determine if this move should be searched exclusively

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -957,11 +957,12 @@ static int generate_single_tile_plays(EndgameCtxWorker *worker) {
       // Reject before touching bonus squares or scanning word extents:
       // most candidate squares fail the cross-set test.
       if (!is_blank) {
-        if (!(combined & ((uint64_t)1 << tile_ml))) {
+        if (!board_is_letter_allowed_in_cross_set(combined, tile_ml)) {
           continue;
         }
       } else {
-        // Any non-blank letter permitted by the combined cross-set is valid.
+        // A blank is playable if any non-blank letter is permitted by the
+        // combined cross-set (bit 0 is the blank marker, so shift it out).
         if (!(combined >> 1)) {
           continue;
         }
@@ -1029,7 +1030,7 @@ static int generate_single_tile_plays(EndgameCtxWorker *worker) {
       if (is_blank) {
         letter = 0;
         for (MachineLetter L = 1; L < (MachineLetter)ld_size; L++) {
-          if ((combined >> L) & 1) {
+          if (board_is_letter_allowed_in_cross_set(combined, L)) {
             letter = L;
             break;
           }

--- a/src/impl/gameplay.c
+++ b/src/impl/gameplay.c
@@ -229,8 +229,46 @@ void update_cross_sets_after_unplay(const Move *move, const Game *game) {
 // --- MoveUndo-based cross-set update functions ---
 // These use the tiles_placed_mask instead of the Move's tiles array
 
+// Save the previous contents of every square game_gen_cross_set may write
+// for (row, col, dir, ci) into the undo, then regenerate the cross set.
+// The saved squares are the cross-set square itself plus the extension-set
+// squares in the through direction (the word edges adjacent to this square).
+// With these saves, unplay_move_incremental's square restore reverts the
+// lazy cross-set updates exactly and no recompute is needed after unplay.
+static void game_gen_cross_set_tracked(const Game *game, int row, int col,
+                                       int csd, int cross_set_index,
+                                       MoveUndo *undo) {
+  if (board_is_position_in_bounds(row, col)) {
+    Board *board = game_get_board(game);
+    move_undo_save_square_at(undo, board, row, col, csd, cross_set_index);
+    const int through_dir = board_toggle_dir(csd);
+    move_undo_save_square_at(undo, board, row, col, through_dir,
+                             cross_set_index);
+    if (!board_is_nonempty_or_bricked(board, row, col) &&
+        !board_are_left_and_right_empty(board, row, col)) {
+      const int left_col =
+          board_get_word_edge(board, row, col - 1, WORD_DIRECTION_LEFT);
+      const int right_col =
+          board_get_word_edge(board, row, col + 1, WORD_DIRECTION_RIGHT);
+      if (left_col < col) {
+        move_undo_save_square_at(undo, board, row, col - 1, through_dir,
+                                 cross_set_index);
+        if (left_col > 0) {
+          move_undo_save_square_at(undo, board, row, left_col - 1, through_dir,
+                                   cross_set_index);
+        }
+      }
+      if (right_col > col) {
+        move_undo_save_square_at(undo, board, row, right_col, through_dir,
+                                 cross_set_index);
+      }
+    }
+  }
+  game_gen_cross_set(game, row, col, csd, cross_set_index);
+}
+
 // calc_for_across using MoveUndo (for forward update when tiles are on board)
-static void calc_for_across_from_undo(const MoveUndo *undo, const Game *game,
+static void calc_for_across_from_undo(MoveUndo *undo, const Game *game,
                                       int row_start, int col_start, int csd) {
   const Board *board = game_get_board(game);
   const bool kwgs_are_shared =
@@ -247,77 +285,36 @@ static void calc_for_across_from_undo(const MoveUndo *undo, const Game *game,
         board_get_word_edge(board, row, col_start, WORD_DIRECTION_RIGHT);
     const int left_col =
         board_get_word_edge(board, row, col_start, WORD_DIRECTION_LEFT);
-    game_gen_cross_set(game, row, right_col + 1, csd, 0);
-    game_gen_cross_set(game, row, left_col - 1, csd, 0);
-    game_gen_cross_set(game, row, col_start, csd, 0);
+    game_gen_cross_set_tracked(game, row, right_col + 1, csd, 0, undo);
+    game_gen_cross_set_tracked(game, row, left_col - 1, csd, 0, undo);
+    game_gen_cross_set_tracked(game, row, col_start, csd, 0, undo);
     if (!kwgs_are_shared) {
-      game_gen_cross_set(game, row, right_col + 1, csd, 1);
-      game_gen_cross_set(game, row, left_col - 1, csd, 1);
-      game_gen_cross_set(game, row, col_start, csd, 1);
+      game_gen_cross_set_tracked(game, row, right_col + 1, csd, 1, undo);
+      game_gen_cross_set_tracked(game, row, left_col - 1, csd, 1, undo);
+      game_gen_cross_set_tracked(game, row, col_start, csd, 1, undo);
     }
   }
 }
 
 // calc_for_self using MoveUndo (doesn't need tiles info, just length)
-static void calc_for_self_from_undo(const MoveUndo *undo, const Game *game,
+static void calc_for_self_from_undo(MoveUndo *undo, const Game *game,
                                     int row_start, int col_start, int csd) {
   for (int col = col_start - 1; col <= col_start + undo->move_tiles_length;
        col++) {
-    game_gen_cross_set(game, row_start, col, csd, 0);
+    game_gen_cross_set_tracked(game, row_start, col, csd, 0, undo);
   }
   if (!game_get_data_is_shared(game, PLAYERS_DATA_TYPE_KWG)) {
     for (int col = col_start - 1; col <= col_start + undo->move_tiles_length;
          col++) {
-      game_gen_cross_set(game, row_start, col, csd, 1);
+      game_gen_cross_set_tracked(game, row_start, col, csd, 1, undo);
     }
   }
 }
 
-// calc_for_across after unplay using MoveUndo
-static void calc_for_across_after_unplay_from_undo(const MoveUndo *undo,
-                                                   const Game *game,
-                                                   int row_start, int col_start,
-                                                   int csd) {
-  const Board *board = game_get_board(game);
-  const bool kwgs_are_shared =
-      game_get_data_is_shared(game, PLAYERS_DATA_TYPE_KWG);
-
-  for (int i = 0; i < undo->move_tiles_length; i++) {
-    // Check tiles_placed_mask: bit i is set if position i had an actual tile
-    if ((undo->tiles_placed_mask & (1 << i)) == 0) {
-      continue; // This was a played-through position, skip it
-    }
-
-    int row = row_start + i;
-
-    // For each tile position, find the word edges by looking at adjacent tiles
-    // that are still on the board (pre-existing tiles, not the ones we just
-    // unplayed)
-    int left_col = col_start - 1;
-    while (left_col >= 0 && !board_is_empty_or_bricked(board, row, left_col)) {
-      left_col--;
-    }
-    int right_col = col_start + 1;
-    while (right_col < BOARD_DIM &&
-           !board_is_empty_or_bricked(board, row, right_col)) {
-      right_col++;
-    }
-
-    // Update cross-sets at left edge, right edge, and the move position itself
-    game_gen_cross_set(game, row, left_col, csd, 0);
-    game_gen_cross_set(game, row, right_col, csd, 0);
-    game_gen_cross_set(game, row, col_start, csd, 0);
-    if (!kwgs_are_shared) {
-      game_gen_cross_set(game, row, left_col, csd, 1);
-      game_gen_cross_set(game, row, right_col, csd, 1);
-      game_gen_cross_set(game, row, col_start, csd, 1);
-    }
-  }
-}
-
-// Update cross-sets for move region using MoveUndo (forward update)
-void update_cross_set_for_move_from_undo(const MoveUndo *undo,
-                                         const Game *game) {
+// Update cross-sets for move region using MoveUndo (forward update).
+// Every square written is first saved into the undo, so unplaying the move
+// restores the cross-sets without recomputation.
+void update_cross_set_for_move_from_undo(MoveUndo *undo, const Game *game) {
   Board *board = game_get_board(game);
   if (board_is_dir_vertical(undo->move_dir)) {
     calc_for_across_from_undo(undo, game, undo->move_row_start,
@@ -332,29 +329,6 @@ void update_cross_set_for_move_from_undo(const MoveUndo *undo,
     board_transpose(board);
     calc_for_across_from_undo(undo, game, undo->move_col_start,
                               undo->move_row_start, BOARD_VERTICAL_DIRECTION);
-    board_transpose(board);
-  }
-}
-
-// Update cross-sets after unplaying using MoveUndo
-void update_cross_sets_after_unplay_from_undo(const MoveUndo *undo,
-                                              const Game *game) {
-  Board *board = game_get_board(game);
-  if (board_is_dir_vertical(undo->move_dir)) {
-    calc_for_across_after_unplay_from_undo(undo, game, undo->move_row_start,
-                                           undo->move_col_start,
-                                           BOARD_VERTICAL_DIRECTION);
-    board_transpose(board);
-    calc_for_self_from_undo(undo, game, undo->move_col_start,
-                            undo->move_row_start, BOARD_VERTICAL_DIRECTION);
-    board_transpose(board);
-  } else {
-    calc_for_self_from_undo(undo, game, undo->move_row_start,
-                            undo->move_col_start, BOARD_VERTICAL_DIRECTION);
-    board_transpose(board);
-    calc_for_across_after_unplay_from_undo(undo, game, undo->move_col_start,
-                                           undo->move_row_start,
-                                           BOARD_VERTICAL_DIRECTION);
     board_transpose(board);
   }
 }

--- a/src/impl/gameplay.h
+++ b/src/impl/gameplay.h
@@ -48,11 +48,11 @@ void unplay_move_incremental(Game *game, const MoveUndo *undo);
 void play_move_endgame_outplay(const Move *move, Game *game, MoveUndo *undo);
 void update_cross_sets_after_unplay(const Move *move, const Game *game);
 
-// MoveUndo-based cross-set update functions (use tiles_placed_mask)
-void update_cross_set_for_move_from_undo(const MoveUndo *undo,
-                                         const Game *game);
-void update_cross_sets_after_unplay_from_undo(const MoveUndo *undo,
-                                              const Game *game);
+// MoveUndo-based cross-set update for the move region (forward, lazy).
+// Saves the previous contents of every square it modifies into the same
+// undo, so unplay_move_incremental's square restore reverts the cross-set
+// updates exactly — no recompute is needed after unplay.
+void update_cross_set_for_move_from_undo(MoveUndo *undo, const Game *game);
 
 void game_play_n_events(GameHistory *game_history, Game *game, int event_index,
                         bool validate, ErrorStack *error_stack);

--- a/test/gameplay_test.c
+++ b/test/gameplay_test.c
@@ -1,4 +1,7 @@
+#include "../src/def/equity_defs.h"
 #include "../src/def/game_defs.h"
+#include "../src/def/game_history_defs.h"
+#include "../src/def/move_defs.h"
 #include "../src/def/rack_defs.h"
 #include "../src/ent/bag.h"
 #include "../src/ent/board.h"
@@ -6,17 +9,20 @@
 #include "../src/ent/game.h"
 #include "../src/ent/letter_distribution.h"
 #include "../src/ent/move.h"
+#include "../src/ent/move_undo.h"
 #include "../src/ent/player.h"
 #include "../src/ent/rack.h"
 #include "../src/ent/validated_move.h"
 #include "../src/impl/config.h"
 #include "../src/impl/gameplay.h"
+#include "../src/impl/move_gen.h"
 #include "../src/util/io_util.h"
 #include "test_constants.h"
 #include "test_util.h"
 #include <assert.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <string.h>
 
 void return_racks_to_bag(const Game *game) {
   return_rack_to_bag(game, 0);
@@ -780,6 +786,110 @@ void test_moves_are_similar(void) {
   config_destroy(config);
 }
 
+// Bag-empty endgame position (no lexicon option so it loads under any
+// english-distribution config).
+#define INCREMENTAL_ROUNDTRIP_ENDGAME_CGP                                      \
+  "5U4OHMIC/5N3WREATH/5T4FAX2/5i3B1VIA1/5N3L1E3/5G2VELDT2/5E3S5/"              \
+  "5DREKS1F3/8YELL3/4ABASER1U3/4GYM3ZO3/WAITE5OR2J/10OI2A/3QUOIT1PINNER/"      \
+  "4RENEGADE2P CDIOST?/AIINOOU 450/392 0"
+
+// Round-trip invariant the endgame solver relies on instead of recomputing
+// cross-sets after unplay: play_move_incremental, then the lazy
+// update_cross_set_for_move_from_undo a descendant node performs before move
+// generation, then unplay_move_incremental must restore the board (letters,
+// cross sets, cross scores, extension sets, anchors, flags) byte-for-byte.
+static void assert_incremental_play_roundtrip(Game *game) {
+  game_gen_all_cross_sets(game);
+  Board *board = game_get_board(game);
+  board_set_cross_sets_valid(board, true);
+  Game *snapshot = game_duplicate(game);
+  const Board *snapshot_board = game_get_board(snapshot);
+
+  MoveList *move_list = move_list_create(30);
+  const MoveGenArgs args = {
+      .game = game,
+      .move_list = move_list,
+      .move_record_type = MOVE_RECORD_ALL,
+      .move_sort_type = MOVE_SORT_SCORE,
+      .override_kwg = NULL,
+      .eq_margin_movegen = 0,
+      .target_equity = EQUITY_MAX_VALUE,
+      .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+  };
+  generate_moves(&args);
+  SortedMoveList *sml = sorted_move_list_create(move_list);
+
+  MoveUndo undo;
+  int tested_vertical = 0;
+  int tested_horizontal = 0;
+  for (int move_idx = 0; move_idx < sml->count; move_idx++) {
+    const Move *move = sml->moves[move_idx];
+    if (move_get_type(move) != GAME_EVENT_TILE_PLACEMENT_MOVE) {
+      continue;
+    }
+    play_move_incremental(move, game, &undo);
+    // Mirror the endgame solver's descendant node: bring cross-sets up to
+    // date from the parent's undo before (hypothetical) move generation.
+    if (undo.move_tiles_length > 0) {
+      update_cross_set_for_move_from_undo(&undo, game);
+      board_set_cross_sets_valid(board, true);
+    }
+    unplay_move_incremental(game, &undo);
+
+    assert(memcmp(board->squares, snapshot_board->squares,
+                  sizeof(board->squares)) == 0);
+    assert(board_get_cross_sets_valid(board) ==
+           board_get_cross_sets_valid(snapshot_board));
+    assert(board_get_tiles_played(board) ==
+           board_get_tiles_played(snapshot_board));
+    assert(memcmp(board->number_of_row_anchors,
+                  snapshot_board->number_of_row_anchors,
+                  sizeof(board->number_of_row_anchors)) == 0);
+    if (board_is_dir_vertical(move_get_dir(move))) {
+      tested_vertical++;
+    } else {
+      tested_horizontal++;
+    }
+  }
+  // The position must exercise both branches of the transposed lazy update.
+  assert(tested_vertical > 0);
+  assert(tested_horizontal > 0);
+
+  // A pass round-trips too (no tiles: nothing to update, flags restored).
+  Move pass;
+  move_set_as_pass(&pass);
+  play_move_incremental(&pass, game, &undo);
+  unplay_move_incremental(game, &undo);
+  assert(memcmp(board->squares, snapshot_board->squares,
+                sizeof(board->squares)) == 0);
+  assert(game_get_consecutive_scoreless_turns(game) ==
+         game_get_consecutive_scoreless_turns(snapshot));
+
+  sorted_move_list_destroy(sml);
+  move_list_destroy(move_list);
+  game_destroy(snapshot);
+}
+
+void test_incremental_cross_set_undo(void) {
+  // Shared-KWG (single lexicon): only cross index 0 is maintained.
+  Config *config = config_create_or_die("set -lex CSW21 -s1 score -s2 score");
+  Game *game = config_game_create(config);
+  load_cgp_or_die(game, INCREMENTAL_ROUNDTRIP_ENDGAME_CGP);
+  assert_incremental_play_roundtrip(game);
+  game_destroy(game);
+  config_destroy(config);
+
+  // Dual-lexicon (non-shared KWGs): the lazy update regenerates both cross
+  // indices, so the undo must capture both.
+  Config *dual_config =
+      config_create_or_die("set -l1 CSW21 -l2 NWL20 -s1 score -s2 score");
+  Game *dual_game = config_game_create(dual_config);
+  load_cgp_or_die(dual_game, INCREMENTAL_ROUNDTRIP_ENDGAME_CGP);
+  assert_incremental_play_roundtrip(dual_game);
+  game_destroy(dual_game);
+  config_destroy(dual_config);
+}
+
 void test_gameplay(void) {
   test_draw_to_full_rack();
   test_rack_is_drawable();
@@ -791,4 +901,5 @@ void test_gameplay(void) {
   test_backups();
   test_leave_record();
   test_moves_are_similar();
+  test_incremental_cross_set_undo();
 }


### PR DESCRIPTION
Three profile-guided optimizations to the endgame solver, plus a unit test and a provability hardening. Built on the movegen work from #551–#554 (now merged to `main`, so this branch is based directly on `main`).

Combined: **315.4s → 283.3s (−10.2%)** on a 500-position non-stuck 3-ply benchmark (`benchns3v3`, 8 threads), with identical solve values. Source change is roughly net-neutral (+206/−189 across 5 files); the test adds +111.

Profiled with macOS `sample` on a `BUILD=profile` binary running the benchmark; each change validated independently on a 100-position quick set, then the full 500.

### 1. Track lazy cross-set updates in MoveUndo; delete the after-unplay recompute (~4%)

The lazy cross-set update for a move now saves every square it writes into that move's own `MoveUndo` (a pre-save of the affected cross-set / extension-set squares), so `unplay_move_incremental`'s square restore reverts cross-sets byte-for-byte. The full cross-set recompute after every unplay (`update_cross_sets_after_unplay_from_undo`) is deleted — it previously ran even when the child subtree never computed cross-sets at all (TT cutoffs, outplays, analytical leaves).

### 2. Order interior-node moves lazily instead of qsorting every node (~5%)

`assign_estimates` no longer sorts. The negamax move loop selection-picks the best remaining move into place for the first 8 indices and qsorts the tail only if the node searches past them — most nodes beta-cut within the first few moves and never pay for a full sort. Root move lists are still fully sorted (`assign_estimates_and_sort`) since every depth iterates them in full. Reordering is restricted to ABDADA pass 0 and to not-yet-searched indices, so `deferred[]` entries stay stable on retry passes.

### 3. Reject single-tile squares via cross-set before scoring work (~1%)

`generate_single_tile_plays` checked the combined cross-set *after* computing bonus multipliers, cross scores, and word extents for every neighbored empty square. Now the cross-set test runs first, and word extents (and the blank's letter) are computed only for squares that improve on the current best. Uses the existing `board_is_letter_allowed_in_cross_set` helper plus a new `board_cross_set_allows_any_letter` for the blank case.

### Capacity bound is now proven, not estimated

Optimization 1 makes `MoveUndo` carry cross-set saves in addition to the letter/anchor saves. Rather than hand-estimate the array size (risky: `NDEBUG` strips the capacity assert from release builds, so an underestimate is a silent out-of-bounds write), `MAX_UNDO_SQUARE_CHANGES` is set to `2*2*BOARD_DIM*BOARD_DIM`. Every save dedups through `saved_squares_bitmap` (one bit per board square), so the count provably cannot exceed the number of board squares — overflow is impossible by construction and the assert is unreachable. Measured high-water mark is **160 across 500 dual-lexicon positions**, far under the 900 ceiling. Per-move reset clears only the bitmap, not the array, so the larger size costs static memory only (~1.9 MB/worker, dwarfed by the TT) and does not change benchmark timing.

### Validation

- New `test_incremental_cross_set_undo` (runs in the `gameplay` test key) asserts the round-trip invariant optimization 1 relies on: `play_move_incremental` → descendant's lazy `update_cross_set_for_move_from_undo` → `unplay_move_incremental` restores the board byte-for-byte (squares array, cross-set validity flag, tiles_played, row-anchor counts). Covers every generated tile placement in both directions plus a pass, in shared-KWG and dual-lexicon (CSW21/NWL20) configs. Verified it fails if a square pre-save is removed.
- `endgame`, `viamover`, `viaopp` (per-depth value asserts) pass; full release suite passes except pre-existing local-data failures that fail identically on `main` (missing local `.wmp` files etc.)
- dev (ASAN/UBSAN, asserts) `endgame` and `gameplay` runs clean — exercises the enlarged undo under sanitizers
- benchmark values identical at every step; cppcheck, clang-format, circular-deps clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)