### PR TITLE
sim: skip dead cross-set update on the final ply of a rollout

### DIFF
--- a/src/impl/gameplay.c
+++ b/src/impl/gameplay.c
@@ -541,7 +541,8 @@ void draw_starting_racks(const Game *game) {
 // Assumes the move has been validated
 // If the input leave rack is not null, it will record the leave of
 // the play in the leave rack.
-void play_move(const Move *move, Game *game, Rack *leave) {
+static void play_move_internal(const Move *move, Game *game, Rack *leave,
+                               bool update_cross_sets) {
   game_backup(game);
   const LetterDistribution *ld = game_get_ld(game);
   int player_on_turn_index = game_get_player_on_turn_index(game);
@@ -552,7 +553,12 @@ void play_move(const Move *move, Game *game, Rack *leave) {
     if (leave) {
       rack_copy(leave, player_on_turn_rack);
     }
-    update_cross_set_for_move(move, game);
+    // Cross-sets are scratch state used only by subsequent move generation.
+    // Callers that play a terminal move whose board state is immediately
+    // discarded (e.g. the final ply of a sim rollout) can skip this work.
+    if (update_cross_sets) {
+      update_cross_set_for_move(move, game);
+    }
     game_set_consecutive_scoreless_turns(game, 0);
 
     player_add_to_score(player_on_turn, move_get_score(move));
@@ -579,6 +585,17 @@ void play_move(const Move *move, Game *game, Rack *leave) {
     game_set_game_end_reason(game, GAME_END_REASON_CONSECUTIVE_ZEROS);
   }
   game_start_next_player_turn(game);
+}
+
+void play_move(const Move *move, Game *game, Rack *leave) {
+  play_move_internal(move, game, leave, true);
+}
+
+// Like play_move, but skips updating the board's cross-sets. Only safe when the
+// resulting position is not used for move generation before being unplayed
+// (which restores the cross-sets via the game backup).
+void play_move_no_cross_set_update(const Move *move, Game *game, Rack *leave) {
+  play_move_internal(move, game, leave, false);
 }
 
 void play_move_without_drawing_tiles(const Move *move, Game *game) {

--- a/src/impl/gameplay.h
+++ b/src/impl/gameplay.h
@@ -17,6 +17,7 @@ Equity calculate_end_rack_points(const Rack *rack,
 Equity calculate_end_rack_penalty(const Rack *rack,
                                   const LetterDistribution *ld);
 void play_move(const Move *move, Game *game, Rack *leave);
+void play_move_no_cross_set_update(const Move *move, Game *game, Rack *leave);
 void play_move_without_drawing_tiles(const Move *move, Game *game);
 void set_random_rack(Game *game, int player_index, const Rack *known_rack);
 const Move *get_top_equity_move(Game *game, MoveList *move_list);

--- a/src/impl/random_variable.c
+++ b/src/impl/random_variable.c
@@ -509,7 +509,14 @@ double rv_sim_sample(RandomVariables *rvs, const uint64_t play_index,
     const Move *best_play = get_top_equity_move(game, move_list);
     rack_copy(&spare_rack, player_get_rack(player_on_turn));
 
-    play_move(best_play, game, NULL);
+    // On the final ply the resulting cross-sets are never read (no further move
+    // generation happens before game_unplay_last_move restores the board), so
+    // skip the cross-set update for that play.
+    if (ply == plies - 1) {
+      play_move_no_cross_set_update(best_play, game, NULL);
+    } else {
+      play_move(best_play, game, NULL);
+    }
     sim_results_increment_node_count(sim_results);
     if (ply == plies - 2 || ply == plies - 1) {
       Equity this_leftover = get_leave_value_for_move(

--- a/test/sim_benchmark_test.c
+++ b/test/sim_benchmark_test.c
@@ -39,12 +39,14 @@ void test_sim_benchmark(void) {
   const char *mi = (mi_env != NULL) ? mi_env : "100000";
   const char *rit_env = getenv("SIMBENCH_RIT");
   const char *rit = (rit_env != NULL) ? rit_env : "true";
+  const char *wmp_env = getenv("SIMBENCH_WMP");
+  const char *wmp = (wmp_env != NULL) ? wmp_env : "true";
   char cmd[256];
   (void)snprintf(cmd, sizeof(cmd),
-                 "set -lex CSW24 -wmp true -rit %s -s1 equity -s2 equity "
+                 "set -lex CSW24 -wmp %s -rit %s -s1 equity -s2 equity "
                  "-r1 all -r2 all -numplays 15 -plies %d -threads 10 -tlim 2 "
                  "-seed 42 -sr tt -minplayiterations %s",
-                 rit, plies, mi);
+                 wmp, rit, plies, mi);
   Config *config = config_create_or_die(cmd);
   load_and_exec_config_or_die(config, "autoplay games 1");
 


### PR DESCRIPTION
## What

In a sim rollout (`rv_sim_sample`), the candidate move and each ply are applied with `play_move`, which rebuilds the board's cross-sets via KWG traversal (`update_cross_set_for_move` → `calc_for_across`/`calc_for_self` → `game_gen_cross_set`). But the cross-sets produced by the **final ply** are never read: no further move generation happens before `game_unplay_last_move` restores the board (and the restore overwrites cross-sets wholesale). Recomputing them is pure dead work.

This PR adds `play_move_no_cross_set_update` — a thin wrapper over a shared `play_move_internal(... , bool update_cross_sets)` — and uses it for the last ply in `rv_sim_sample`. `play_move` keeps its exact behavior.

Also adds a `SIMBENCH_WMP` env var to `simbench` so the benchmark can run a true kwg-only baseline (defaults to `true`, prior behavior unchanged).

## Why it's safe

Cross-sets are scratch state read only by subsequent move generation. After the final ply: the win%/spread/leftover math reads scores, the bag, and the *pre-play* rack — never cross-sets — and `game_unplay_last_move` does a full `board_copy` restore. So skipping the last update cannot change results.

**Bit-identical:** `sim`, `gameplay`, and `movegen` tests all pass unchanged (the `sim` test asserts exact equity/win% values).

## Benchmark

2-ply, CSW24, wmp+rit, 10 threads (`simbench`).

**Profile** (macOS `sample`, `BUILD=profile`) — noise-free attribution:

| | baseline | opt | Δ |
|---|---|---|---|
| `update_cross_set_for_move` (inclusive samples) | 1911 | 1093 | **−818 (−43%)** |

≈ **−1.46% of total sim CPU.** The cut is 43% rather than the naïve 1/3 (one of three applied moves) because the skipped update is the *last* ply's — the fullest board, hence the priciest cross-set update.

**Wall-clock** — interleaved 15×15 A/B (`BUILD=release`), iters/sec:

| | base | opt |
|---|---|---|
| mean | 17,801 | 18,126 |
| median | 17,711 | 18,104 |
| stdev | 251 | 162 |
| min–max | 17,567–18,575 | 17,932–18,557 |

Paired (controls for thermal drift over the 30-min run): **mean diff +326 iters/sec (+1.83%)**, median +362, **won 14/15 pairs** (sole loss −18, round 1 when coldest), **paired t = 12.2** (p ≪ 0.001). Conservative, since opt ran second each round (hotter machine).

Profile −1.46% CPU and wall-clock +1.83% throughput are consistent; the wall-clock edge comes from reduced cache pressure (the skipped update is the densest board).

## Context

Came out of profiling where the non-movegen share of sim CPU goes (~7% under wmp+rit). The #1 non-movegen cost turned out to be cross-set recompute in `play_move`, not the game-state backup/restore. This PR takes the provably-dead slice of that; further cross-set/backup work is left for separate, focused changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)