### PR TITLE
endgame: fix stale cross-sets in greedy playout (illegal plays in leaf heuristic)

### DIFF
--- a/src/impl/gameplay.c
+++ b/src/impl/gameplay.c
@@ -730,10 +730,17 @@ void play_move_incremental(const Move *move, Game *game, MoveUndo *undo) {
     undo->tiles_placed_mask = tiles_placed_mask;
 
     play_move_on_board_tracked(move, game, undo);
-    // Cross-sets are NOT updated here - they are computed lazily before move
-    // generation. The caller can call update_cross_set_for_move if eager update
-    // is needed, or leave them invalid for lazy evaluation.
-    board_set_cross_sets_valid(board, false);
+    // Update cross-sets eagerly, tracked into this move's undo so unplay
+    // restores them exactly. Deferring the update (computing it lazily before
+    // the next move generation) was unsafe: a move whose lazy update never ran
+    // -- e.g. the last move of a greedy playout, or any node that does not
+    // re-generate -- left its placed and neighbor squares with stale,
+    // empty-isolated TRIVIAL cross-sets. Those propagated through the
+    // save/restore cycle across the search tree and let move generation place
+    // tiles forming invalid words. The update is incremental (only the move's
+    // region), so eager evaluation keeps correctness without a full recompute.
+    update_cross_set_for_move_from_undo(undo, game);
+    board_set_cross_sets_valid(board, true);
     game_set_consecutive_scoreless_turns(game, 0);
 
     player_add_to_score(player_on_turn, move_get_score(move));

--- a/test/gameplay_test.c
+++ b/test/gameplay_test.c
@@ -828,6 +828,27 @@ static void assert_incremental_play_roundtrip(Game *game) {
       continue;
     }
     play_move_incremental(move, game, &undo);
+    // Regression guard for the greedy-playout staleness bug: an incremental
+    // play must leave cross-sets valid and identical to a full recompute, even
+    // with NO subsequent lazy update. The old deferred behavior left them
+    // invalid/stale, which let the endgame playout generate invalid words.
+    assert(board_get_cross_sets_valid(board));
+    {
+      Game *fresh = game_duplicate(game);
+      game_gen_all_cross_sets(fresh);
+      const Board *fresh_board = game_get_board(fresh);
+      for (int r = 0; r < BOARD_DIM; r++) {
+        for (int c = 0; c < BOARD_DIM; c++) {
+          for (int d = 0; d < 2; d++) {
+            assert(board_get_cross_set(board, r, c, d, 0) ==
+                   board_get_cross_set(fresh_board, r, c, d, 0));
+            assert(board_get_cross_set(board, r, c, d, 1) ==
+                   board_get_cross_set(fresh_board, r, c, d, 1));
+          }
+        }
+      }
+      game_destroy(fresh);
+    }
     // Mirror the endgame solver's descendant node: bring cross-sets up to
     // date from the parent's undo before (hypothetical) move generation.
     if (undo.move_tiles_length > 0) {

--- a/test/gameplay_test.c
+++ b/test/gameplay_test.c
@@ -1,3 +1,4 @@
+#include "../src/def/board_defs.h"
 #include "../src/def/equity_defs.h"
 #include "../src/def/game_defs.h"
 #include "../src/def/game_history_defs.h"


### PR DESCRIPTION
## Endgame greedy-playout cross-set staleness — invalid plays in the leaf heuristic

### TL;DR
The endgame's greedy-playout move generation reads **stale cross-sets** and places tiles that form **invalid words** (e.g. `CUZ`, `IIRADE`), perturbing the leaf heuristic by multiple points. This is a real, pre-existing correctness bug on `main` that affects every endgame solve's playout. This PR fixes it by making the incremental cross-set update **eager** instead of deferred, and adds a regression guard. Cost: **~3.6%** on the endgame benchmark — the part of a prior "speedup" that was fast only because it was wrong.

### Symptom
During the greedy playout, with the board's live cross-sets, movegen picks a play that a fresh cross-set recompute rejects:
```
live{tm=...380 sc=25} fresh{tm=...0c3 sc=14}   board row 14 = "C6FRONDEUR..."
```
i.e. it plays `C`+`U`+`Z` = **"CUZ"** (not a word) for 25 because the cross-set at that square is stale; with fresh cross-sets the move drops to a legal 14. Swings of ~11 points in the leaf evaluation.

### Root cause
Two commits combined to produce this:

1. **`f4346e27` "Implement lazy cross-set evaluation in endgame solver"** introduced a **deferred** cross-set update: `play_move_incremental` leaves cross-sets invalid and a later lazy `update_cross_set_for_move_from_undo` recomputes them "before move generation." This update is **skippable** — for the last move of a greedy playout, or any node that doesn't re-generate, it never runs, leaving placed/neighbor squares with stale, empty-isolated `TRIVIAL` cross-sets. That commit *also* kept a full cross-set recompute after every unplay, which **masked** the bug by resetting cross-sets to fresh on each unplay.

2. **`8636f992` "track lazy cross-set updates in MoveUndo, drop unplay recompute"** added a tracked incremental save/restore and **deleted that full unplay recompute** — removing the mask. It shipped as "**~4% faster … with identical values** (100-position quick set, 2 reps)." The "identical values" was the too-good-to-be-true part: the quick set was too small to catch that values were *not* identical, so a correctness regression landed as a clean 4% win.

Once unmasked, the staleness **self-propagates**: the next move's lazy update reads the stale `TRIVIAL`, saves it as the "old value," and unplay restores `TRIVIAL` — so it spreads across the search tree until movegen builds an invalid word.

The invariant it violates: **an occupied square must have `cross_set == 0`**. Stale squares were occupied yet held `TRIVIAL` (the empty-isolated value).

### The fix
Perform the tracked, **incremental** cross-set update **eagerly** in `play_move_incremental` (saved into the move's undo for exact restore on unplay) instead of deferring it. Still incremental — only the move's region — no full recompute. `play_move_incremental` is endgame-only, so the change is confined there; the lazy-update sites become guarded no-ops.

### Why this is not a rollback
A revert of `8636f992` would restore the **full-board cross-set recompute after every unplay** — fixing correctness only by *re-masking* the latent deferral bug, and discarding the (correct) incremental save/restore. This fix instead targets the actual cause:

| | unplay mechanism | deferral bug |
|---|---|---|
| buggy `main` (`8636f992`) | tracked incremental restore | present + unmasked |
| rollback of `8636f992` | full recompute (slower) | present but re-masked |
| **this PR** | **tracked incremental restore** | **eliminated at the source** |

So it keeps the legitimate half of the speedup (incremental restore over full recompute) and only gives up the unsafe half (skipping cross-set updates the playout then reads stale).

### Validation
- **Occupied-square invariant** (`occupied ⇒ cross_set==0`), checked at every playout generation point: **0** violations (was failing).
- **Live-vs-fresh movegen** (re-run the same playout movegen after a full fresh recompute — the pick must not change): **0** divergences (was producing illegal plays / 11-pt swings).
- Existing `endgame` and `gameplay` unit tests pass.

### Regression guard
`test_incremental_cross_set_undo` now asserts that **after an incremental play, with no subsequent lazy update, cross-sets are valid and byte-match a full recompute**. This fails on the old deferred behavior and passes after the fix — directly locking the invariant the bug violated. (The pre-existing round-trip test passed because it always performed the lazy update, so it never exercised the skipped-update path.)

### Performance cost of correctness
Eager updates (plus the now-correct, slightly different search tree) cost **~3.6%** on the endgame benchmark (`benchns3v3`, 500 positions, 3-ply, release):

| | total | avg/solve |
|---|---|---|
| `main` (buggy) | 284.3s | 0.569s |
| this PR | 294.6s | 0.589s |
| | **+3.6%** | +0.020s |

(The bypass variant is +3.6% too: 285.6s → 296.0s.) This lands a touch under what a rollback would cost (`8636f992`'s claimed ~4%), consistent with retaining the incremental restore. A possible follow-up to claw some back: force the eager update only where the lazy update would otherwise be skipped (last playout move / non-regenerating nodes), keeping deferral where a descendant recomputes anyway.

### Note on endgame values
Because the fix removes invalid plays from the greedy leaf heuristic, endgame solved values **change** relative to buggy `main`. These are corrections — the prior values were computed against an over-permissive playout — confirmed by the invariant checks above.

### Repro
A separate `endgame-staleness-repro` branch carries three gated diagnostic checks that each fail on `main` and demonstrate the bug end-to-end via `benchns3v3`:
- `EG_STALE_CHECK` — live vs fresh-recompute movegen pick
- `EG_UNPLAY_CHECK` — cross-sets after unplay vs fresh
- `EG_OCC_CHECK` — occupied-square `cross_set==0` invariant

### Takeaway / follow-up
A 4% endgame "win" guarded by a too-small equivalence check silently shipped illegal plays into the playout. A **small/regular movegen agreement test** (small-move vs regular movegen producing the same plays) and the live-vs-fresh cross-set guard above are the kinds of checks that catch this class going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
