### PR TITLE
Add KWG_MAKER_MERGE_TAIL (wolges-style tail merging) as opt-in

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,6 +14,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install networkx
+          sudo apt-get update
           sudo apt-get install -y clang-format-20
 
       - name: Check circular dependencies
@@ -43,6 +44,7 @@ jobs:
 
       - name: Run clang-tidy static analysis
         run: |
+          sudo apt-get update
           sudo apt-get install -y clang-tidy-18 && ./tidy.sh clang-tidy-18
 
   unit-tests-release:

--- a/src/def/convert_defs.h
+++ b/src/def/convert_defs.h
@@ -5,6 +5,9 @@ typedef enum {
   CONVERT_TEXT2DAWG,
   CONVERT_TEXT2GADDAG,
   CONVERT_TEXT2KWG,
+  // Like CONVERT_TEXT2KWG but uses wolges-style tail merging for a smaller
+  // (but slightly slower to traverse) node array.
+  CONVERT_TEXT2KWG_TAIL_MERGE,
   CONVERT_DAWG2TEXT,
   CONVERT_GADDAG2TEXT,
   CONVERT_CSV2KLV,

--- a/src/def/kwg_defs.h
+++ b/src/def/kwg_defs.h
@@ -30,6 +30,11 @@ typedef enum {
 typedef enum {
   KWG_MAKER_MERGE_NONE,
   KWG_MAKER_MERGE_EXACT,
+  // Like KWG_MAKER_MERGE_EXACT, but additionally overlaps sibling lists (child
+  // lists) when one is a tail of another (wolges-style "tail merging"),
+  // producing a smaller node array at the cost of cache locality during
+  // movegen.
+  KWG_MAKER_MERGE_TAIL,
 } kwg_maker_merge_t;
 
 #endif

--- a/src/impl/convert.c
+++ b/src/impl/convert.c
@@ -130,7 +130,11 @@ void convert_from_text_with_dwl(const LetterDistribution *ld,
     } else if (conversion_type == CONVERT_TEXT2GADDAG) {
       output_type = KWG_MAKER_OUTPUT_GADDAG;
     }
-    KWG *kwg = make_kwg_from_words(strings, output_type, KWG_MAKER_MERGE_EXACT);
+    const kwg_maker_merge_t merge_type =
+        (conversion_type == CONVERT_TEXT2KWG_TAIL_MERGE)
+            ? KWG_MAKER_MERGE_TAIL
+            : KWG_MAKER_MERGE_EXACT;
+    KWG *kwg = make_kwg_from_words(strings, output_type, merge_type);
     kwg_write_to_file(kwg, kwg_output_filename, error_stack);
     if (!error_stack_is_empty(error_stack)) {
       error_stack_push(
@@ -155,6 +159,7 @@ void convert_with_names(const LetterDistribution *ld,
   if ((conversion_type == CONVERT_TEXT2DAWG) ||
       (conversion_type == CONVERT_TEXT2GADDAG) ||
       (conversion_type == CONVERT_TEXT2KWG) ||
+      (conversion_type == CONVERT_TEXT2KWG_TAIL_MERGE) ||
       (conversion_type == CONVERT_TEXT2WORDMAP)) {
     DictionaryWordList *strings = dictionary_word_list_create();
     convert_from_text_with_dwl(ld, conversion_type, data_paths, input_name,
@@ -256,6 +261,8 @@ get_conversion_type_from_string(const char *conversion_type_string) {
     conversion_type = CONVERT_TEXT2GADDAG;
   } else if (strings_equal(conversion_type_string, "text2kwg")) {
     conversion_type = CONVERT_TEXT2KWG;
+  } else if (strings_equal(conversion_type_string, "text2kwgtailmerge")) {
+    conversion_type = CONVERT_TEXT2KWG_TAIL_MERGE;
   } else if (strings_equal(conversion_type_string, "dawg2text")) {
     conversion_type = CONVERT_DAWG2TEXT;
   } else if (strings_equal(conversion_type_string, "gaddag2text")) {

--- a/src/impl/kwg_maker.c
+++ b/src/impl/kwg_maker.c
@@ -584,9 +584,256 @@ static void serialize_states_to_kwg(const StateList *states, uint32_t dawg_root,
   free(chain_base_map);
 }
 
+// ============================================================================
+// Tail-merging (wolges-style) serializer
+// ============================================================================
+//
+// "Tail" here means the tail end of a child (sibling) list, not a word suffix.
+// The State graph built above is already a minimal DAG: identical sibling
+// chains are shared (two parents whose children are byte-identical point to the
+// same head State). serialize_states_to_kwg, however, lays every distinct chain
+// head down as its own contiguous run, so a child list that is only a tail of
+// another (e.g. [R,S] vs [E,R,S]) is duplicated in the output.
+//
+// This serializer instead overlaps such tails: a node whose children are [R,S]
+// points into the middle of an existing [E,R,S] run. It is a direct port of
+// wolges' BuildLayout::MagpieMerged defragger (gen_head_indexes /
+// gen_to_end_lens / defrag_magpie_merged / to_vec). See
+// https://github.com/andy-k/wolges/blob/main/src/build.rs
+
+// Temporary sentinel marking a state's output slot as reserved-but-unassigned
+// while we break self-cycles during the post-order walk.
+enum { TAIL_DEFRAG_PENDING = 0xFFFFFFFF };
+
+typedef struct TailDefragger {
+  const State *states;
+  // head_indexes[p] = the head (first sibling) of the longest sibling chain
+  // that state p is a tail of. Canonicalizing arc targets through this is what
+  // enables tail overlap.
+  uint32_t *head_indexes;
+  // to_end_lens[p] = number of siblings from p to the end of its chain.
+  uint32_t *to_end_lens;
+  // destination[p] = output node index assigned to state p (0 = unassigned).
+  uint32_t *destination;
+  uint32_t num_written;
+} TailDefragger;
+
+// head_indexes[p] points to the head of p's sibling chain. Because a tail state
+// can belong to several chains, we pick the lowest-indexed predecessor, which
+// (since states are topologically ordered with next_index < p) chases up to the
+// head of the longest containing chain.
+static void tail_compute_head_indexes(const StateList *states,
+                                      uint32_t *head_indexes) {
+  const uint32_t count = (uint32_t)states->count;
+  for (uint32_t state_idx = 0; state_idx < count; state_idx++) {
+    head_indexes[state_idx] = state_idx;
+  }
+  // Point each state's next_index back to it (its immediate predecessor).
+  for (uint32_t state_idx = count - 1; state_idx >= 1; state_idx--) {
+    head_indexes[states->states[state_idx].next_index] = state_idx;
+  }
+  // head_indexes[0] is garbage and unused. Chase predecessors to the chain
+  // head.
+  for (uint32_t state_idx = count - 1; state_idx >= 1; state_idx--) {
+    head_indexes[state_idx] = head_indexes[head_indexes[state_idx]];
+  }
+}
+
+static void tail_compute_to_end_lens(const StateList *states,
+                                     uint32_t *to_end_lens) {
+  const uint32_t count = (uint32_t)states->count;
+  for (uint32_t state_idx = 0; state_idx < count; state_idx++) {
+    to_end_lens[state_idx] = 1;
+  }
+  // next_index < state_idx, so the value we add is already finalized.
+  for (uint32_t state_idx = 1; state_idx < count; state_idx++) {
+    const uint32_t next = states->states[state_idx].next_index;
+    if (next != 0) {
+      to_end_lens[state_idx] += to_end_lens[next];
+    }
+  }
+}
+
+// Reserve output space for the chain headed (after canonicalization) at p, then
+// recurse into children, then assign each sibling an output slot — stopping
+// early if a tail of this chain was already placed elsewhere, in which case
+// the remaining siblings reuse those slots.
+static void tail_defrag(TailDefragger *defragger, uint32_t p) {
+  p = defragger->head_indexes[p];
+  if (defragger->destination[p] != 0) {
+    return;
+  }
+  const uint32_t initial_num_written = defragger->num_written;
+  defragger->destination[p] = TAIL_DEFRAG_PENDING;
+  const uint32_t num = defragger->to_end_lens[p];
+  defragger->num_written += num;
+  for (uint32_t sibling = p;;) {
+    const uint32_t arc_index = defragger->states[sibling].arc_index;
+    if (arc_index != 0) {
+      tail_defrag(defragger, arc_index);
+    }
+    sibling = defragger->states[sibling].next_index;
+    if (sibling == 0) {
+      break;
+    }
+  }
+  uint32_t write_p = p;
+  defragger->destination[write_p] = 0;
+  for (uint32_t ofs = 0; ofs < num; ofs++) {
+    if (defragger->destination[write_p] != 0) {
+      break;
+    }
+    defragger->destination[write_p] = initial_num_written + ofs;
+    write_p = defragger->states[write_p].next_index;
+  }
+}
+
+static inline uint32_t tail_node_value(const TailDefragger *defragger,
+                                       uint32_t arc_index, bool is_end,
+                                       bool accepts, uint8_t tile) {
+  uint32_t node = ((uint32_t)tile) << KWG_TILE_BIT_OFFSET;
+  if (accepts) {
+    node |= KWG_NODE_ACCEPTS_FLAG;
+  }
+  if (is_end) {
+    node |= KWG_NODE_IS_END_FLAG;
+  }
+  node |= (defragger->destination[arc_index] & KWG_ARC_INDEX_MASK);
+  return node;
+}
+
+// MAGPIE builds sibling chains highest-tile-first (arc_index -> highest tile,
+// next_index descending to the lowest, which carries next_index 0). wolges'
+// defragger above assumes the opposite orientation (arc_index -> lowest tile,
+// next_index ascending to the highest). The tail-merge sharing is anchored at
+// the next_index-0 end, so feeding it MAGPIE's orientation would overlap the
+// wrong (low-tile) end. This converter rebuilds the (already minimal) state
+// graph in wolges' orientation via the same hash-consing dedup, so shared
+// reversed tails merge correctly.
+typedef struct WolgesConverter {
+  const StateList *src;
+  StateList *dst;
+  StateHashTable *table;
+  uint32_t *memo; // src head index -> dst head index (UINT32_MAX = unconverted)
+} WolgesConverter;
+
+static uint32_t wolges_convert_chain(WolgesConverter *converter,
+                                     uint32_t src_head) {
+  if (src_head == 0) {
+    return 0;
+  }
+  if (converter->memo[src_head] != UINT32_MAX) {
+    return converter->memo[src_head];
+  }
+  // Collect this chain's siblings in MAGPIE order (highest tile first),
+  // converting each child subtree first.
+  uint8_t tiles[MACHINE_LETTER_MAX_VALUE];
+  uint8_t accepts[MACHINE_LETTER_MAX_VALUE];
+  uint32_t arcs[MACHINE_LETTER_MAX_VALUE];
+  uint32_t count = 0;
+  for (uint32_t s = src_head; s != 0;
+       s = converter->src->states[s].next_index) {
+    tiles[count] = converter->src->states[s].tile;
+    accepts[count] = converter->src->states[s].accepts;
+    arcs[count] =
+        wolges_convert_chain(converter, converter->src->states[s].arc_index);
+    count++;
+  }
+  // Chaining next_index = previous insertion while iterating highest -> lowest
+  // produces the ascending chain (head = lowest tile, highest carries
+  // next_index 0), matching wolges' make_state.
+  uint32_t ret = 0;
+  for (uint32_t k = 0; k < count; k++) {
+    ret = state_hash_table_find_or_insert(converter->table, converter->dst,
+                                          tiles[k], accepts[k], arcs[k], ret);
+  }
+  converter->memo[src_head] = ret;
+  return ret;
+}
+
+static void serialize_states_to_kwg_tail_merged(const StateList *src_states,
+                                                uint32_t dawg_root,
+                                                uint32_t gaddag_root,
+                                                bool output_dawg,
+                                                bool output_gaddag, KWG *kwg) {
+  // Reorient into wolges' convention.
+  StateList states;
+  state_list_create(&states, src_states->count);
+  StateHashTable convert_table;
+  state_hash_table_create(&convert_table, src_states->count * 2 + 1,
+                          src_states->count);
+  uint32_t *memo = malloc_or_die(sizeof(uint32_t) * src_states->count);
+  for (size_t i = 0; i < src_states->count; i++) {
+    memo[i] = UINT32_MAX;
+  }
+  WolgesConverter converter = {
+      .src = src_states, .dst = &states, .table = &convert_table, .memo = memo};
+  if (output_dawg) {
+    dawg_root = wolges_convert_chain(&converter, dawg_root);
+  }
+  if (output_gaddag) {
+    gaddag_root = wolges_convert_chain(&converter, gaddag_root);
+  }
+  free(memo);
+  state_hash_table_destroy(&convert_table);
+
+  const size_t count = states.count;
+  TailDefragger defragger = {
+      .states = states.states,
+      .head_indexes = malloc_or_die(sizeof(uint32_t) * count),
+      .to_end_lens = malloc_or_die(sizeof(uint32_t) * count),
+      .destination = calloc_or_die(count, sizeof(uint32_t)),
+      // Reserve output nodes 0 and 1 for the DAWG and GADDAG root pointers, as
+      // MAGPIE readers expect both to be present.
+      .num_written = 2,
+  };
+  tail_compute_head_indexes(&states, defragger.head_indexes);
+  tail_compute_to_end_lens(&states, defragger.to_end_lens);
+
+  // Mark the null state as placed so arc_index 0 resolves to a 0 pointer and
+  // self-cycles during the walk terminate.
+  defragger.destination[0] = TAIL_DEFRAG_PENDING;
+  if (output_dawg && dawg_root != 0) {
+    tail_defrag(&defragger, dawg_root);
+  }
+  if (output_gaddag && gaddag_root != 0) {
+    tail_defrag(&defragger, gaddag_root);
+  }
+  defragger.destination[0] = 0;
+
+  kwg_allocate_nodes(kwg, defragger.num_written);
+  uint32_t *kwg_nodes = kwg_get_mutable_nodes(kwg);
+  kwg_nodes[0] = tail_node_value(&defragger, dawg_root, true, false, 0);
+  kwg_nodes[1] = tail_node_value(&defragger, gaddag_root, true, false, 0);
+
+  for (uint32_t state_idx = 1; state_idx < count; state_idx++) {
+    uint32_t output_idx = defragger.destination[state_idx];
+    if (output_idx == 0) {
+      continue;
+    }
+    for (uint32_t sibling = state_idx;;) {
+      const uint32_t next = defragger.states[sibling].next_index;
+      kwg_nodes[output_idx] = tail_node_value(
+          &defragger, defragger.states[sibling].arc_index, next == 0,
+          defragger.states[sibling].accepts, defragger.states[sibling].tile);
+      if (next == 0) {
+        break;
+      }
+      sibling = next;
+      output_idx++;
+    }
+  }
+
+  free(defragger.head_indexes);
+  free(defragger.to_end_lens);
+  free(defragger.destination);
+  state_list_destroy(&states);
+}
+
 // Fast KWG builder using compact states and transition stack
 KWG *make_kwg_from_words_fast(const DictionaryWordList *words,
-                              kwg_maker_output_t output) {
+                              kwg_maker_output_t output,
+                              kwg_maker_merge_t merge) {
   const bool output_dawg = (output == KWG_MAKER_OUTPUT_DAWG) ||
                            (output == KWG_MAKER_OUTPUT_DAWG_AND_GADDAG);
   const bool output_gaddag = (output == KWG_MAKER_OUTPUT_GADDAG) ||
@@ -672,7 +919,12 @@ KWG *make_kwg_from_words_fast(const DictionaryWordList *words,
 
   // Serialize to KWG format
   KWG *kwg = kwg_create_empty();
-  serialize_states_to_kwg(&states, dawg_root, gaddag_root, kwg);
+  if (merge == KWG_MAKER_MERGE_TAIL) {
+    serialize_states_to_kwg_tail_merged(&states, dawg_root, gaddag_root,
+                                        output_dawg, output_gaddag, kwg);
+  } else {
+    serialize_states_to_kwg(&states, dawg_root, gaddag_root, kwg);
+  }
 
   transition_stack_destroy(&stack);
   state_hash_table_destroy(&table);
@@ -1224,8 +1476,8 @@ static inline int get_letters_in_common(const DictionaryWord *word,
 KWG *make_kwg_from_words(const DictionaryWordList *words,
                          kwg_maker_output_t output, kwg_maker_merge_t merging) {
   // Use the fast compact-state builder when merging is enabled
-  if (merging == KWG_MAKER_MERGE_EXACT) {
-    return make_kwg_from_words_fast(words, output);
+  if (merging == KWG_MAKER_MERGE_EXACT || merging == KWG_MAKER_MERGE_TAIL) {
+    return make_kwg_from_words_fast(words, output, merging);
   }
 
   const bool output_dawg = (output == KWG_MAKER_OUTPUT_DAWG) ||
@@ -1312,8 +1564,8 @@ KWG *make_kwg_from_words_small(const DictionaryWordList *words,
                                kwg_maker_output_t output,
                                kwg_maker_merge_t merging) {
   // Use the fast compact-state builder when merging is enabled
-  if (merging == KWG_MAKER_MERGE_EXACT) {
-    return make_kwg_from_words_fast(words, output);
+  if (merging == KWG_MAKER_MERGE_EXACT || merging == KWG_MAKER_MERGE_TAIL) {
+    return make_kwg_from_words_fast(words, output, merging);
   }
 
   const bool output_dawg = (output == KWG_MAKER_OUTPUT_DAWG) ||

--- a/test/kwg_maker_test.c
+++ b/test/kwg_maker_test.c
@@ -1,3 +1,4 @@
+#include "../src/compat/ctime.h"
 #include "../src/def/kwg_defs.h"
 #include "../src/def/letter_distribution_defs.h"
 #include "../src/ent/dictionary_word.h"
@@ -7,11 +8,13 @@
 #include "../src/ent/player.h"
 #include "../src/impl/config.h"
 #include "../src/impl/kwg_maker.h"
+#include "../src/impl/word_prune.h"
 #include "../src/util/io_util.h"
 #include "../src/util/string_util.h"
 #include "test_util.h"
 #include <assert.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -423,6 +426,144 @@ void test_full_csw_gaddag(void) {
   game_destroy(game);
   kwg_destroy(kwg);
   config_destroy(config);
+}
+
+// Builds CSW21 with both KWG_MAKER_MERGE_EXACT and KWG_MAKER_MERGE_TAIL,
+// confirms the tail-merged graph round-trips the identical word set and
+// GADDAG strings, and reports the node-count savings.
+void test_kwg_tail_merge(void) {
+  Config *config = config_create_or_die("set -lex CSW21");
+  Game *game = config_game_create(config);
+  const Player *player = game_get_player(game, 0);
+  const KWG *csw_kwg = player_get_kwg(player);
+  DictionaryWordList *words = dictionary_word_list_create();
+  kwg_write_words(csw_kwg, kwg_get_dawg_root_node_index(csw_kwg), words, NULL);
+
+  DictionaryWordList *gaddag_strings = dictionary_word_list_create();
+  add_gaddag_strings(words, gaddag_strings);
+
+  KWG *exact_kwg = make_kwg_from_words(words, KWG_MAKER_OUTPUT_DAWG_AND_GADDAG,
+                                       KWG_MAKER_MERGE_EXACT);
+  KWG *tail_kwg = make_kwg_from_words(words, KWG_MAKER_OUTPUT_DAWG_AND_GADDAG,
+                                      KWG_MAKER_MERGE_TAIL);
+
+  const int exact_nodes = kwg_get_number_of_nodes(exact_kwg);
+  const int tail_nodes = kwg_get_number_of_nodes(tail_kwg);
+  printf("kwg tail merge: exact=%d nodes, tail=%d nodes (saved %d, %.2f%%)\n",
+         exact_nodes, tail_nodes, exact_nodes - tail_nodes,
+         100.0 * (exact_nodes - tail_nodes) / exact_nodes);
+  assert(tail_nodes < exact_nodes);
+
+  // The tail-merged graph must encode the identical DAWG word set...
+  bool *nodes_reached =
+      calloc_or_die(kwg_get_number_of_nodes(tail_kwg), sizeof(bool));
+  DictionaryWordList *encoded_words = dictionary_word_list_create();
+  kwg_write_words(tail_kwg, kwg_get_dawg_root_node_index(tail_kwg),
+                  encoded_words, nodes_reached);
+  assert_word_lists_are_equal(words, encoded_words);
+
+  // ...and the identical GADDAG strings.
+  DictionaryWordList *encoded_gaddag_strings = dictionary_word_list_create();
+  kwg_write_gaddag_strings(tail_kwg, kwg_get_root_node_index(tail_kwg),
+                           encoded_gaddag_strings, nodes_reached);
+  assert_word_lists_are_equal(gaddag_strings, encoded_gaddag_strings);
+
+  // Every node (past the two root pointers) must be reachable: no orphans.
+  for (int i = 2; i < kwg_get_number_of_nodes(tail_kwg); i++) {
+    assert(nodes_reached[i]);
+  }
+
+  free(nodes_reached);
+  dictionary_word_list_destroy(encoded_gaddag_strings);
+  dictionary_word_list_destroy(encoded_words);
+  dictionary_word_list_destroy(gaddag_strings);
+  dictionary_word_list_destroy(words);
+  kwg_destroy(tail_kwg);
+  kwg_destroy(exact_kwg);
+  game_destroy(game);
+  config_destroy(config);
+}
+
+// Builds a GADDAG from `word_list` with each merge style, timing build speed.
+// This is the endgame/PEG word-prune code path (make_kwg_from_words_small,
+// OUTPUT_GADDAG), where build time — not node count — is what matters.
+static void bench_kwg_merge_build(const char *label,
+                                  const DictionaryWordList *word_list) {
+  const int word_count = dictionary_word_list_get_count(word_list);
+  const kwg_maker_merge_t merges[3] = {
+      KWG_MAKER_MERGE_NONE, KWG_MAKER_MERGE_EXACT, KWG_MAKER_MERGE_TAIL};
+  const char *names[3] = {"none  ", "exact ", "tail  "};
+  int reps = 4000000 / (word_count + 1);
+  if (reps < 10) {
+    reps = 10;
+  }
+  if (reps > 4000) {
+    reps = 4000;
+  }
+  printf("[%-14s] %6d words, reps=%d\n", label, word_count, reps);
+  for (int merge_idx = 0; merge_idx < 3; merge_idx++) {
+    KWG *warm = make_kwg_from_words_small(word_list, KWG_MAKER_OUTPUT_GADDAG,
+                                          merges[merge_idx]);
+    const int nodes = kwg_get_number_of_nodes(warm);
+    kwg_destroy(warm);
+    Timer timer;
+    ctimer_start(&timer);
+    for (int rep = 0; rep < reps; rep++) {
+      KWG *kwg = make_kwg_from_words_small(word_list, KWG_MAKER_OUTPUT_GADDAG,
+                                           merges[merge_idx]);
+      kwg_destroy(kwg);
+    }
+    const double secs = ctimer_elapsed_seconds(&timer);
+    printf("    %s  %9.1f us/build   %8d nodes\n", names[merge_idx],
+           1e6 * secs / reps, nodes);
+  }
+}
+
+void test_kwg_merge_build_bench(void) {
+  Config *config = config_create_or_die("set -lex CSW21");
+  Game *game = config_game_create(config);
+  const KWG *csw_kwg = player_get_kwg(game_get_player(game, 0));
+  DictionaryWordList *all_words = dictionary_word_list_create();
+  kwg_write_words(csw_kwg, kwg_get_dawg_root_node_index(csw_kwg), all_words,
+                  NULL);
+  const int total = dictionary_word_list_get_count(all_words);
+
+  // Synthetic size sweep: evenly-sampled (still sorted, unique) sublists at
+  // sizes spanning what an endgame/PEG word prune produces.
+  const int sizes[] = {100, 500, 2000, 10000, 50000};
+  for (size_t size_idx = 0; size_idx < sizeof(sizes) / sizeof(sizes[0]);
+       size_idx++) {
+    const int target = sizes[size_idx];
+    DictionaryWordList *sub = dictionary_word_list_create();
+    for (int word_idx = 0; word_idx < target; word_idx++) {
+      const DictionaryWord *word = dictionary_word_list_get_word(
+          all_words, (int)((int64_t)word_idx * total / target));
+      dictionary_word_list_add_word(sub, dictionary_word_get_word(word),
+                                    dictionary_word_get_length(word));
+    }
+    char label[32];
+    (void)snprintf(label, sizeof(label), "sampled-%d", target);
+    bench_kwg_merge_build(label, sub);
+    dictionary_word_list_destroy(sub);
+  }
+  dictionary_word_list_destroy(all_words);
+  game_destroy(game);
+  config_destroy(config);
+
+  // A real, nearly-full board: the genuine word-prune output an endgame faces.
+  Config *pos_config = config_create_or_die("set -lex NWL20");
+  load_and_exec_config_or_die(
+      pos_config,
+      "cgp AIDER2U7/b1E1E2N1Z5/AWN1T2M1ATT3/LI1COBLE2OW3/OP2U2E2AA3/"
+      "NE2CUSTARDS1Q1/ER1OH5I2U1/S2K2FOB1ERGOT/5HEXYLS2I1/4JIN6N1/"
+      "2GOOP2NAIVEsT/1DIRE10/2GAY10/15/15 AEFILMR/DIV 371/412 0");
+  const Game *pos_game = config_get_game(pos_config);
+  const KWG *full_kwg = player_get_kwg(game_get_player(pos_game, 0));
+  DictionaryWordList *pruned = dictionary_word_list_create();
+  generate_possible_words(pos_game, full_kwg, pruned);
+  bench_kwg_merge_build("real-fullboard", pruned);
+  dictionary_word_list_destroy(pruned);
+  config_destroy(pos_config);
 }
 
 void test_kwg_maker(void) {

--- a/test/kwg_maker_test.h
+++ b/test/kwg_maker_test.h
@@ -2,5 +2,7 @@
 #define KWG_MAKER_TEST_H
 
 void test_kwg_maker(void);
+void test_kwg_tail_merge(void);
+void test_kwg_merge_build_bench(void);
 
 #endif

--- a/test/test.c
+++ b/test/test.c
@@ -158,6 +158,8 @@ static TestEntry on_demand_test_table[] = {
     {"benchns", test_benchmark_nonstuck},
     {"benchns3v3", test_benchmark_nonstuck_3v3},
     {"multipv", test_multi_pv},
+    {"kwgtailmerge", test_kwg_tail_merge},
+    {"kwgmergebench", test_kwg_merge_build_bench},
     {"kue", test_kue},
     {"monsterq", test_monster_q},
     {"simbench", test_sim_benchmark},


### PR DESCRIPTION
## Summary

Adds a third KWG node-array layout, `KWG_MAKER_MERGE_TAIL`, that overlaps child (sibling) lists when one is a **tail** of another ("tail merging" — the tail end of a child list, not a word suffix), matching wolges' `MagpieMerged` layout. The minimal state DAG MAGPIE already builds is reoriented into wolges' ascending-sibling convention (MAGPIE builds chains high→low; wolges low→high) and run through a port of wolges' `defrag_magpie_merged`.

Exposed via a new `convert text2kwgtailmerge` command for producing smaller distributable `.kwg` files.

**Validated against a wolges-built reference** (`buildlex english-magpiemerged-kwg`): identical node count and byte-identical DAWG + GADDAG *contents* (md5) for CSW21:

| layout | nodes | bytes |
|---|---|---|
| `MERGE_EXACT` (status quo) | 1,240,912 | 4,963,648 |
| `MERGE_TAIL` (new) | 1,200,257 | 4,801,028 |

(−3.28% / ~159 KB). Output isn't byte-identical to wolges since MAGPIE's state-index order differs, producing a different but equally-compact valid tie-break.

## Why MERGE_EXACT remains the default (and the word-prune choice)

`MERGE_EXACT` is the status quo and the layout used by the endgame and PEG word-prune path (`make_kwg_from_words_small`, `OUTPUT_GADDAG`). This PR leaves it unchanged, because for KWG *creation* it is strictly better:

**1. Faster to create.** Tail merging does everything `EXACT` does plus a reorientation rebuild and overlap passes, so it is consistently slower to build (`kwgmergebench`, GADDAG, single-threaded):

| wordlist | EXACT | TAIL | delta |
|---|---|---|---|
| real full board (~1.3k words) | 266 µs | 300 µs | **+13%** |
| sampled 2,000 | 2,982 µs | 3,890 µs | **+30%** |
| sampled 50,000 | 64.6 ms | 78.8 ms | **+22%** |

On the representative endgame word-prune size (~1.3k words), `EXACT` is both the fastest to build and ~60% smaller than `MERGE_NONE`.

**2. Performance-neutral for move-finding.** The 3.28% smaller node array yields no measurable autoplay/movegen speedup (CSW21, single-threaded, identical seeded games): tail/exact median wall-clock ratio **1.0009** — within noise. The extra node duplication `MERGE_EXACT` keeps (better cache locality) costs nothing here.

So `MERGE_TAIL` is purely a file-size option for shipped lexica, never a hot-path or word-prune choice.

## Tests

Two on-demand tests added:
- `kwgtailmerge` — round-trips CSW21 through `MERGE_TAIL` and asserts identical DAWG word set + GADDAG strings vs `MERGE_EXACT`, all nodes reachable, smaller node count.
- `kwgmergebench` — the build-time comparison above (synthetic size sweep + a real `generate_possible_words` full-board position).

## CI fix (incidental)

`lint-fast` and `clang-tidy` installed `clang-format-20` / `clang-tidy-18` via apt without a preceding `apt-get update`, so a superseded package version 404s against the Ubuntu mirror (this was failing `lint-fast` independent of the diff). Added `apt-get update` before those installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)