### PR TITLE
word_prune: enumerate non-playthrough words via the gaddag (no DAWG)

### DIFF
--- a/src/impl/word_prune.c
+++ b/src/impl/word_prune.c
@@ -326,6 +326,56 @@ void add_playthrough_words_from_row(const BoardRow *board_row, const KWG *kwg,
   }
 }
 
+// Enumerate words playable in empty space (non-playthrough) using only the
+// GADDAG, so wordprune runs on any KWG including gaddag-only pruned ones (no
+// DAWG required). For each first letter, follow its arc then the separator to
+// reach the forward (DAWG-equivalent) node, then reuse the existing forward
+// walk for the suffix. gaddag_root -> first_letter -> SEPARATOR encodes the
+// same forward suffix language as the DAWG node after that first letter.
+void add_words_without_playthrough_gaddag(
+    const KWG *kwg, Rack *rack, int max_nonplaythrough, MachineLetter *word,
+    DictionaryWordList *possible_word_list) {
+  if (max_nonplaythrough <= 0) {
+    return;
+  }
+  const uint32_t gaddag_root = kwg_get_root_node_index(kwg);
+  for (uint32_t node_idx = gaddag_root;; node_idx++) {
+    const uint32_t node = kwg_node(kwg, node_idx);
+    const MachineLetter ml = kwg_node_tile(node);
+    const bool have_natural = rack_get_letter(rack, ml) > 0;
+    const bool have_blank = rack_get_letter(rack, BLANK_MACHINE_LETTER) > 0;
+    if (ml != SEPARATION_MACHINE_LETTER && (have_natural || have_blank)) {
+      // Cross the separator from the single-letter reversed prefix [ml] to the
+      // forward node (and its acceptance: whether ml alone is a word).
+      uint32_t fwd_node = 0;
+      bool fwd_accepts = false;
+      for (uint32_t sep_idx = kwg_node_arc_index_prefetch(node, kwg);;
+           sep_idx++) {
+        const uint32_t sep = kwg_node(kwg, sep_idx);
+        if (kwg_node_tile(sep) == SEPARATION_MACHINE_LETTER) {
+          fwd_node = kwg_node_arc_index_prefetch(sep, kwg);
+          fwd_accepts = kwg_node_accepts(sep);
+          break;
+        }
+        if (kwg_node_is_end(sep)) {
+          break;
+        }
+      }
+      if (fwd_node != 0 || fwd_accepts) {
+        word[0] = ml; // blanks are recorded as their natural letter
+        const MachineLetter consumed = have_natural ? ml : BLANK_MACHINE_LETTER;
+        rack_take_letter(rack, consumed);
+        add_words_without_playthrough(kwg, fwd_node, rack, max_nonplaythrough,
+                                      word, 1, fwd_accepts, possible_word_list);
+        rack_add_letter(rack, consumed);
+      }
+    }
+    if (kwg_node_is_end(node)) {
+      break;
+    }
+  }
+}
+
 void generate_possible_words(const Game *game, const KWG *override_kwg,
                              DictionaryWordList *possible_word_list) {
   const KWG *kwg = override_kwg;
@@ -369,9 +419,9 @@ void generate_possible_words(const Game *game, const KWG *override_kwg,
   }
 
   MachineLetter word[BOARD_DIM];
-  add_words_without_playthrough(kwg, kwg_get_dawg_root_node_index(kwg),
-                                &unplayed_as_rack, max_nonplaythrough_spaces,
-                                word, 0, false, temp_list);
+  // Gaddag-only enumeration (no DAWG dependency) so this works on any KWG.
+  add_words_without_playthrough_gaddag(
+      kwg, &unplayed_as_rack, max_nonplaythrough_spaces, word, temp_list);
   for (int i = 0; i < board_rows->num_rows; i++) {
     add_playthrough_words_from_row(&board_rows->rows[i], kwg, &unplayed_as_rack,
                                    temp_list);


### PR DESCRIPTION
## What

`generate_possible_words` enumerated non-playthrough words (those playable in empty space) by walking the **DAWG root**, while playthrough words already used the gaddag. That meant wordprune **required the KWG to carry a DAWG**, and would silently produce wrong results if given a gaddag-only KWG.

This replaces the non-playthrough enumeration with `add_words_without_playthrough_gaddag`, which walks **only the gaddag**: for each first letter, follow its arc then the separator to reach the forward node, then reuse the existing forward walk for the suffix. `gaddag_root -> c0 -> SEPARATOR` encodes the identical forward-suffix language as `dawg_root -> c0`, so the output is unchanged.

## Correctness

Byte-identical output — the `word_prune` unit test's exact word-count assertions (279053 / 62702 / 6396 / 11161) and specific-word present/absent checks all pass unchanged. cppcheck and clang-format are clean.

## Motivation

This lets wordprune run on **any** KWG, including the gaddag-only pruned KWGs the engine already builds. That enables **chaining wordprunes** — pruning an already-pruned KWG — **which has never been tried before**. For example, building a tighter per-candidate prune from a parent prune during pre-endgame/endgame search, instead of re-pruning from the full lexicon every time. It's also a latent-correctness fix: passing a gaddag-only override KWG to `generate_possible_words` was previously unsafe.

## Alternative considered (and rejected)

The other way to make chaining work would have been the opposite: have wordprune **output** a DAWG too (build pruned KWGs as `DAWG_AND_GADDAG`), so the existing DAWG-based enumeration could prune from them. That only makes sense if a DAWG in the pruned KWG earns its keep elsewhere, so we tried to get value from it in move generation.

The idea: for forward-from-anchor plays in the small-move (`go_on_small`) generator, seed the rightward walk from `dawg_root -> anchor_letter` instead of the gaddag's post-separator node (provably the same forward language) to get a more compact, cache-local traversal. It was value-exact (movegen unit test passed), but **came up short on speed: ~1.1-1.2% slower**, consistently, on both pruned and full-lexicon endgame solves. The reason is that the gaddag's post-separator subtree already *is* a DAWG (same forward node count, zero instruction savings), and pruned KWGs are small enough to be cache-resident — so adding a DAWG only makes them bigger with no locality win.

With no downstream use to justify the larger pruned KWG, making wordprune **gaddag-only** (this PR) is the better direction: pruned KWGs stay small and gaddag-only, and chaining still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)