### PR TITLE
endgame: streaming / live-PV / top-K analysis hooks

### DIFF
--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -817,12 +817,12 @@ uint64_t endgame_ctx_get_nodes_searched(const EndgameCtx *ctx) {
   return total;
 }
 
-int endgame_ctx_get_current_line(const EndgameCtx *ctx, int thread_index,
+int endgame_ctx_get_current_line(const EndgameCtx *ctx, int worker_index,
                                  uint64_t *out_line, int max_len) {
-  if (thread_index < 0 || thread_index >= ctx->cap_workers) {
+  if (worker_index < 0 || worker_index >= ctx->cap_workers) {
     return 0;
   }
-  const EndgameCtxWorker *w = ctx->workers[thread_index];
+  const EndgameCtxWorker *w = ctx->workers[worker_index];
   // Acquire on length pairs with release on writer side: by the time we
   // observe length L, all writes to current_line[0..L-1] up to that
   // store are visible. The worker may have moved on since then; entries
@@ -840,14 +840,14 @@ int endgame_ctx_get_current_line(const EndgameCtx *ctx, int thread_index,
   return len;
 }
 
-int endgame_ctx_get_live_pv(const EndgameCtx *ctx, int thread_index,
+int endgame_ctx_get_live_pv(const EndgameCtx *ctx, int worker_index,
                             uint64_t *out_moves, int max_len,
                             int32_t *out_value) {
-  if (thread_index < 0 || thread_index >= ctx->cap_workers) {
+  if (worker_index < 0 || worker_index >= ctx->cap_workers) {
     *out_value = 0;
     return 0;
   }
-  const EndgameCtxWorker *w = ctx->workers[thread_index];
+  const EndgameCtxWorker *w = ctx->workers[worker_index];
   // Seqlock read: try a few times to capture a consistent snapshot
   // (length, moves, value all from the same writer update).
   for (int attempt = 0; attempt < 4; attempt++) {
@@ -879,12 +879,12 @@ int endgame_ctx_get_live_pv(const EndgameCtx *ctx, int thread_index,
   return 0;
 }
 
-int endgame_ctx_get_live_top_k_pvs(const EndgameCtx *ctx, int thread_index,
+int endgame_ctx_get_live_top_k_pvs(const EndgameCtx *ctx, int worker_index,
                                    EndgameLivePvSnapshot *out, int max_k) {
-  if (thread_index < 0 || thread_index >= ctx->cap_workers || max_k <= 0) {
+  if (worker_index < 0 || worker_index >= ctx->cap_workers || max_k <= 0) {
     return 0;
   }
-  const EndgameCtxWorker *w = ctx->workers[thread_index];
+  const EndgameCtxWorker *w = ctx->workers[worker_index];
   for (int attempt = 0; attempt < 4; attempt++) {
     const uint64_t seq1 =
         atomic_load_explicit(&w->live_top_k_seq, memory_order_acquire);

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -837,9 +837,10 @@ static int endgame_active_worker_count(const EndgameCtx *ctx) {
 uint64_t endgame_ctx_get_nodes_searched(const EndgameCtx *ctx) {
   uint64_t total = 0;
   const int active = endgame_active_worker_count(ctx);
-  for (int i = 0; i < active; i++) {
-    total += atomic_load_explicit(&ctx->workers[i]->published_nodes_searched,
-                                  memory_order_relaxed);
+  for (int worker_idx = 0; worker_idx < active; worker_idx++) {
+    total += atomic_load_explicit(
+        &ctx->workers[worker_idx]->published_nodes_searched,
+        memory_order_relaxed);
   }
   return total;
 }
@@ -850,21 +851,22 @@ int endgame_ctx_get_current_line(const EndgameCtx *ctx, int worker_index,
       worker_index >= endgame_active_worker_count(ctx)) {
     return 0;
   }
-  const EndgameCtxWorker *w = ctx->workers[worker_index];
+  const EndgameCtxWorker *worker = ctx->workers[worker_index];
   // Acquire on length pairs with release on writer side: by the time we
   // observe length L, all writes to current_line[0..L-1] up to that
   // store are visible. The worker may have moved on since then; entries
   // beyond what we read may correspond to a different sibling subtree.
-  int len = atomic_load_explicit(&w->current_line_len, memory_order_acquire);
+  int len =
+      atomic_load_explicit(&worker->current_line_len, memory_order_acquire);
   if (len > max_len) {
     len = max_len;
   }
   if (len > MAX_SEARCH_DEPTH) {
     len = MAX_SEARCH_DEPTH;
   }
-  for (int i = 0; i < len; i++) {
-    out_line[i] =
-        atomic_load_explicit(&w->current_line[i], memory_order_relaxed);
+  for (int ply_idx = 0; ply_idx < len; ply_idx++) {
+    out_line[ply_idx] = atomic_load_explicit(&worker->current_line[ply_idx],
+                                             memory_order_relaxed);
   }
   return len;
 }
@@ -877,30 +879,31 @@ int endgame_ctx_get_live_pv(const EndgameCtx *ctx, int worker_index,
     *out_value = 0;
     return 0;
   }
-  const EndgameCtxWorker *w = ctx->workers[worker_index];
+  const EndgameCtxWorker *worker = ctx->workers[worker_index];
   // Seqlock read: try a few times to capture a consistent snapshot
   // (length, moves, value all from the same writer update).
   for (int attempt = 0; attempt < 4; attempt++) {
     const uint64_t seq1 =
-        atomic_load_explicit(&w->live_pv_seq, memory_order_acquire);
+        atomic_load_explicit(&worker->live_pv_seq, memory_order_acquire);
     if ((seq1 & 1ULL) != 0) {
       continue; // writer in progress
     }
-    int len = atomic_load_explicit(&w->live_pv_length, memory_order_relaxed);
+    int len =
+        atomic_load_explicit(&worker->live_pv_length, memory_order_relaxed);
     const int32_t value =
-        atomic_load_explicit(&w->live_pv_value, memory_order_relaxed);
+        atomic_load_explicit(&worker->live_pv_value, memory_order_relaxed);
     if (len > max_len) {
       len = max_len;
     }
     if (len > MAX_SEARCH_DEPTH) {
       len = MAX_SEARCH_DEPTH;
     }
-    for (int i = 0; i < len; i++) {
-      out_moves[i] =
-          atomic_load_explicit(&w->live_pv_tiny_moves[i], memory_order_relaxed);
+    for (int ply_idx = 0; ply_idx < len; ply_idx++) {
+      out_moves[ply_idx] = atomic_load_explicit(
+          &worker->live_pv_tiny_moves[ply_idx], memory_order_relaxed);
     }
     const uint64_t seq2 =
-        atomic_load_explicit(&w->live_pv_seq, memory_order_acquire);
+        atomic_load_explicit(&worker->live_pv_seq, memory_order_acquire);
     if (seq1 == seq2) {
       *out_value = value;
       return len;
@@ -916,39 +919,40 @@ int endgame_ctx_get_live_top_k_pvs(const EndgameCtx *ctx, int worker_index,
       worker_index >= endgame_active_worker_count(ctx)) {
     return 0;
   }
-  const EndgameCtxWorker *w = ctx->workers[worker_index];
+  const EndgameCtxWorker *worker = ctx->workers[worker_index];
   for (int attempt = 0; attempt < 4; attempt++) {
     const uint64_t seq1 =
-        atomic_load_explicit(&w->live_top_k_seq, memory_order_acquire);
+        atomic_load_explicit(&worker->live_top_k_seq, memory_order_acquire);
     if ((seq1 & 1ULL) != 0) {
       continue; // writer in progress
     }
     int filled =
-        atomic_load_explicit(&w->live_top_k_filled, memory_order_relaxed);
+        atomic_load_explicit(&worker->live_top_k_filled, memory_order_relaxed);
     if (filled > max_k) {
       filled = max_k;
     }
     if (filled > MAX_ENDGAME_DISPLAY_PVS) {
       filled = MAX_ENDGAME_DISPLAY_PVS;
     }
-    for (int i = 0; i < filled; i++) {
-      out[i].root_tiny = atomic_load_explicit(&w->live_top_k_root_tiny[i],
-                                              memory_order_relaxed);
-      out[i].value =
-          atomic_load_explicit(&w->live_top_k_value[i], memory_order_relaxed);
-      int cont_len = atomic_load_explicit(&w->live_top_k_continuation_len[i],
-                                          memory_order_relaxed);
+    for (int pv_idx = 0; pv_idx < filled; pv_idx++) {
+      out[pv_idx].root_tiny = atomic_load_explicit(
+          &worker->live_top_k_root_tiny[pv_idx], memory_order_relaxed);
+      out[pv_idx].value = atomic_load_explicit(
+          &worker->live_top_k_value[pv_idx], memory_order_relaxed);
+      int cont_len = atomic_load_explicit(
+          &worker->live_top_k_continuation_len[pv_idx], memory_order_relaxed);
       if (cont_len > MAX_SEARCH_DEPTH) {
         cont_len = MAX_SEARCH_DEPTH;
       }
-      out[i].continuation_len = cont_len;
-      for (int j = 0; j < cont_len; j++) {
-        out[i].continuation_tiny[j] = atomic_load_explicit(
-            &w->live_top_k_continuation[i][j], memory_order_relaxed);
+      out[pv_idx].continuation_len = cont_len;
+      for (int ply_idx = 0; ply_idx < cont_len; ply_idx++) {
+        out[pv_idx].continuation_tiny[ply_idx] = atomic_load_explicit(
+            &worker->live_top_k_continuation[pv_idx][ply_idx],
+            memory_order_relaxed);
       }
     }
     const uint64_t seq2 =
-        atomic_load_explicit(&w->live_top_k_seq, memory_order_acquire);
+        atomic_load_explicit(&worker->live_top_k_seq, memory_order_acquire);
     if (seq1 == seq2) {
       return filled;
     }
@@ -974,8 +978,9 @@ void endgame_ctx_destroy(EndgameCtx *ctx) {
   if (!ctx) {
     return;
   }
-  for (int i = 0; i < atomic_load(&ctx->cap_workers); i++) {
-    solver_worker_destroy(ctx->workers[i]);
+  for (int worker_idx = 0; worker_idx < atomic_load(&ctx->cap_workers);
+       worker_idx++) {
+    solver_worker_destroy(ctx->workers[worker_idx]);
   }
   free(ctx->workers);
   free(ctx->worker_ids);
@@ -2034,7 +2039,7 @@ check_depth_deadline(EndgameCtxWorker *worker) {
 
 // Republish worker thread 0's live multi-PV top-K leaderboard with the
 // (root_tiny, value, continuation) for one just-completed root move. Keeps
-// entries sorted descending by value, deduped by root_tiny, capped at K_max
+// entries sorted descending by value, deduped by root_tiny, capped at max_k
 // (<= MAX_ENDGAME_DISPLAY_PVS). Seqlock writer: bump seq odd, mutate, bump
 // even, so endgame_ctx_get_live_top_k_pvs reads a consistent snapshot.
 // Atomically copy leaderboard slot `src` onto slot `dst` (relaxed loads/stores;
@@ -2053,10 +2058,10 @@ static void topk_copy_slot(EndgameCtxWorker *worker, int dst, int src) {
       &worker->live_top_k_continuation_len[src], memory_order_relaxed);
   atomic_store_explicit(&worker->live_top_k_continuation_len[dst], cont_len,
                         memory_order_relaxed);
-  for (int j = 0; j < cont_len; j++) {
+  for (int ply_idx = 0; ply_idx < cont_len; ply_idx++) {
     atomic_store_explicit(
-        &worker->live_top_k_continuation[dst][j],
-        atomic_load_explicit(&worker->live_top_k_continuation[src][j],
+        &worker->live_top_k_continuation[dst][ply_idx],
+        atomic_load_explicit(&worker->live_top_k_continuation[src][ply_idx],
                              memory_order_relaxed),
         memory_order_relaxed);
   }
@@ -2065,12 +2070,12 @@ static void topk_copy_slot(EndgameCtxWorker *worker, int dst, int src) {
 static void publish_live_top_k_pv(EndgameCtxWorker *worker, uint64_t root_tiny,
                                   int32_t value,
                                   const struct PVLine *continuation,
-                                  int K_max) {
-  if (K_max < 1) {
+                                  int max_k) {
+  if (max_k < 1) {
     return;
   }
-  if (K_max > MAX_ENDGAME_DISPLAY_PVS) {
-    K_max = MAX_ENDGAME_DISPLAY_PVS;
+  if (max_k > MAX_ENDGAME_DISPLAY_PVS) {
+    max_k = MAX_ENDGAME_DISPLAY_PVS;
   }
   // Begin seqlock write window: bump seq odd.
   const uint64_t seq_before =
@@ -2082,11 +2087,11 @@ static void publish_live_top_k_pv(EndgameCtxWorker *worker, uint64_t root_tiny,
       atomic_load_explicit(&worker->live_top_k_filled, memory_order_relaxed);
 
   // Remove existing entry for same root_tiny so we can re-insert sorted.
-  for (int i = 0; i < filled; i++) {
-    if (atomic_load_explicit(&worker->live_top_k_root_tiny[i],
+  for (int pv_idx = 0; pv_idx < filled; pv_idx++) {
+    if (atomic_load_explicit(&worker->live_top_k_root_tiny[pv_idx],
                              memory_order_relaxed) == root_tiny) {
-      for (int j = i; j < filled - 1; j++) {
-        topk_copy_slot(worker, j, j + 1);
+      for (int shift_idx = pv_idx; shift_idx < filled - 1; shift_idx++) {
+        topk_copy_slot(worker, shift_idx, shift_idx + 1);
       }
       filled--;
       break;
@@ -2095,18 +2100,18 @@ static void publish_live_top_k_pv(EndgameCtxWorker *worker, uint64_t root_tiny,
 
   // Find insertion position (descending order by value).
   int insert_pos = filled;
-  for (int i = 0; i < filled; i++) {
-    if (value > atomic_load_explicit(&worker->live_top_k_value[i],
+  for (int pv_idx = 0; pv_idx < filled; pv_idx++) {
+    if (value > atomic_load_explicit(&worker->live_top_k_value[pv_idx],
                                      memory_order_relaxed)) {
-      insert_pos = i;
+      insert_pos = pv_idx;
       break;
     }
   }
 
-  if (insert_pos < K_max) {
-    const int last = (filled < K_max) ? filled : (K_max - 1);
-    for (int i = last; i > insert_pos; i--) {
-      topk_copy_slot(worker, i, i - 1);
+  if (insert_pos < max_k) {
+    const int last = (filled < max_k) ? filled : (max_k - 1);
+    for (int slot_idx = last; slot_idx > insert_pos; slot_idx--) {
+      topk_copy_slot(worker, slot_idx, slot_idx - 1);
     }
     atomic_store_explicit(&worker->live_top_k_root_tiny[insert_pos], root_tiny,
                           memory_order_relaxed);
@@ -2116,14 +2121,14 @@ static void publish_live_top_k_pv(EndgameCtxWorker *worker, uint64_t root_tiny,
     if (cont_len > MAX_SEARCH_DEPTH) {
       cont_len = MAX_SEARCH_DEPTH;
     }
-    for (int i = 0; i < cont_len; i++) {
-      atomic_store_explicit(&worker->live_top_k_continuation[insert_pos][i],
-                            continuation->moves[i].tiny_move,
-                            memory_order_relaxed);
+    for (int ply_idx = 0; ply_idx < cont_len; ply_idx++) {
+      atomic_store_explicit(
+          &worker->live_top_k_continuation[insert_pos][ply_idx],
+          continuation->moves[ply_idx].tiny_move, memory_order_relaxed);
     }
     atomic_store_explicit(&worker->live_top_k_continuation_len[insert_pos],
                           cont_len, memory_order_relaxed);
-    if (filled < K_max) {
+    if (filled < max_k) {
       filled++;
     }
     atomic_store_explicit(&worker->live_top_k_filled, filled,
@@ -2658,9 +2663,10 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
               atomic_load_explicit(&worker->live_pv_seq, memory_order_relaxed);
           atomic_store_explicit(&worker->live_pv_seq, seq_before + 1,
                                 memory_order_release);
-          for (int i = 0; i < new_len; i++) {
-            atomic_store_explicit(&worker->live_pv_tiny_moves[i],
-                                  pv->moves[i].tiny_move, memory_order_relaxed);
+          for (int ply_idx = 0; ply_idx < new_len; ply_idx++) {
+            atomic_store_explicit(&worker->live_pv_tiny_moves[ply_idx],
+                                  pv->moves[ply_idx].tiny_move,
+                                  memory_order_relaxed);
           }
           atomic_store_explicit(&worker->live_pv_length, new_len,
                                 memory_order_relaxed);

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -192,7 +192,9 @@ struct EndgameCtx {
   // bag_copy into incompatibly-sized allocations.
   EndgameCtxWorker **workers;
   cpthread_t *worker_ids;
-  int cap_workers; // number of created worker structs (workers[0..cap_workers))
+  // _Atomic so the lock-free live-view accessors can read it (acquire) while
+  // endgame_add_worker grows it (under add_mutex) during a solve.
+  atomic_int cap_workers; // created worker structs (workers[0..cap_workers))
   int arr_cap; // allocated length of workers[]/worker_ids[] (>= cap_workers)
   const LetterDistribution *workers_ld;
   // Dynamic worker injection (endgame_add_worker): grow an in-flight solve's
@@ -822,8 +824,9 @@ void endgame_ctx_clear_transposition_table(EndgameCtx *ctx) {
 // so the accessors below must not read them.
 static int endgame_active_worker_count(const EndgameCtx *ctx) {
   int active = atomic_load_explicit(&ctx->live_workers, memory_order_acquire);
-  if (active > ctx->cap_workers) {
-    active = ctx->cap_workers;
+  const int cap = atomic_load_explicit(&ctx->cap_workers, memory_order_acquire);
+  if (active > cap) {
+    active = cap;
   }
   if (active < 0) {
     active = 0;
@@ -971,7 +974,7 @@ void endgame_ctx_destroy(EndgameCtx *ctx) {
   if (!ctx) {
     return;
   }
-  for (int i = 0; i < ctx->cap_workers; i++) {
+  for (int i = 0; i < atomic_load(&ctx->cap_workers); i++) {
     solver_worker_destroy(ctx->workers[i]);
   }
   free(ctx->workers);
@@ -1082,14 +1085,14 @@ static void endgame_ctx_prepare_workers(EndgameCtx *solver,
   // If the letter distribution changed (e.g., different lexicon), the worker
   // game copies have incompatibly-sized bags/racks. Destroy and rebuild.
   if (solver->workers_ld != NULL && solver->workers_ld != ld) {
-    for (int idx = 0; idx < solver->cap_workers; idx++) {
+    for (int idx = 0; idx < atomic_load(&solver->cap_workers); idx++) {
       solver_worker_destroy(solver->workers[idx]);
     }
     free(solver->workers);
     free(solver->worker_ids);
     solver->workers = NULL;
     solver->worker_ids = NULL;
-    solver->cap_workers = 0;
+    atomic_store(&solver->cap_workers, 0);
     solver->arr_cap = 0;
   }
   solver->workers_ld = ld;
@@ -1114,12 +1117,13 @@ static void endgame_ctx_prepare_workers(EndgameCtx *solver,
   // needed_cap >= threads above, so whenever this loop runs (threads > 0) the
   // array was allocated; assert it for the static analyzer and as a guard.
   assert(solver->threads == 0 || solver->workers != NULL);
-  for (int idx = solver->cap_workers; idx < solver->threads; idx++) {
+  for (int idx = atomic_load(&solver->cap_workers); idx < solver->threads;
+       idx++) {
     solver->workers[idx] =
         endgame_ctx_create_worker(solver, idx, base_seed, solver->game);
   }
-  if (solver->cap_workers < solver->threads) {
-    solver->cap_workers = solver->threads;
+  if (atomic_load(&solver->cap_workers) < solver->threads) {
+    atomic_store(&solver->cap_workers, solver->threads);
   }
   // Cached workers persist across solves; the ordinal is the array position and
   // never changes. Each worker gets its MoveGen cache slot on demand from
@@ -3466,10 +3470,12 @@ bool endgame_add_worker(EndgameCtx *solver) {
   // Create the worker struct on first use at this ordinal; reuse it on later
   // solves. Either way, stamp this solve's ordinal. The worker's MoveGen cache
   // slot is assigned on demand by get_movegen() when it first generates moves.
-  if (ordinal >= solver->cap_workers) {
+  if (ordinal >= atomic_load(&solver->cap_workers)) {
     solver->workers[ordinal] = endgame_ctx_create_worker(
         solver, ordinal, solver->worker_base_seed, solver->game);
-    solver->cap_workers = ordinal + 1;
+    // Release so a live-view accessor that later reads this cap (acquire) also
+    // sees the fully-created worker struct stored just above.
+    atomic_store(&solver->cap_workers, ordinal + 1);
   } else {
     solver->workers[ordinal]->ordinal = ordinal;
   }

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -250,11 +250,13 @@ struct EndgameCtxWorker {
   // getter. current_line[i] is the tiny_move played at the i-th ply
   // from the root; current_line_len is the number of valid entries.
   // Worker writes the move slot, then atomic_store_release the length;
-  // reader does atomic_load_acquire on the length, then reads the
-  // line. Reader may see torn entries if the worker is concurrently
-  // ascending into a sibling subtree, but the result remains
-  // structurally consistent (length matches what's been written).
-  uint64_t current_line[MAX_SEARCH_DEPTH];
+  // reader does atomic_load_acquire on the length, then reads the line.
+  // The slots are relaxed atomics so concurrent reader/writer access is a
+  // well-defined relaxed access, not a C data race: the reader may still
+  // observe a slot the writer is updating (the value is "stale", not torn
+  // or UB), but the result stays structurally consistent (length matches
+  // what has been published).
+  _Atomic uint64_t current_line[MAX_SEARCH_DEPTH];
   _Atomic int current_line_len;
 
   // Live best-PV-from-root snapshot. Updated by abdada_negamax every
@@ -263,8 +265,10 @@ struct EndgameCtxWorker {
   // each depth.  Seqlock pattern: live_pv_seq is even when the
   // snapshot is consistent, odd while a write is in progress. Reader
   // loads seq, reads length+moves+value, loads seq again; retries on
-  // odd or mismatched seq.
-  uint64_t live_pv_tiny_moves[MAX_SEARCH_DEPTH];
+  // odd or mismatched seq. The data slots are relaxed atomics (accessed
+  // under the seq's release/acquire fences) so the lock-free protocol is
+  // free of C data races.
+  _Atomic uint64_t live_pv_tiny_moves[MAX_SEARCH_DEPTH];
   _Atomic int32_t live_pv_value;
   _Atomic int live_pv_length;
   _Atomic uint64_t live_pv_seq;
@@ -275,13 +279,15 @@ struct EndgameCtxWorker {
   // continuation tiny_moves from after the root move, and the
   // continuation length).  Entries are sorted descending by value.
   // live_top_k_filled is how many of MAX_ENDGAME_DISPLAY_PVS slots
-  // are currently populated. Same seqlock pattern as live_pv.
+  // are currently populated. Same seqlock pattern as live_pv; the data
+  // slots are relaxed atomics so the protocol is C-data-race-free.
   // Reset to 0 entries at the start of each new IDS depth so the
   // leaderboard reflects the current depth's evaluations only.
-  uint64_t live_top_k_root_tiny[MAX_ENDGAME_DISPLAY_PVS];
-  int32_t live_top_k_value[MAX_ENDGAME_DISPLAY_PVS];
-  uint64_t live_top_k_continuation[MAX_ENDGAME_DISPLAY_PVS][MAX_SEARCH_DEPTH];
-  int live_top_k_continuation_len[MAX_ENDGAME_DISPLAY_PVS];
+  _Atomic uint64_t live_top_k_root_tiny[MAX_ENDGAME_DISPLAY_PVS];
+  _Atomic int32_t live_top_k_value[MAX_ENDGAME_DISPLAY_PVS];
+  _Atomic uint64_t live_top_k_continuation[MAX_ENDGAME_DISPLAY_PVS]
+                                          [MAX_SEARCH_DEPTH];
+  _Atomic int live_top_k_continuation_len[MAX_ENDGAME_DISPLAY_PVS];
   _Atomic int live_top_k_filled;
   _Atomic uint64_t live_top_k_seq;
 };
@@ -808,9 +814,27 @@ void endgame_ctx_clear_transposition_table(EndgameCtx *ctx) {
   }
 }
 
+// Number of workers valid to observe in the current solve: live_workers
+// (initial + injected) clamped to cap_workers. The clamp guards the brief
+// window at solve start before prepare_workers has created worker structs up
+// to live_workers. Workers at indices >= this count are not part of the
+// current solve and hold stale live-view state left over from a previous one,
+// so the accessors below must not read them.
+static int endgame_active_worker_count(const EndgameCtx *ctx) {
+  int active = atomic_load_explicit(&ctx->live_workers, memory_order_acquire);
+  if (active > ctx->cap_workers) {
+    active = ctx->cap_workers;
+  }
+  if (active < 0) {
+    active = 0;
+  }
+  return active;
+}
+
 uint64_t endgame_ctx_get_nodes_searched(const EndgameCtx *ctx) {
   uint64_t total = 0;
-  for (int i = 0; i < ctx->cap_workers; i++) {
+  const int active = endgame_active_worker_count(ctx);
+  for (int i = 0; i < active; i++) {
     total += atomic_load_explicit(&ctx->workers[i]->published_nodes_searched,
                                   memory_order_relaxed);
   }
@@ -819,7 +843,8 @@ uint64_t endgame_ctx_get_nodes_searched(const EndgameCtx *ctx) {
 
 int endgame_ctx_get_current_line(const EndgameCtx *ctx, int worker_index,
                                  uint64_t *out_line, int max_len) {
-  if (worker_index < 0 || worker_index >= ctx->cap_workers) {
+  if (max_len <= 0 || worker_index < 0 ||
+      worker_index >= endgame_active_worker_count(ctx)) {
     return 0;
   }
   const EndgameCtxWorker *w = ctx->workers[worker_index];
@@ -835,7 +860,8 @@ int endgame_ctx_get_current_line(const EndgameCtx *ctx, int worker_index,
     len = MAX_SEARCH_DEPTH;
   }
   for (int i = 0; i < len; i++) {
-    out_line[i] = w->current_line[i];
+    out_line[i] =
+        atomic_load_explicit(&w->current_line[i], memory_order_relaxed);
   }
   return len;
 }
@@ -843,7 +869,8 @@ int endgame_ctx_get_current_line(const EndgameCtx *ctx, int worker_index,
 int endgame_ctx_get_live_pv(const EndgameCtx *ctx, int worker_index,
                             uint64_t *out_moves, int max_len,
                             int32_t *out_value) {
-  if (worker_index < 0 || worker_index >= ctx->cap_workers) {
+  if (max_len <= 0 || worker_index < 0 ||
+      worker_index >= endgame_active_worker_count(ctx)) {
     *out_value = 0;
     return 0;
   }
@@ -866,7 +893,8 @@ int endgame_ctx_get_live_pv(const EndgameCtx *ctx, int worker_index,
       len = MAX_SEARCH_DEPTH;
     }
     for (int i = 0; i < len; i++) {
-      out_moves[i] = w->live_pv_tiny_moves[i];
+      out_moves[i] =
+          atomic_load_explicit(&w->live_pv_tiny_moves[i], memory_order_relaxed);
     }
     const uint64_t seq2 =
         atomic_load_explicit(&w->live_pv_seq, memory_order_acquire);
@@ -881,7 +909,8 @@ int endgame_ctx_get_live_pv(const EndgameCtx *ctx, int worker_index,
 
 int endgame_ctx_get_live_top_k_pvs(const EndgameCtx *ctx, int worker_index,
                                    EndgameLivePvSnapshot *out, int max_k) {
-  if (worker_index < 0 || worker_index >= ctx->cap_workers || max_k <= 0) {
+  if (max_k <= 0 || worker_index < 0 ||
+      worker_index >= endgame_active_worker_count(ctx)) {
     return 0;
   }
   const EndgameCtxWorker *w = ctx->workers[worker_index];
@@ -900,15 +929,19 @@ int endgame_ctx_get_live_top_k_pvs(const EndgameCtx *ctx, int worker_index,
       filled = MAX_ENDGAME_DISPLAY_PVS;
     }
     for (int i = 0; i < filled; i++) {
-      out[i].root_tiny = w->live_top_k_root_tiny[i];
-      out[i].value = w->live_top_k_value[i];
-      int cont_len = w->live_top_k_continuation_len[i];
+      out[i].root_tiny = atomic_load_explicit(&w->live_top_k_root_tiny[i],
+                                              memory_order_relaxed);
+      out[i].value =
+          atomic_load_explicit(&w->live_top_k_value[i], memory_order_relaxed);
+      int cont_len = atomic_load_explicit(&w->live_top_k_continuation_len[i],
+                                          memory_order_relaxed);
       if (cont_len > MAX_SEARCH_DEPTH) {
         cont_len = MAX_SEARCH_DEPTH;
       }
       out[i].continuation_len = cont_len;
       for (int j = 0; j < cont_len; j++) {
-        out[i].continuation_tiny[j] = w->live_top_k_continuation[i][j];
+        out[i].continuation_tiny[j] = atomic_load_explicit(
+            &w->live_top_k_continuation[i][j], memory_order_relaxed);
       }
     }
     const uint64_t seq2 =
@@ -2000,6 +2033,31 @@ check_depth_deadline(EndgameCtxWorker *worker) {
 // entries sorted descending by value, deduped by root_tiny, capped at K_max
 // (<= MAX_ENDGAME_DISPLAY_PVS). Seqlock writer: bump seq odd, mutate, bump
 // even, so endgame_ctx_get_live_top_k_pvs reads a consistent snapshot.
+// Atomically copy leaderboard slot `src` onto slot `dst` (relaxed loads/stores;
+// the surrounding seqlock release/acquire provides ordering for readers). Only
+// the live continuation prefix is copied, which is all a reader observes.
+static void topk_copy_slot(EndgameCtxWorker *worker, int dst, int src) {
+  atomic_store_explicit(&worker->live_top_k_root_tiny[dst],
+                        atomic_load_explicit(&worker->live_top_k_root_tiny[src],
+                                             memory_order_relaxed),
+                        memory_order_relaxed);
+  atomic_store_explicit(&worker->live_top_k_value[dst],
+                        atomic_load_explicit(&worker->live_top_k_value[src],
+                                             memory_order_relaxed),
+                        memory_order_relaxed);
+  const int cont_len = atomic_load_explicit(
+      &worker->live_top_k_continuation_len[src], memory_order_relaxed);
+  atomic_store_explicit(&worker->live_top_k_continuation_len[dst], cont_len,
+                        memory_order_relaxed);
+  for (int j = 0; j < cont_len; j++) {
+    atomic_store_explicit(
+        &worker->live_top_k_continuation[dst][j],
+        atomic_load_explicit(&worker->live_top_k_continuation[src][j],
+                             memory_order_relaxed),
+        memory_order_relaxed);
+  }
+}
+
 static void publish_live_top_k_pv(EndgameCtxWorker *worker, uint64_t root_tiny,
                                   int32_t value,
                                   const struct PVLine *continuation,
@@ -2021,15 +2079,10 @@ static void publish_live_top_k_pv(EndgameCtxWorker *worker, uint64_t root_tiny,
 
   // Remove existing entry for same root_tiny so we can re-insert sorted.
   for (int i = 0; i < filled; i++) {
-    if (worker->live_top_k_root_tiny[i] == root_tiny) {
+    if (atomic_load_explicit(&worker->live_top_k_root_tiny[i],
+                             memory_order_relaxed) == root_tiny) {
       for (int j = i; j < filled - 1; j++) {
-        worker->live_top_k_root_tiny[j] = worker->live_top_k_root_tiny[j + 1];
-        worker->live_top_k_value[j] = worker->live_top_k_value[j + 1];
-        worker->live_top_k_continuation_len[j] =
-            worker->live_top_k_continuation_len[j + 1];
-        memcpy(worker->live_top_k_continuation[j],
-               worker->live_top_k_continuation[j + 1],
-               sizeof(uint64_t) * MAX_SEARCH_DEPTH);
+        topk_copy_slot(worker, j, j + 1);
       }
       filled--;
       break;
@@ -2039,7 +2092,8 @@ static void publish_live_top_k_pv(EndgameCtxWorker *worker, uint64_t root_tiny,
   // Find insertion position (descending order by value).
   int insert_pos = filled;
   for (int i = 0; i < filled; i++) {
-    if (value > worker->live_top_k_value[i]) {
+    if (value > atomic_load_explicit(&worker->live_top_k_value[i],
+                                     memory_order_relaxed)) {
       insert_pos = i;
       break;
     }
@@ -2048,25 +2102,23 @@ static void publish_live_top_k_pv(EndgameCtxWorker *worker, uint64_t root_tiny,
   if (insert_pos < K_max) {
     const int last = (filled < K_max) ? filled : (K_max - 1);
     for (int i = last; i > insert_pos; i--) {
-      worker->live_top_k_root_tiny[i] = worker->live_top_k_root_tiny[i - 1];
-      worker->live_top_k_value[i] = worker->live_top_k_value[i - 1];
-      worker->live_top_k_continuation_len[i] =
-          worker->live_top_k_continuation_len[i - 1];
-      memcpy(worker->live_top_k_continuation[i],
-             worker->live_top_k_continuation[i - 1],
-             sizeof(uint64_t) * MAX_SEARCH_DEPTH);
+      topk_copy_slot(worker, i, i - 1);
     }
-    worker->live_top_k_root_tiny[insert_pos] = root_tiny;
-    worker->live_top_k_value[insert_pos] = value;
+    atomic_store_explicit(&worker->live_top_k_root_tiny[insert_pos], root_tiny,
+                          memory_order_relaxed);
+    atomic_store_explicit(&worker->live_top_k_value[insert_pos], value,
+                          memory_order_relaxed);
     int cont_len = (continuation != NULL) ? continuation->num_moves : 0;
     if (cont_len > MAX_SEARCH_DEPTH) {
       cont_len = MAX_SEARCH_DEPTH;
     }
     for (int i = 0; i < cont_len; i++) {
-      worker->live_top_k_continuation[insert_pos][i] =
-          continuation->moves[i].tiny_move;
+      atomic_store_explicit(&worker->live_top_k_continuation[insert_pos][i],
+                            continuation->moves[i].tiny_move,
+                            memory_order_relaxed);
     }
-    worker->live_top_k_continuation_len[insert_pos] = cont_len;
+    atomic_store_explicit(&worker->live_top_k_continuation_len[insert_pos],
+                          cont_len, memory_order_relaxed);
     if (filled < K_max) {
       filled++;
     }
@@ -2456,9 +2508,11 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
       // Live-progress: publish this move into the per-thread "current line"
       // buffer before recursing so a polling reader can see what the engine
       // is currently exploring even during a long single-root subtree where
-      // no other signal updates. Length store uses release ordering so the
-      // reader (acquire on length) sees the tiny_move write.
-      worker->current_line[undo_index] = small_move->tiny_move;
+      // no other signal updates. The slot store is a relaxed atomic; the
+      // length store uses release ordering so the reader (acquire on length)
+      // sees the tiny_move write.
+      atomic_store_explicit(&worker->current_line[undo_index],
+                            small_move->tiny_move, memory_order_relaxed);
       atomic_store_explicit(&worker->current_line_len, undo_index + 1,
                             memory_order_release);
 
@@ -2601,7 +2655,8 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
           atomic_store_explicit(&worker->live_pv_seq, seq_before + 1,
                                 memory_order_release);
           for (int i = 0; i < new_len; i++) {
-            worker->live_pv_tiny_moves[i] = pv->moves[i].tiny_move;
+            atomic_store_explicit(&worker->live_pv_tiny_moves[i],
+                                  pv->moves[i].tiny_move, memory_order_relaxed);
           }
           atomic_store_explicit(&worker->live_pv_length, new_len,
                                 memory_order_relaxed);

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -207,7 +207,7 @@ struct EndgameCtx {
 
 struct EndgameCtxWorker {
   // Worker ordinal within this solve (0..threads-1, == position in the cached
-  // workers[] array, so stable across solves). ordinal 0 is the root master:
+  // workers[] array, so stable across solves). ordinal 0 is the main worker:
   // it owns root move ordering, ply-2 tracking, the soft-time check, and PV
   // display. Drives per-worker jitter parity. Each worker reaches move
   // generation through get_movegen(), which auto-assigns a distinct per-pthread
@@ -2813,7 +2813,7 @@ void iterative_deepening(EndgameCtxWorker *worker, int plies) {
   // Publish the d=0 root-move list to clients before any depth begins.
   // root_moves_total is bumped here (rather than only at depth-loop entry) so
   // the polled progress atomics agree with the callback's view of the
-  // candidate count even before depth-1 starts. Master worker (ordinal 0)
+  // candidate count even before depth-1 starts. Main worker (ordinal 0)
   // only; the arena holds the sorted moves contiguously from offset 0.
   if (worker->ordinal == 0) {
     atomic_store(&worker->solver->root_moves_total, initial_move_count);
@@ -2948,7 +2948,7 @@ void iterative_deepening(EndgameCtxWorker *worker, int plies) {
     }
 
     worker->current_iterative_deepening_depth = ply;
-    // Update root move progress counters (master worker, ordinal 0, only)
+    // Update root move progress counters (main worker, ordinal 0, only)
     if (worker->ordinal == 0) {
       atomic_store(&worker->solver->current_depth, ply);
       atomic_store(&worker->solver->root_moves_completed, 0);
@@ -3046,7 +3046,7 @@ void iterative_deepening(EndgameCtxWorker *worker, int plies) {
     endgame_results_set_best_pvline(worker->solver->results, &pv, pv_value,
                                     ply);
 
-    // Call per-ply callback (only this solver's master worker, ordinal 0, to
+    // Call per-ply callback (only this solver's main worker, ordinal 0, to
     // avoid race conditions).
     if (worker->ordinal == 0 && worker->solver->per_ply_callback) {
       // Extend PV from TT + greedy playout for display
@@ -3212,8 +3212,8 @@ void endgame_solve_inline(EndgameCtx **ctx, const EndgameArgs *endgame_args,
   EndgameCtx *solver = *ctx;
 
   endgame_ctx_reset(solver, results, endgame_args);
-  // The inline master runs in the calling thread, so the base worker count is
-  // always 1 regardless of the caller's num_threads — only injected helpers
+  // The inline main worker runs in the calling thread, so the base worker count
+  // is always 1 regardless of the caller's num_threads — only injected helpers
   // (ordinals > 0) are spawned. Force threads/live_workers to 1 so injection
   // ordinals and join ranges stay consistent (otherwise helpers would start at
   // ordinal == num_threads, leaving gaps).
@@ -3229,9 +3229,10 @@ void endgame_solve_inline(EndgameCtx **ctx, const EndgameArgs *endgame_args,
   atomic_store(&solver->stuck_tile_logged, 1);
 
   // Open the injection window so helpers can be added mid-search via
-  // endgame_add_worker while this thread runs the master (ordinal 0). The
-  // calling thread is the master, so unlike endgame_solve there is no spawned
-  // thread for ordinal 0 — only injected helpers (ordinals > 0) are joined.
+  // endgame_add_worker while this thread runs the main worker (ordinal 0). The
+  // calling thread is the main worker, so unlike endgame_solve there is no
+  // spawned thread for ordinal 0 — only injected helpers (ordinals > 0) are
+  // joined.
   if (solver->max_workers > solver->threads) {
     cpthread_mutex_lock(&solver->add_mutex);
     atomic_store(&solver->window_open_ns, ctimer_monotonic_ns());
@@ -3243,8 +3244,8 @@ void endgame_solve_inline(EndgameCtx **ctx, const EndgameArgs *endgame_args,
   iterative_deepening(solver->workers[0], solver->requested_plies);
 
   // Shut the window and join any injected helpers. live_workers counts the
-  // in-thread master (solver->threads, normally 1) plus any added workers, so
-  // the spawned pthreads are [solver->threads, live_workers).
+  // in-thread main worker (solver->threads, normally 1) plus any added workers,
+  // so the spawned pthreads are [solver->threads, live_workers).
   cpthread_mutex_lock(&solver->add_mutex);
   atomic_store(&solver->adding_closed, 1);
   const int total_workers = atomic_load(&solver->live_workers);
@@ -3310,8 +3311,9 @@ void endgame_solve(EndgameCtx **ctx, const EndgameArgs *endgame_args,
     cpthread_mutex_unlock(&solver->add_mutex);
   }
 
-  // Wait for the initial workers. The master (ordinal 0) drives completion, so
-  // once these exit the search has finished (or interrupted/timed out).
+  // Wait for the initial workers. The main worker (ordinal 0) drives
+  // completion, so once these exit the search has finished (or
+  // interrupted/timed out).
   for (int thread_index = 0; thread_index < solver->threads; thread_index++) {
     cpthread_join(solver->worker_ids[thread_index]);
   }

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -3204,6 +3204,15 @@ void iterative_deepening(EndgameCtxWorker *worker, int plies) {
       atomic_store(&worker->solver->search_complete, 1);
     }
   }
+
+  // Final flush: this worker has stopped searching, so publish its exact
+  // node count. The periodic in-search flush only fires every
+  // DEPTH_DEADLINE_CHECK_INTERVAL nodes, so without this the tail of every
+  // worker (and all of a very short solve) would be permanently
+  // under-reported by up to DEPTH_DEADLINE_CHECK_INTERVAL-1 nodes. All
+  // exit paths of the loop above fall through to here.
+  atomic_store_explicit(&worker->published_nodes_searched,
+                        worker->local_nodes_searched, memory_order_relaxed);
 }
 
 void *solver_worker_start(void *uncasted_solver_worker) {

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -168,6 +168,14 @@ struct EndgameCtx {
   // Per-ply callback for iterative deepening progress
   EndgamePerPlyCallback per_ply_callback;
   void *per_ply_callback_data;
+  // Fired once on thread 0 before iterative deepening begins, with the sorted
+  // d=0 root-move list (for an initial leaderboard render).
+  EndgameBeforeSearchCallback before_search_callback;
+  void *before_search_callback_data;
+  // Fired on thread 0 each time a root move completes at the current IDS depth
+  // (for live per-root leaderboard updates).
+  EndgamePerRootMoveCallback per_root_move_callback;
+  void *per_root_move_callback_data;
 
   // Owned by the caller:
   EndgameResults *results;
@@ -229,6 +237,53 @@ struct EndgameCtxWorker {
   bool in_first_root_move; // True when thread 0 is inside root move idx==0
   // Counter for throttling per-depth deadline checks in abdada_negamax
   uint64_t nodes_since_deadline_check;
+
+  // Per-thread node counter for the live-progress getter. Plain uint64
+  // (no atomics on the writer side); flushed periodically to the
+  // shared atomic via the deadline-check rhythm. The reader sums per-
+  // thread atomics, so a brief lag (up to DEPTH_DEADLINE_CHECK_INTERVAL
+  // nodes) is acceptable.
+  uint64_t local_nodes_searched;
+  _Atomic uint64_t published_nodes_searched;
+
+  // Per-thread "current line being explored" for the live-progress
+  // getter. current_line[i] is the tiny_move played at the i-th ply
+  // from the root; current_line_len is the number of valid entries.
+  // Worker writes the move slot, then atomic_store_release the length;
+  // reader does atomic_load_acquire on the length, then reads the
+  // line. Reader may see torn entries if the worker is concurrently
+  // ascending into a sibling subtree, but the result remains
+  // structurally consistent (length matches what's been written).
+  uint64_t current_line[MAX_SEARCH_DEPTH];
+  _Atomic int current_line_len;
+
+  // Live best-PV-from-root snapshot. Updated by abdada_negamax every
+  // time best_value improves at the root (is_root=true), so a polling
+  // reader can watch the engine's evolving best line refine through
+  // each depth.  Seqlock pattern: live_pv_seq is even when the
+  // snapshot is consistent, odd while a write is in progress. Reader
+  // loads seq, reads length+moves+value, loads seq again; retries on
+  // odd or mismatched seq.
+  uint64_t live_pv_tiny_moves[MAX_SEARCH_DEPTH];
+  _Atomic int32_t live_pv_value;
+  _Atomic int live_pv_length;
+  _Atomic uint64_t live_pv_seq;
+
+  // Live multi-PV top-K snapshot, updated per root completion (so
+  // every per_root_move_callback firing also republishes here).
+  // Each slot has (root tiny_move, spread-adjusted value, the
+  // continuation tiny_moves from after the root move, and the
+  // continuation length).  Entries are sorted descending by value.
+  // live_top_k_filled is how many of MAX_ENDGAME_DISPLAY_PVS slots
+  // are currently populated. Same seqlock pattern as live_pv.
+  // Reset to 0 entries at the start of each new IDS depth so the
+  // leaderboard reflects the current depth's evaluations only.
+  uint64_t live_top_k_root_tiny[MAX_ENDGAME_DISPLAY_PVS];
+  int32_t live_top_k_value[MAX_ENDGAME_DISPLAY_PVS];
+  uint64_t live_top_k_continuation[MAX_ENDGAME_DISPLAY_PVS][MAX_SEARCH_DEPTH];
+  int live_top_k_continuation_len[MAX_ENDGAME_DISPLAY_PVS];
+  _Atomic int live_top_k_filled;
+  _Atomic uint64_t live_top_k_seq;
 };
 
 #ifndef MAX
@@ -570,6 +625,12 @@ void endgame_ctx_reset(EndgameCtx *es, EndgameResults *results,
   es->use_heuristics = endgame_args->use_heuristics;
   es->forced_pass_bypass = endgame_args->forced_pass_bypass;
   es->num_top_moves = endgame_args->num_top_moves;
+  // The in-search top-K array (topk_values) and the live multi-PV leaderboard
+  // are sized to MAX_ENDGAME_DISPLAY_PVS; clamp so a caller asking for more
+  // displayed root moves can't overrun them.
+  if (es->num_top_moves > MAX_ENDGAME_DISPLAY_PVS) {
+    es->num_top_moves = MAX_ENDGAME_DISPLAY_PVS;
+  }
   es->threads = endgame_args->num_threads;
   if (es->threads < 1) {
     es->threads = 1;
@@ -659,6 +720,10 @@ void endgame_ctx_reset(EndgameCtx *es, EndgameResults *results,
   es->game = endgame_args->game;
   es->per_ply_callback = endgame_args->per_ply_callback;
   es->per_ply_callback_data = endgame_args->per_ply_callback_data;
+  es->before_search_callback = endgame_args->before_search_callback;
+  es->before_search_callback_data = endgame_args->before_search_callback_data;
+  es->per_root_move_callback = endgame_args->per_root_move_callback;
+  es->per_root_move_callback_data = endgame_args->per_root_move_callback_data;
   if (endgame_args->shared_tt) {
     // Use caller-provided TT. Free any previously owned TT.
     if (!es->tt_is_external) {
@@ -737,6 +802,127 @@ void endgame_ctx_get_progress(const EndgameCtx *ctx, int *current_depth,
   *ply2_moves_total = atomic_load(&ctx->ply2_moves_total);
 }
 
+void endgame_ctx_clear_transposition_table(EndgameCtx *ctx) {
+  if (ctx->transposition_table != NULL) {
+    transposition_table_reset(ctx->transposition_table);
+  }
+}
+
+uint64_t endgame_ctx_get_nodes_searched(const EndgameCtx *ctx) {
+  uint64_t total = 0;
+  for (int i = 0; i < ctx->cap_workers; i++) {
+    total += atomic_load_explicit(&ctx->workers[i]->published_nodes_searched,
+                                  memory_order_relaxed);
+  }
+  return total;
+}
+
+int endgame_ctx_get_current_line(const EndgameCtx *ctx, int thread_index,
+                                 uint64_t *out_line, int max_len) {
+  if (thread_index < 0 || thread_index >= ctx->cap_workers) {
+    return 0;
+  }
+  const EndgameCtxWorker *w = ctx->workers[thread_index];
+  // Acquire on length pairs with release on writer side: by the time we
+  // observe length L, all writes to current_line[0..L-1] up to that
+  // store are visible. The worker may have moved on since then; entries
+  // beyond what we read may correspond to a different sibling subtree.
+  int len = atomic_load_explicit(&w->current_line_len, memory_order_acquire);
+  if (len > max_len) {
+    len = max_len;
+  }
+  if (len > MAX_SEARCH_DEPTH) {
+    len = MAX_SEARCH_DEPTH;
+  }
+  for (int i = 0; i < len; i++) {
+    out_line[i] = w->current_line[i];
+  }
+  return len;
+}
+
+int endgame_ctx_get_live_pv(const EndgameCtx *ctx, int thread_index,
+                            uint64_t *out_moves, int max_len,
+                            int32_t *out_value) {
+  if (thread_index < 0 || thread_index >= ctx->cap_workers) {
+    *out_value = 0;
+    return 0;
+  }
+  const EndgameCtxWorker *w = ctx->workers[thread_index];
+  // Seqlock read: try a few times to capture a consistent snapshot
+  // (length, moves, value all from the same writer update).
+  for (int attempt = 0; attempt < 4; attempt++) {
+    const uint64_t seq1 =
+        atomic_load_explicit(&w->live_pv_seq, memory_order_acquire);
+    if ((seq1 & 1ULL) != 0) {
+      continue; // writer in progress
+    }
+    int len = atomic_load_explicit(&w->live_pv_length, memory_order_relaxed);
+    const int32_t value =
+        atomic_load_explicit(&w->live_pv_value, memory_order_relaxed);
+    if (len > max_len) {
+      len = max_len;
+    }
+    if (len > MAX_SEARCH_DEPTH) {
+      len = MAX_SEARCH_DEPTH;
+    }
+    for (int i = 0; i < len; i++) {
+      out_moves[i] = w->live_pv_tiny_moves[i];
+    }
+    const uint64_t seq2 =
+        atomic_load_explicit(&w->live_pv_seq, memory_order_acquire);
+    if (seq1 == seq2) {
+      *out_value = value;
+      return len;
+    }
+  }
+  *out_value = 0;
+  return 0;
+}
+
+int endgame_ctx_get_live_top_k_pvs(const EndgameCtx *ctx, int thread_index,
+                                   EndgameLivePvSnapshot *out, int max_k) {
+  if (thread_index < 0 || thread_index >= ctx->cap_workers || max_k <= 0) {
+    return 0;
+  }
+  const EndgameCtxWorker *w = ctx->workers[thread_index];
+  for (int attempt = 0; attempt < 4; attempt++) {
+    const uint64_t seq1 =
+        atomic_load_explicit(&w->live_top_k_seq, memory_order_acquire);
+    if ((seq1 & 1ULL) != 0) {
+      continue; // writer in progress
+    }
+    int filled =
+        atomic_load_explicit(&w->live_top_k_filled, memory_order_relaxed);
+    if (filled > max_k) {
+      filled = max_k;
+    }
+    if (filled > MAX_ENDGAME_DISPLAY_PVS) {
+      filled = MAX_ENDGAME_DISPLAY_PVS;
+    }
+    for (int i = 0; i < filled; i++) {
+      out[i].root_tiny = w->live_top_k_root_tiny[i];
+      out[i].value = w->live_top_k_value[i];
+      int cont_len = w->live_top_k_continuation_len[i];
+      if (cont_len > MAX_SEARCH_DEPTH) {
+        cont_len = MAX_SEARCH_DEPTH;
+      }
+      out[i].continuation_len = cont_len;
+      for (int j = 0; j < cont_len; j++) {
+        out[i].continuation_tiny[j] = w->live_top_k_continuation[i][j];
+      }
+    }
+    const uint64_t seq2 =
+        atomic_load_explicit(&w->live_top_k_seq, memory_order_acquire);
+    if (seq1 == seq2) {
+      return filled;
+    }
+  }
+  return 0;
+}
+
+// Defined below; used by both the worker create and reset paths.
+static void reset_worker_analysis_state(EndgameCtxWorker *worker);
+
 static void solver_worker_destroy(EndgameCtxWorker *solver_worker) {
   if (!solver_worker) {
     return;
@@ -797,8 +983,24 @@ static EndgameCtxWorker *endgame_ctx_create_worker(EndgameCtx *solver,
   solver_worker->best_pv_value = -LARGE_VALUE;
   solver_worker->completed_depth = 0;
   solver_worker->nodes_since_deadline_check = 0;
+  reset_worker_analysis_state(solver_worker);
 
   return solver_worker;
+}
+
+// Zero the per-worker live-progress / live-PV / live-top-K snapshot state.
+// Called from both the worker create and reset paths so a fresh solve never
+// inherits a stale leaderboard or node count from a prior solve.
+static void reset_worker_analysis_state(EndgameCtxWorker *worker) {
+  worker->local_nodes_searched = 0;
+  atomic_store_explicit(&worker->published_nodes_searched, 0,
+                        memory_order_relaxed);
+  atomic_store_explicit(&worker->current_line_len, 0, memory_order_relaxed);
+  atomic_store_explicit(&worker->live_pv_length, 0, memory_order_relaxed);
+  atomic_store_explicit(&worker->live_pv_value, 0, memory_order_relaxed);
+  atomic_store_explicit(&worker->live_pv_seq, 0, memory_order_relaxed);
+  atomic_store_explicit(&worker->live_top_k_filled, 0, memory_order_relaxed);
+  atomic_store_explicit(&worker->live_top_k_seq, 0, memory_order_relaxed);
 }
 
 // Reset an existing worker for a new solve without reallocating.
@@ -818,6 +1020,7 @@ static void endgame_ctx_reset_worker(EndgameCtxWorker *worker,
   worker->best_pv_value = -LARGE_VALUE;
   worker->completed_depth = 0;
   worker->nodes_since_deadline_check = 0;
+  reset_worker_analysis_state(worker);
 }
 
 void endgame_ctx_reset_worker_and_game(EndgameCtx *solver, uint64_t base_seed,
@@ -1792,11 +1995,102 @@ check_depth_deadline(EndgameCtxWorker *worker) {
   return false;
 }
 
+// Republish worker thread 0's live multi-PV top-K leaderboard with the
+// (root_tiny, value, continuation) for one just-completed root move. Keeps
+// entries sorted descending by value, deduped by root_tiny, capped at K_max
+// (<= MAX_ENDGAME_DISPLAY_PVS). Seqlock writer: bump seq odd, mutate, bump
+// even, so endgame_ctx_get_live_top_k_pvs reads a consistent snapshot.
+static void publish_live_top_k_pv(EndgameCtxWorker *worker, uint64_t root_tiny,
+                                  int32_t value,
+                                  const struct PVLine *continuation,
+                                  int K_max) {
+  if (K_max < 1) {
+    return;
+  }
+  if (K_max > MAX_ENDGAME_DISPLAY_PVS) {
+    K_max = MAX_ENDGAME_DISPLAY_PVS;
+  }
+  // Begin seqlock write window: bump seq odd.
+  const uint64_t seq_before =
+      atomic_load_explicit(&worker->live_top_k_seq, memory_order_relaxed);
+  atomic_store_explicit(&worker->live_top_k_seq, seq_before + 1,
+                        memory_order_release);
+
+  int filled =
+      atomic_load_explicit(&worker->live_top_k_filled, memory_order_relaxed);
+
+  // Remove existing entry for same root_tiny so we can re-insert sorted.
+  for (int i = 0; i < filled; i++) {
+    if (worker->live_top_k_root_tiny[i] == root_tiny) {
+      for (int j = i; j < filled - 1; j++) {
+        worker->live_top_k_root_tiny[j] = worker->live_top_k_root_tiny[j + 1];
+        worker->live_top_k_value[j] = worker->live_top_k_value[j + 1];
+        worker->live_top_k_continuation_len[j] =
+            worker->live_top_k_continuation_len[j + 1];
+        memcpy(worker->live_top_k_continuation[j],
+               worker->live_top_k_continuation[j + 1],
+               sizeof(uint64_t) * MAX_SEARCH_DEPTH);
+      }
+      filled--;
+      break;
+    }
+  }
+
+  // Find insertion position (descending order by value).
+  int insert_pos = filled;
+  for (int i = 0; i < filled; i++) {
+    if (value > worker->live_top_k_value[i]) {
+      insert_pos = i;
+      break;
+    }
+  }
+
+  if (insert_pos < K_max) {
+    const int last = (filled < K_max) ? filled : (K_max - 1);
+    for (int i = last; i > insert_pos; i--) {
+      worker->live_top_k_root_tiny[i] = worker->live_top_k_root_tiny[i - 1];
+      worker->live_top_k_value[i] = worker->live_top_k_value[i - 1];
+      worker->live_top_k_continuation_len[i] =
+          worker->live_top_k_continuation_len[i - 1];
+      memcpy(worker->live_top_k_continuation[i],
+             worker->live_top_k_continuation[i - 1],
+             sizeof(uint64_t) * MAX_SEARCH_DEPTH);
+    }
+    worker->live_top_k_root_tiny[insert_pos] = root_tiny;
+    worker->live_top_k_value[insert_pos] = value;
+    int cont_len = (continuation != NULL) ? continuation->num_moves : 0;
+    if (cont_len > MAX_SEARCH_DEPTH) {
+      cont_len = MAX_SEARCH_DEPTH;
+    }
+    for (int i = 0; i < cont_len; i++) {
+      worker->live_top_k_continuation[insert_pos][i] =
+          continuation->moves[i].tiny_move;
+    }
+    worker->live_top_k_continuation_len[insert_pos] = cont_len;
+    if (filled < K_max) {
+      filled++;
+    }
+    atomic_store_explicit(&worker->live_top_k_filled, filled,
+                          memory_order_relaxed);
+  }
+
+  // End seqlock write window: bump seq even.
+  atomic_store_explicit(&worker->live_top_k_seq, seq_before + 2,
+                        memory_order_release);
+}
+
 int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
                        int32_t alpha, int32_t beta, PVLine *pv, bool pv_node,
                        bool exclusive_p, float opp_stuck_frac) {
 
   assert(pv_node || alpha == beta - 1);
+
+  // Live-progress: count this node visit in the per-thread local counter.
+  // The published-to-shared atomic is updated alongside the deadline check
+  // below, batching ~DEPTH_DEADLINE_CHECK_INTERVAL increments into one
+  // atomic_store. Reader sees an upper-bound-stale view, which is fine for
+  // a "is the engine making progress" UI.
+  worker->local_nodes_searched++;
 
   if (iterative_deepening_should_stop(worker->solver)) {
     return ABDADA_INTERRUPTED;
@@ -1809,6 +2103,11 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
   // deep searches (e.g. 25-ply) would otherwise overflow the stack.
   if (++worker->nodes_since_deadline_check >= DEPTH_DEADLINE_CHECK_INTERVAL) {
     worker->nodes_since_deadline_check = 0;
+    // Flush per-thread node count to the shared atomic at the same
+    // cadence as the deadline check, so the live-progress getter sees
+    // updates ~once per DEPTH_DEADLINE_CHECK_INTERVAL nodes per worker.
+    atomic_store_explicit(&worker->published_nodes_searched,
+                          worker->local_nodes_searched, memory_order_relaxed);
     if (check_depth_deadline(worker)) {
       return ABDADA_INTERRUPTED;
     }
@@ -2051,7 +2350,11 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
   }
   const int multi_pv_k = worker->solver->num_top_moves;
   const bool multi_pv = is_root && multi_pv_k > 1;
-  int32_t topk_values[MAX_VARIANT_LENGTH];
+  // Sized for the live multi-PV leaderboard breadth (up to
+  // MAX_ENDGAME_DISPLAY_PVS root moves), not the per-line depth. num_top_moves
+  // is clamped to MAX_ENDGAME_DISPLAY_PVS in endgame_ctx_reset so topk_insert
+  // (called with k == multi_pv_k) never writes past this array.
+  int32_t topk_values[MAX_ENDGAME_DISPLAY_PVS];
   int topk_n = 0;
 
   // ABDADA: track deferred moves for second phase
@@ -2150,6 +2453,15 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
       // Calculate undo index for incremental backup
       int undo_index = worker->solver->requested_plies - depth;
 
+      // Live-progress: publish this move into the per-thread "current line"
+      // buffer before recursing so a polling reader can see what the engine
+      // is currently exploring even during a long single-root subtree where
+      // no other signal updates. Length store uses release ordering so the
+      // reader (acquire on length) sees the tiny_move write.
+      worker->current_line[undo_index] = small_move->tiny_move;
+      atomic_store_explicit(&worker->current_line_len, undo_index + 1,
+                            memory_order_release);
+
       // Use optimized function for outplays - skips board/cross-set updates
       if (is_outplay) {
         play_move_endgame_outplay(worker->move_list->spare_move,
@@ -2237,6 +2549,12 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
       // child's subtree was saved into this undo (or a descendant's undo that
       // was already restored), so the square restore reverted them exactly.
 
+      // Live-progress: pop the line back to the parent's depth. The entry at
+      // undo_index is left as-is (overwritten by the next sibling's push).
+      // Release pairs with the reader's acquire on length.
+      atomic_store_explicit(&worker->current_line_len, undo_index,
+                            memory_order_release);
+
       if (value == ABDADA_INTERRUPTED) {
         all_done = true;
         best_value = ABDADA_INTERRUPTED;
@@ -2268,6 +2586,31 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
         pvline_update(pv, &child_pv, small_move,
                       best_value - worker->solver->initial_spread);
         pv->negamax_depth = child_pv.negamax_depth + 1;
+        // Live PV publish (root only): a polling reader sees the engine's
+        // evolving best line refine through each depth as root moves get
+        // evaluated. Seqlock pattern: bump seq odd to signal "writing", write
+        // moves+value+length, bump seq even to signal "consistent". Reader
+        // retries on odd / mismatched seq.
+        if (is_root) {
+          int new_len = pv->num_moves;
+          if (new_len > MAX_SEARCH_DEPTH) {
+            new_len = MAX_SEARCH_DEPTH;
+          }
+          const uint64_t seq_before =
+              atomic_load_explicit(&worker->live_pv_seq, memory_order_relaxed);
+          atomic_store_explicit(&worker->live_pv_seq, seq_before + 1,
+                                memory_order_release);
+          for (int i = 0; i < new_len; i++) {
+            worker->live_pv_tiny_moves[i] = pv->moves[i].tiny_move;
+          }
+          atomic_store_explicit(&worker->live_pv_length, new_len,
+                                memory_order_relaxed);
+          atomic_store_explicit(&worker->live_pv_value,
+                                best_value - worker->solver->initial_spread,
+                                memory_order_relaxed);
+          atomic_store_explicit(&worker->live_pv_seq, seq_before + 2,
+                                memory_order_release);
+        }
       }
       if (is_root) {
         // At the very top depth, set the estimated value of the small move,
@@ -2278,6 +2621,21 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
         // are not missed.
         if (worker->ordinal == 0) {
           atomic_fetch_add(&worker->solver->root_moves_completed, 1);
+          // Spread-adjusted value, same sign convention as PVLine.score.
+          const int32_t reported_value =
+              -value - worker->solver->initial_spread;
+          if (worker->solver->per_root_move_callback) {
+            worker->solver->per_root_move_callback(
+                depth, idx, small_move, reported_value,
+                worker->solver->per_root_move_callback_data);
+          }
+          // Live multi-PV: republish the top-K leaderboard with this root's
+          // evaluation. Covers all root completions (including ABDADA pass-2
+          // deferred re-evaluations), so the displayed leaderboard always
+          // reflects the most recent value seen for each root move at the
+          // current depth.
+          publish_live_top_k_pv(worker, small_move->tiny_move, reported_value,
+                                &child_pv, worker->solver->num_top_moves);
         }
       }
       if (is_ply2) {
@@ -2452,6 +2810,23 @@ void iterative_deepening(EndgameCtxWorker *worker, int plies) {
   assert((size_t)worker->small_move_arena->size ==
          initial_move_count * sizeof(SmallMove));
 
+  // Publish the d=0 root-move list to clients before any depth begins.
+  // root_moves_total is bumped here (rather than only at depth-loop entry) so
+  // the polled progress atomics agree with the callback's view of the
+  // candidate count even before depth-1 starts. Master worker (ordinal 0)
+  // only; the arena holds the sorted moves contiguously from offset 0.
+  if (worker->ordinal == 0) {
+    atomic_store(&worker->solver->root_moves_total, initial_move_count);
+    if (worker->solver->before_search_callback) {
+      const SmallMove *initial_moves =
+          (const SmallMove *)worker->small_move_arena->memory;
+      worker->solver->before_search_callback(
+          worker->game_copy, initial_moves, initial_move_count,
+          worker->solver->initial_spread, worker->solver->solving_player,
+          worker->solver->before_search_callback_data);
+    }
+  }
+
   worker->current_iterative_deepening_depth = 1;
   int start = 1;
   if (!worker->solver->iterative_deepening_optim) {
@@ -2580,6 +2955,17 @@ void iterative_deepening(EndgameCtxWorker *worker, int plies) {
       atomic_store(&worker->solver->root_moves_total, worker->n_initial_moves);
       atomic_store(&worker->solver->ply2_moves_completed, 0);
       atomic_store(&worker->solver->ply2_moves_total, 0);
+      // Live multi-PV: clear the top-K leaderboard so it reflects the new
+      // depth's evaluations only. Brief seqlock window; a reader sees
+      // filled=0 momentarily, then watches entries fill in as roots complete.
+      const uint64_t topk_seq_before =
+          atomic_load_explicit(&worker->live_top_k_seq, memory_order_relaxed);
+      atomic_store_explicit(&worker->live_top_k_seq, topk_seq_before + 1,
+                            memory_order_release);
+      atomic_store_explicit(&worker->live_top_k_filled, 0,
+                            memory_order_relaxed);
+      atomic_store_explicit(&worker->live_top_k_seq, topk_seq_before + 2,
+                            memory_order_release);
       worker->in_first_root_move = false;
     }
     double depth_start_time = ctimer_elapsed_seconds(&ids_timer);

--- a/src/impl/endgame.h
+++ b/src/impl/endgame.h
@@ -262,12 +262,13 @@ void endgame_ctx_get_progress(const EndgameCtx *ctx, int *current_depth,
                               int *root_moves_completed, int *root_moves_total,
                               int *ply2_moves_completed, int *ply2_moves_total);
 
-// Sum of nodes searched across all worker threads, lagging by up to
-// DEPTH_DEADLINE_CHECK_INTERVAL nodes per thread (the period at which
-// each worker flushes its non-atomic local counter to the shared
-// atomic). Cheap to call from any thread; intended for "is the engine
-// alive / nodes per second" UI heartbeats during long single-root
-// subtree evaluations.
+// Sum of nodes searched across all worker threads. While the search is
+// running this lags by up to DEPTH_DEADLINE_CHECK_INTERVAL nodes per thread
+// (the period at which each worker flushes its non-atomic local counter to
+// the shared atomic); each worker does a final exact flush when it stops, so
+// once the solve completes the total is exact. Cheap to call from any thread;
+// intended for "is the engine alive / nodes per second" UI heartbeats during
+// long single-root subtree evaluations.
 uint64_t endgame_ctx_get_nodes_searched(const EndgameCtx *ctx);
 
 // Snapshot of the line currently being explored by worker `worker_index`

--- a/src/impl/endgame.h
+++ b/src/impl/endgame.h
@@ -24,6 +24,57 @@ enum {
 
 typedef struct EndgameCtx EndgameCtx;
 
+// ===========================================================================
+// Live analysis interface
+// ===========================================================================
+//
+// The solver exposes its in-progress state so a UI (or any observer) can
+// render a live view of the search. There are two complementary ways to
+// observe; a consumer may use either or both:
+//
+//   * Push — the callbacks on EndgameArgs (before_search / per_root_move /
+//     per_ply). They fire synchronously, ON the solver's worker thread 0, at
+//     well-defined moments (search start, each root completion, each completed
+//     depth). They deliver exact, in-order state, but they run inside the
+//     search: a handler must be cheap, must not block, and must copy out
+//     anything it keeps (pointer arguments are valid only for the call).
+//
+//   * Pull — the endgame_ctx_get_* accessors below. A separate thread polls
+//     these at its own cadence (e.g. a render loop) while endgame_solve runs
+//     on another thread. They return lock-free, internally-consistent
+//     snapshots (seqlock / release-acquire) and never block the search. A
+//     snapshot may be a few nodes stale, which is fine for a heartbeat or a
+//     leaderboard.
+//
+// Everything here is observation only: nothing feeds back into the search, and
+// whether or not it is read does not change the result.
+//
+// Conventions shared by the whole interface:
+//
+//   * Values are spreads in WHOLE POINTS — not the millipoint Equity used
+//     elsewhere in MAGPIE — from the solving player's perspective: positive
+//     means the solving player is ahead. This matches PVLine.score.
+//     "Spread-adjusted" below means the raw negamax value has had the root's
+//     initial spread folded in, so it is the projected final spread, not a
+//     delta from the current position.
+//
+//   * Moves are returned as `tiny_move` codes: the compact 64-bit SmallMove
+//     encoding (schema in move.h). A code of 0 is a pass. To render one, wrap
+//     it in a SmallMove and decode it against the board:
+//         SmallMove sm = {0};
+//         sm.tiny_move = code;
+//         Move move;
+//         small_move_to_move(&move, &sm, board);
+//     The push callbacks hand back SmallMove pointers directly; the pull
+//     accessors hand back raw codes so each snapshot stays a flat, copy-safe
+//     value with no engine-owned pointers in it.
+//
+//   * `thread_index` selects which worker to observe. Thread 0 is the master:
+//     it owns root ordering, the progress counters, and the live PV /
+//     leaderboard, so a simple UI passes 0 for the canonical view. Other
+//     indices expose the parallel ABDADA helper threads and are rarely needed.
+// ===========================================================================
+
 // Callback for per-ply PV reporting during iterative deepening
 // Parameters: depth, value (spread delta), pv_line, game,
 //             ranked_pvs (top-K PVLines with TT-extended variations),
@@ -188,6 +239,13 @@ endgame_ctx_get_transposition_table(const EndgameCtx *ctx);
 // (the cost is the same — a memset of the full TT — but no malloc/free).
 // No-op if the ctx has no TT (tt_fraction_of_mem == 0).
 void endgame_ctx_clear_transposition_table(EndgameCtx *ctx);
+// Coarse progress counters for a progress bar (master worker's view). Writes
+// the current iterative-deepening depth, and how many of this depth's root
+// moves have finished (completed/total). The ply2_* out-params are an optional
+// finer-grained sub-progress — how many children of the first root move have
+// finished — for a UI that wants a second bar during a long first root; a
+// simple consumer can pass them and ignore the values. All are plain atomic
+// reads, cheap from any thread.
 void endgame_ctx_get_progress(const EndgameCtx *ctx, int *current_depth,
                               int *root_moves_completed, int *root_moves_total,
                               int *ply2_moves_completed, int *ply2_moves_total);
@@ -217,9 +275,8 @@ int endgame_ctx_get_current_line(const EndgameCtx *ctx, int thread_index,
 // successive root moves get evaluated).
 //
 // Writes up to `max_len` `tiny_move` entries into `out_moves` and
-// returns the number written (0..max_len). `*out_value` is set to
-// the spread-adjusted PV value (same sign convention as
-// PVLine.score).
+// returns the number written (0..max_len). `*out_value` is set to the
+// spread-adjusted value (whole points; see conventions above).
 //
 // Uses a seqlock so the moves array, length, and value all come
 // from the same writer update — never from a half-overwritten
@@ -230,11 +287,15 @@ int endgame_ctx_get_live_pv(const EndgameCtx *ctx, int thread_index,
                             uint64_t *out_moves, int max_len,
                             int32_t *out_value);
 
-// One slot of the live multi-PV top-K leaderboard. root_tiny is the
-// first move (a SmallMove tiny_move); value is the spread-adjusted
-// negamax value (same sign convention as PVLine.score); continuation
-// is the rest of the line (depth - 1 moves at most), with
-// continuation_len in [0, MAX_SEARCH_DEPTH].
+// One slot of the live multi-PV top-K leaderboard: a root move, its current
+// spread-adjusted value (whole points; see conventions above), and the
+// continuation line found after it (up to depth - 1 more moves,
+// continuation_len in [0, MAX_SEARCH_DEPTH]). Moves are tiny_move codes.
+//
+// This is a flat, copy-safe value type, deliberately distinct from PVLine:
+// PVLine carries a Game* and is sized for the search, whereas a poller wants
+// to memcpy a leaderboard slice out under the seqlock and keep using it after
+// the engine has moved on. The snapshot owns no engine pointers.
 typedef struct EndgameLivePvSnapshot {
   uint64_t root_tiny;
   int32_t value;

--- a/src/impl/endgame.h
+++ b/src/impl/endgame.h
@@ -7,6 +7,7 @@
 // search. The board-size limitation comes from MoveUndo's 16-bit
 // tiles_placed_mask.
 
+#include "../def/game_defs.h"
 #include "../ent/endgame_results.h"
 #include "../ent/game.h"
 #include "../ent/game_history.h"
@@ -33,6 +34,48 @@ typedef void (*EndgamePerPlyCallback)(int depth, int32_t value,
                                       const struct PVLine *ranked_pvs,
                                       int num_ranked_pvs, void *user_data);
 
+// Callback fired once before iterative deepening begins. Provides the
+// d=0 root-move list (sorted descending by static estimate from
+// assign_estimates_and_sort), letting the caller render an initial
+// leaderboard before any depth completes. Fires from worker thread 0
+// after its initial-move generation finishes (sub-ms after
+// endgame_solve start) and before any negamax call. The polled
+// atomics (endgame_ctx_get_progress) are guaranteed to show
+// root_moves_total == initial_move_count and root_moves_completed == 0
+// at the moment this callback fires; current_depth is still 0.
+//
+// game is the worker's game copy (already in endgame_solving_mode);
+// initial_moves points into the worker's small_move_arena and is
+// valid only for the duration of the callback. Copy out anything
+// needed past callback return.
+typedef void (*EndgameBeforeSearchCallback)(
+    const struct Game *game, const struct SmallMove *initial_moves,
+    int initial_move_count, int initial_spread, int solving_player,
+    void *user_data);
+
+// Callback fired each time a root move completes its negamax evaluation
+// at the current iterative-deepening depth, from worker thread 0 only.
+// Lets clients re-rank the leaderboard live (per-root resolution rather
+// than per-completed-depth) and watch values swing during long depths.
+//
+// Parameters:
+//   depth      - the IDS depth this completion is at (>= 1)
+//   root_index - index of the root move within the (currently sorted)
+//                root_moves array, 0..root_moves_total-1
+//   move       - the root move that just completed (caller must copy if
+//                it needs the value past callback return)
+//   value      - the negamax value of this root, in spread units
+//                (already adjusted by initial_spread; same sign convention
+//                as PVLine.score)
+//   user_data  - opaque
+//
+// Fires from inside abdada_negamax. Multiple per-root callbacks may
+// happen back-to-back at the same depth as roots complete in scan order.
+// Implementations must be thread-safe even though only thread 0 calls.
+typedef void (*EndgamePerRootMoveCallback)(int depth, int root_index,
+                                           const struct SmallMove *move,
+                                           int32_t value, void *user_data);
+
 typedef struct EndgameArgs {
   ThreadControl *thread_control;
   const Game *game;
@@ -46,6 +89,10 @@ typedef struct EndgameArgs {
   int num_top_moves;
   EndgamePerPlyCallback per_ply_callback;
   void *per_ply_callback_data;
+  EndgameBeforeSearchCallback before_search_callback;
+  void *before_search_callback_data;
+  EndgamePerRootMoveCallback per_root_move_callback;
+  void *per_root_move_callback_data;
   dual_lexicon_mode_t dual_lexicon_mode;
   // If true, play forced passes without consuming a depth ply (default: false)
   bool forced_pass_bypass;
@@ -135,8 +182,79 @@ void endgame_solve_inline(EndgameCtx **ctx, const EndgameArgs *endgame_args,
                           EndgameResults *results);
 const TranspositionTable *
 endgame_ctx_get_transposition_table(const EndgameCtx *ctx);
+// Reset (zero) the transposition table contents but keep the allocation.
+// Useful between unrelated solves on the same ctx when the caller wants
+// each solve to start from a cold cache without paying the realloc cost
+// (the cost is the same — a memset of the full TT — but no malloc/free).
+// No-op if the ctx has no TT (tt_fraction_of_mem == 0).
+void endgame_ctx_clear_transposition_table(EndgameCtx *ctx);
 void endgame_ctx_get_progress(const EndgameCtx *ctx, int *current_depth,
                               int *root_moves_completed, int *root_moves_total,
                               int *ply2_moves_completed, int *ply2_moves_total);
+
+// Sum of nodes searched across all worker threads, lagging by up to
+// DEPTH_DEADLINE_CHECK_INTERVAL nodes per thread (the period at which
+// each worker flushes its non-atomic local counter to the shared
+// atomic). Cheap to call from any thread; intended for "is the engine
+// alive / nodes per second" UI heartbeats during long single-root
+// subtree evaluations.
+uint64_t endgame_ctx_get_nodes_searched(const EndgameCtx *ctx);
+
+// Snapshot of the line currently being explored by worker thread
+// `thread_index`. Writes up to `max_len` `tiny_move` entries into
+// `out_line` and returns the number written (0..max_len). The line
+// reads thread-local state without locking; the reader uses
+// release/acquire on the length so the prefix length is always
+// consistent, but individual entries past the length may still be
+// torn if the worker is concurrently swapping into a sibling subtree.
+// For display only; never used to drive search decisions.
+int endgame_ctx_get_current_line(const EndgameCtx *ctx, int thread_index,
+                                 uint64_t *out_line, int max_len);
+
+// Snapshot of the live best PV from worker `thread_index`. Updated by
+// the engine each time best_value improves at the root (so during a
+// long depth the reader can see the engine's best line refine as
+// successive root moves get evaluated).
+//
+// Writes up to `max_len` `tiny_move` entries into `out_moves` and
+// returns the number written (0..max_len). `*out_value` is set to
+// the spread-adjusted PV value (same sign convention as
+// PVLine.score).
+//
+// Uses a seqlock so the moves array, length, and value all come
+// from the same writer update — never from a half-overwritten
+// state. If a consistent snapshot can't be obtained after a few
+// retries (writer continuously updating) returns 0 and *out_value=0;
+// callers should treat that as "no fresh PV this frame".
+int endgame_ctx_get_live_pv(const EndgameCtx *ctx, int thread_index,
+                            uint64_t *out_moves, int max_len,
+                            int32_t *out_value);
+
+// One slot of the live multi-PV top-K leaderboard. root_tiny is the
+// first move (a SmallMove tiny_move); value is the spread-adjusted
+// negamax value (same sign convention as PVLine.score); continuation
+// is the rest of the line (depth - 1 moves at most), with
+// continuation_len in [0, MAX_SEARCH_DEPTH].
+typedef struct EndgameLivePvSnapshot {
+  uint64_t root_tiny;
+  int32_t value;
+  int continuation_len;
+  uint64_t continuation_tiny[MAX_SEARCH_DEPTH];
+} EndgameLivePvSnapshot;
+
+// Snapshot of the live multi-PV top-K leaderboard from worker
+// `thread_index`. Each slot in `out` is filled with one root move,
+// its current value, and the continuation line found at this depth.
+// Slots are sorted descending by value; the leaderboard is reset at
+// the start of each IDS depth and fills in as roots complete (so the
+// reader may see fewer than max_k entries early in a depth).
+//
+// Writes up to min(max_k, MAX_ENDGAME_DISPLAY_PVS, K_currently_filled)
+// entries and returns the number written. Uses a seqlock so a
+// snapshot is consistent (every entry came from the same writer
+// update). Returns 0 if a consistent snapshot can't be obtained
+// after a few retries.
+int endgame_ctx_get_live_top_k_pvs(const EndgameCtx *ctx, int thread_index,
+                                   EndgameLivePvSnapshot *out, int max_k);
 
 #endif

--- a/src/impl/endgame.h
+++ b/src/impl/endgame.h
@@ -57,10 +57,14 @@ typedef struct EndgameCtx EndgameCtx;
 //
 //   * Values are spreads in WHOLE POINTS — not the millipoint Equity used
 //     elsewhere in MAGPIE — from the solving player's perspective: positive
-//     means the solving player is ahead. This matches PVLine.score.
-//     "Spread-adjusted" below means the raw negamax value has had the root's
-//     initial spread folded in, so it is the projected final spread, not a
-//     delta from the current position.
+//     means the endgame nets points for the solving player. This matches
+//     PVLine.score.
+//     "Spread-adjusted" below means the root's initial spread has been
+//     subtracted from the raw negamax value (which is itself the projected
+//     final spread), so the reported number is the delta — the net point
+//     swing over the endgame from the current position, not the projected
+//     final spread. (The per-ply callback documents this same value as the
+//     "spread delta".)
 //
 //   * Moves are returned as `tiny_move` codes: the compact 64-bit SmallMove
 //     encoding (schema in move.h). A code of 0 is a pass. To render one, wrap

--- a/src/impl/endgame.h
+++ b/src/impl/endgame.h
@@ -33,12 +33,12 @@ typedef struct EndgameCtx EndgameCtx;
 // observe; a consumer may use either or both:
 //
 //   * Push — the callbacks on EndgameArgs (before_search / per_root_move /
-//     per_ply). They fire synchronously, on the master worker (ordinal 0), at
+//     per_ply). They fire synchronously, on the main worker (ordinal 0), at
 //     well-defined moments (search start, each root completion, each completed
 //     depth). They deliver exact, in-order state, but they run inside the
 //     search: a handler must be cheap, must not block, and must copy out
 //     anything it keeps (pointer arguments are valid only for the call).
-//     Note the master is not necessarily a dedicated thread: endgame_solve
+//     Note the main worker is not necessarily a dedicated thread: endgame_solve
 //     runs it on a spawned worker thread, but endgame_solve_inline (the entry
 //     point the PEG solver drives) runs it on the *calling* thread — so a
 //     handler may execute on the caller's own thread.
@@ -74,10 +74,10 @@ typedef struct EndgameCtx EndgameCtx;
 //     value with no engine-owned pointers in it.
 //
 //   * `worker_index` selects which worker to observe (an index into the
-//     solver's worker pool, not an OS thread id). Index 0 is the master: it
-//     owns root ordering, the progress counters, and the live PV / leaderboard,
-//     so a simple UI passes 0 for the canonical view. Higher indices are the
-//     parallel ABDADA helper workers and are rarely needed.
+//     solver's worker pool, not an OS thread id). Index 0 is the main worker:
+//     it owns root ordering, the progress counters, and the live PV /
+//     leaderboard, so a simple UI passes 0 for the canonical view. Higher
+//     indices are the parallel ABDADA helper workers and are rarely needed.
 // ===========================================================================
 
 // Callback for per-ply PV reporting during iterative deepening
@@ -93,7 +93,7 @@ typedef void (*EndgamePerPlyCallback)(int depth, int32_t value,
 // Callback fired once before iterative deepening begins. Provides the
 // d=0 root-move list (sorted descending by static estimate from
 // assign_estimates_and_sort), letting the caller render an initial
-// leaderboard before any depth completes. Fires from the master worker
+// leaderboard before any depth completes. Fires from the main worker
 // (ordinal 0; see the overview above for which thread that is) after its
 // initial-move generation finishes (sub-ms after the solve starts) and
 // before any negamax call. The polled
@@ -111,7 +111,7 @@ typedef void (*EndgameBeforeSearchCallback)(
     void *user_data);
 
 // Callback fired each time a root move completes its negamax evaluation at
-// the current iterative-deepening depth, from the master worker (ordinal 0)
+// the current iterative-deepening depth, from the main worker (ordinal 0)
 // only. Lets clients re-rank the leaderboard live (per-root resolution rather
 // than per-completed-depth) and watch values swing during long depths.
 //
@@ -128,7 +128,7 @@ typedef void (*EndgameBeforeSearchCallback)(
 //
 // Fires from inside abdada_negamax. Multiple per-root callbacks may happen
 // back-to-back at the same depth as roots complete in scan order. Only the
-// master worker calls, but it may be any OS thread (see the overview), so a
+// main worker calls, but it may be any OS thread (see the overview), so a
 // handler must not assume a fixed calling thread.
 typedef void (*EndgamePerRootMoveCallback)(int depth, int root_index,
                                            const struct SmallMove *move,
@@ -208,21 +208,22 @@ void endgame_ctx_destroy(EndgameCtx *ctx);
 void endgame_solve(EndgameCtx **ctx, const EndgameArgs *endgame_args,
                    EndgameResults *results, ErrorStack *error_stack);
 // Inject one additional ABDADA worker into an in-flight solve. Works against
-// both entry points: endgame_solve (spawned master) and endgame_solve_inline
-// (the calling thread is the master). It may be called from another thread
-// (e.g. a pool lending an idle core) or from the solving thread itself — the
-// injection test drives it from the master's per_ply_callback. The new worker
-// gets the next free ordinal (> 0, never the root master), its own ABDADA
-// jitter from that ordinal, a game copy from the (read-only) root inputs, and a
-// MoveGen cache slot assigned on demand by get_movegen(); it cooperates with
-// the running workers purely through the shared TT and self-exits when the
-// search completes. Returns true if a worker was spawned, false if the
-// injection window is shut or the max_workers ceiling is reached. Only valid
-// against a ctx whose current solve was launched with max_workers enabling
-// growth (max_workers > effective thread count after reset normalization).
+// both entry points: endgame_solve (spawned main worker) and
+// endgame_solve_inline (the calling thread is the main worker). It may be
+// called from another thread (e.g. a pool lending an idle core) or from the
+// solving thread itself — the injection test drives it from the main worker's
+// per_ply_callback. The new worker gets the next free ordinal (> 0, never
+// ordinal 0), its own ABDADA jitter from that ordinal, a game copy from the
+// (read-only) root inputs, and a MoveGen cache slot assigned on demand by
+// get_movegen(); it cooperates with the running workers purely through the
+// shared TT and self-exits when the search completes. Returns true if a worker
+// was spawned, false if the injection window is shut or the max_workers ceiling
+// is reached. Only valid against a ctx whose current solve was launched with
+// max_workers enabling growth (max_workers > effective thread count after reset
+// normalization).
 bool endgame_add_worker(EndgameCtx *ctx);
 
-// Number of worker threads currently live in this solve (master + injected
+// Number of worker threads currently live in this solve (main worker + injected
 // helpers). Lets an injection monitor cap total threads near the core count.
 int endgame_live_workers(const EndgameCtx *ctx);
 // True while the solve is accepting injected workers (window open).
@@ -246,7 +247,7 @@ endgame_ctx_get_transposition_table(const EndgameCtx *ctx);
 // (the cost is the same — a memset of the full TT — but no malloc/free).
 // No-op if the ctx has no TT (tt_fraction_of_mem == 0).
 void endgame_ctx_clear_transposition_table(EndgameCtx *ctx);
-// Coarse progress counters for a progress bar (master worker's view). Writes
+// Coarse progress counters for a progress bar (main worker's view). Writes
 // the current iterative-deepening depth, and how many of this depth's root
 // moves have finished (completed/total). The ply2_* out-params are an optional
 // finer-grained sub-progress — how many children of the first root move have
@@ -266,7 +267,7 @@ void endgame_ctx_get_progress(const EndgameCtx *ctx, int *current_depth,
 uint64_t endgame_ctx_get_nodes_searched(const EndgameCtx *ctx);
 
 // Snapshot of the line currently being explored by worker `worker_index`
-// (0 = master; see conventions above). Writes up to `max_len` `tiny_move`
+// (0 = main worker; see conventions above). Writes up to `max_len` `tiny_move`
 // entries into `out_line` and returns the number written (0..max_len). The
 // line reads per-worker state without locking; the reader uses
 // release/acquire on the length so the prefix length is always
@@ -276,7 +277,7 @@ uint64_t endgame_ctx_get_nodes_searched(const EndgameCtx *ctx);
 int endgame_ctx_get_current_line(const EndgameCtx *ctx, int worker_index,
                                  uint64_t *out_line, int max_len);
 
-// Snapshot of the live best PV from worker `worker_index` (0 = master).
+// Snapshot of the live best PV from worker `worker_index` (0 = main worker).
 // Updated by the engine each time best_value improves at the root (so during a
 // long depth the reader can see the engine's best line refine as
 // successive root moves get evaluated).
@@ -311,7 +312,7 @@ typedef struct EndgameLivePvSnapshot {
 } EndgameLivePvSnapshot;
 
 // Snapshot of the live multi-PV top-K leaderboard from worker `worker_index`
-// (0 = master). Each slot in `out` is filled with one root move,
+// (0 = main worker). Each slot in `out` is filled with one root move,
 // its current value, and the continuation line found at this depth.
 // Slots are sorted descending by value; the leaderboard is reset at
 // the start of each IDS depth and fills in as roots complete (so the

--- a/src/impl/endgame.h
+++ b/src/impl/endgame.h
@@ -269,11 +269,12 @@ uint64_t endgame_ctx_get_nodes_searched(const EndgameCtx *ctx);
 // Snapshot of the line currently being explored by worker `worker_index`
 // (0 = main worker; see conventions above). Writes up to `max_len` `tiny_move`
 // entries into `out_line` and returns the number written (0..max_len). The
-// line reads per-worker state without locking; the reader uses
-// release/acquire on the length so the prefix length is always
-// consistent, but individual entries past the length may still be
-// torn if the worker is concurrently swapping into a sibling subtree.
-// For display only; never used to drive search decisions.
+// line reads per-worker state without locking: the slots are relaxed atomics
+// and the reader uses release/acquire on the length, so the prefix length is
+// always consistent and each slot read is well-defined (no torn reads). A slot
+// the worker is concurrently overwriting may simply be stale — it can reflect a
+// different sibling subtree than the reported length — which is fine for a
+// display heartbeat. For display only; never used to drive search decisions.
 int endgame_ctx_get_current_line(const EndgameCtx *ctx, int worker_index,
                                  uint64_t *out_line, int max_len);
 

--- a/src/impl/endgame.h
+++ b/src/impl/endgame.h
@@ -33,11 +33,15 @@ typedef struct EndgameCtx EndgameCtx;
 // observe; a consumer may use either or both:
 //
 //   * Push — the callbacks on EndgameArgs (before_search / per_root_move /
-//     per_ply). They fire synchronously, ON the solver's worker thread 0, at
+//     per_ply). They fire synchronously, on the master worker (ordinal 0), at
 //     well-defined moments (search start, each root completion, each completed
 //     depth). They deliver exact, in-order state, but they run inside the
 //     search: a handler must be cheap, must not block, and must copy out
 //     anything it keeps (pointer arguments are valid only for the call).
+//     Note the master is not necessarily a dedicated thread: endgame_solve
+//     runs it on a spawned worker thread, but endgame_solve_inline (the entry
+//     point the PEG solver drives) runs it on the *calling* thread — so a
+//     handler may execute on the caller's own thread.
 //
 //   * Pull — the endgame_ctx_get_* accessors below. A separate thread polls
 //     these at its own cadence (e.g. a render loop) while endgame_solve runs
@@ -69,10 +73,11 @@ typedef struct EndgameCtx EndgameCtx;
 //     accessors hand back raw codes so each snapshot stays a flat, copy-safe
 //     value with no engine-owned pointers in it.
 //
-//   * `thread_index` selects which worker to observe. Thread 0 is the master:
-//     it owns root ordering, the progress counters, and the live PV /
-//     leaderboard, so a simple UI passes 0 for the canonical view. Other
-//     indices expose the parallel ABDADA helper threads and are rarely needed.
+//   * `worker_index` selects which worker to observe (an index into the
+//     solver's worker pool, not an OS thread id). Index 0 is the master: it
+//     owns root ordering, the progress counters, and the live PV / leaderboard,
+//     so a simple UI passes 0 for the canonical view. Higher indices are the
+//     parallel ABDADA helper workers and are rarely needed.
 // ===========================================================================
 
 // Callback for per-ply PV reporting during iterative deepening
@@ -88,9 +93,10 @@ typedef void (*EndgamePerPlyCallback)(int depth, int32_t value,
 // Callback fired once before iterative deepening begins. Provides the
 // d=0 root-move list (sorted descending by static estimate from
 // assign_estimates_and_sort), letting the caller render an initial
-// leaderboard before any depth completes. Fires from worker thread 0
-// after its initial-move generation finishes (sub-ms after
-// endgame_solve start) and before any negamax call. The polled
+// leaderboard before any depth completes. Fires from the master worker
+// (ordinal 0; see the overview above for which thread that is) after its
+// initial-move generation finishes (sub-ms after the solve starts) and
+// before any negamax call. The polled
 // atomics (endgame_ctx_get_progress) are guaranteed to show
 // root_moves_total == initial_move_count and root_moves_completed == 0
 // at the moment this callback fires; current_depth is still 0.
@@ -104,9 +110,9 @@ typedef void (*EndgameBeforeSearchCallback)(
     int initial_move_count, int initial_spread, int solving_player,
     void *user_data);
 
-// Callback fired each time a root move completes its negamax evaluation
-// at the current iterative-deepening depth, from worker thread 0 only.
-// Lets clients re-rank the leaderboard live (per-root resolution rather
+// Callback fired each time a root move completes its negamax evaluation at
+// the current iterative-deepening depth, from the master worker (ordinal 0)
+// only. Lets clients re-rank the leaderboard live (per-root resolution rather
 // than per-completed-depth) and watch values swing during long depths.
 //
 // Parameters:
@@ -120,9 +126,10 @@ typedef void (*EndgameBeforeSearchCallback)(
 //                as PVLine.score)
 //   user_data  - opaque
 //
-// Fires from inside abdada_negamax. Multiple per-root callbacks may
-// happen back-to-back at the same depth as roots complete in scan order.
-// Implementations must be thread-safe even though only thread 0 calls.
+// Fires from inside abdada_negamax. Multiple per-root callbacks may happen
+// back-to-back at the same depth as roots complete in scan order. Only the
+// master worker calls, but it may be any OS thread (see the overview), so a
+// handler must not assume a fixed calling thread.
 typedef void (*EndgamePerRootMoveCallback)(int depth, int root_index,
                                            const struct SmallMove *move,
                                            int32_t value, void *user_data);
@@ -258,19 +265,19 @@ void endgame_ctx_get_progress(const EndgameCtx *ctx, int *current_depth,
 // subtree evaluations.
 uint64_t endgame_ctx_get_nodes_searched(const EndgameCtx *ctx);
 
-// Snapshot of the line currently being explored by worker thread
-// `thread_index`. Writes up to `max_len` `tiny_move` entries into
-// `out_line` and returns the number written (0..max_len). The line
-// reads thread-local state without locking; the reader uses
+// Snapshot of the line currently being explored by worker `worker_index`
+// (0 = master; see conventions above). Writes up to `max_len` `tiny_move`
+// entries into `out_line` and returns the number written (0..max_len). The
+// line reads per-worker state without locking; the reader uses
 // release/acquire on the length so the prefix length is always
 // consistent, but individual entries past the length may still be
 // torn if the worker is concurrently swapping into a sibling subtree.
 // For display only; never used to drive search decisions.
-int endgame_ctx_get_current_line(const EndgameCtx *ctx, int thread_index,
+int endgame_ctx_get_current_line(const EndgameCtx *ctx, int worker_index,
                                  uint64_t *out_line, int max_len);
 
-// Snapshot of the live best PV from worker `thread_index`. Updated by
-// the engine each time best_value improves at the root (so during a
+// Snapshot of the live best PV from worker `worker_index` (0 = master).
+// Updated by the engine each time best_value improves at the root (so during a
 // long depth the reader can see the engine's best line refine as
 // successive root moves get evaluated).
 //
@@ -283,7 +290,7 @@ int endgame_ctx_get_current_line(const EndgameCtx *ctx, int thread_index,
 // state. If a consistent snapshot can't be obtained after a few
 // retries (writer continuously updating) returns 0 and *out_value=0;
 // callers should treat that as "no fresh PV this frame".
-int endgame_ctx_get_live_pv(const EndgameCtx *ctx, int thread_index,
+int endgame_ctx_get_live_pv(const EndgameCtx *ctx, int worker_index,
                             uint64_t *out_moves, int max_len,
                             int32_t *out_value);
 
@@ -303,8 +310,8 @@ typedef struct EndgameLivePvSnapshot {
   uint64_t continuation_tiny[MAX_SEARCH_DEPTH];
 } EndgameLivePvSnapshot;
 
-// Snapshot of the live multi-PV top-K leaderboard from worker
-// `thread_index`. Each slot in `out` is filled with one root move,
+// Snapshot of the live multi-PV top-K leaderboard from worker `worker_index`
+// (0 = master). Each slot in `out` is filled with one root move,
 // its current value, and the continuation line found at this depth.
 // Slots are sorted descending by value; the leaderboard is reset at
 // the start of each IDS depth and fills in as roots complete (so the
@@ -315,7 +322,7 @@ typedef struct EndgameLivePvSnapshot {
 // snapshot is consistent (every entry came from the same writer
 // update). Returns 0 if a consistent snapshot can't be obtained
 // after a few retries.
-int endgame_ctx_get_live_top_k_pvs(const EndgameCtx *ctx, int thread_index,
+int endgame_ctx_get_live_top_k_pvs(const EndgameCtx *ctx, int worker_index,
                                    EndgameLivePvSnapshot *out, int max_k);
 
 #endif

--- a/test/endgame_test.c
+++ b/test/endgame_test.c
@@ -929,11 +929,8 @@ typedef struct BeforeSearchCaptured {
   int initial_move_count;
   int initial_spread;
   int solving_player;
-  // first move's tiny_move + estimated_value (lets us verify the array is
-  // sorted descending by static estimate at the moment of firing)
-  uint64_t first_move_tiny;
-  int32_t first_move_estimate;
-  // sortedness check across all received moves
+  // sortedness check across all received moves: are they in descending static
+  // estimate order at the moment the callback fires?
   bool sorted_desc_by_estimate;
 } BeforeSearchCaptured;
 
@@ -947,10 +944,6 @@ static void capture_before_search_cb(const Game *game,
   c->initial_move_count = initial_move_count;
   c->initial_spread = initial_spread;
   c->solving_player = solving_player;
-  if (initial_move_count > 0) {
-    c->first_move_tiny = initial_moves[0].tiny_move;
-    c->first_move_estimate = small_move_get_estimated_value(&initial_moves[0]);
-  }
   c->sorted_desc_by_estimate = true;
   for (int i = 1; i < initial_move_count; i++) {
     if (small_move_get_estimated_value(&initial_moves[i]) >
@@ -1030,7 +1023,9 @@ void test_before_search_callback(void) {
   assert(captured.call_count == 1);
   assert(captured.initial_move_count > 0);
   assert(captured.solving_player == 0);
-  assert(captured.first_move_tiny != 0); // not PASS at slot 0
+  // The callback contract is about sortedness and counts, not move identity:
+  // PASS (tiny_move == 0) is a legal root move and qsort has no tie-breaker,
+  // so it may legitimately land at slot 0 — don't assert against it.
   assert(captured.sorted_desc_by_estimate);
 
   // Polled atomics seen from inside the callback must match the callback's

--- a/test/endgame_test.c
+++ b/test/endgame_test.c
@@ -11,6 +11,7 @@
 #include "../src/ent/player.h"
 #include "../src/ent/rack.h"
 #include "../src/ent/thread_control.h"
+#include "../src/ent/xoshiro.h"
 #include "../src/impl/config.h"
 #include "../src/impl/endgame.h"
 #include "../src/impl/gameplay.h"
@@ -23,6 +24,7 @@
 #include "test_constants.h"
 #include "test_util.h"
 #include <assert.h>
+#include <stdatomic.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -919,7 +921,580 @@ void test_via_opp_must_block_every_depth(void) {
   }
 }
 
+// before_search_callback tests
+// ---------------------------------------------------------------------------
+
+typedef struct BeforeSearchCaptured {
+  int call_count;
+  int initial_move_count;
+  int initial_spread;
+  int solving_player;
+  // first move's tiny_move + estimated_value (lets us verify the array is
+  // sorted descending by static estimate at the moment of firing)
+  uint64_t first_move_tiny;
+  int32_t first_move_estimate;
+  // sortedness check across all received moves
+  bool sorted_desc_by_estimate;
+} BeforeSearchCaptured;
+
+static void capture_before_search_cb(const Game *game,
+                                     const SmallMove *initial_moves,
+                                     int initial_move_count, int initial_spread,
+                                     int solving_player, void *user_data) {
+  (void)game;
+  BeforeSearchCaptured *c = (BeforeSearchCaptured *)user_data;
+  c->call_count++;
+  c->initial_move_count = initial_move_count;
+  c->initial_spread = initial_spread;
+  c->solving_player = solving_player;
+  if (initial_move_count > 0) {
+    c->first_move_tiny = initial_moves[0].tiny_move;
+    c->first_move_estimate = small_move_get_estimated_value(&initial_moves[0]);
+  }
+  c->sorted_desc_by_estimate = true;
+  for (int i = 1; i < initial_move_count; i++) {
+    if (small_move_get_estimated_value(&initial_moves[i]) >
+        small_move_get_estimated_value(&initial_moves[i - 1])) {
+      c->sorted_desc_by_estimate = false;
+      break;
+    }
+  }
+}
+
+// Asserts the new before_search_callback fires exactly once per solve, with
+// initial_move_count > 0, sorted descending by estimated_value, and that the
+// polled progress atomics show root_moves_total == initial_move_count and
+// root_moves_completed == 0 immediately at callback time (so a UI polling
+// the atomics can render a coherent d=0 leaderboard from the same snapshot
+// the callback delivered).
+static atomic_int g_atomic_check_state_total;
+static atomic_int g_atomic_check_state_completed;
+static atomic_int g_atomic_check_state_depth;
+static EndgameCtx **g_atomic_check_ctx_pp;
+
+static void capture_and_poll_before_search_cb(
+    const Game *game, const SmallMove *initial_moves, int initial_move_count,
+    int initial_spread, int solving_player, void *user_data) {
+  capture_before_search_cb(game, initial_moves, initial_move_count,
+                           initial_spread, solving_player, user_data);
+  // Poll the public progress atomics from inside the callback so we can
+  // assert UI-visible state agrees with the callback args at the same
+  // moment in time.
+  int cur_depth = 0;
+  int done = 0;
+  int total = 0;
+  int dummy_a = 0;
+  int dummy_b = 0;
+  endgame_ctx_get_progress(*g_atomic_check_ctx_pp, &cur_depth, &done, &total,
+                           &dummy_a, &dummy_b);
+  atomic_store(&g_atomic_check_state_depth, cur_depth);
+  atomic_store(&g_atomic_check_state_completed, done);
+  atomic_store(&g_atomic_check_state_total, total);
+}
+
+void test_before_search_callback(void) {
+  Config *config = config_create_or_die("set -s1 score -s2 score");
+  load_and_exec_config_or_die(
+      config, "cgp 9A1PIXY/9S1L3/2ToWNLETS1O3/9U1DA1R/3GERANIAL1U1I/9g2T1C/"
+              "8WE2OBI/6EMU4ON/6AID3GO1/5HUN4ET1/4ZA1T4ME1/1Q1FAKEY3JOES/"
+              "FIVE1E5IT1C/5SPORRAN2A/6ORE2N2D BGIV/DEHILOR 384/389 0 "
+              "-lex NWL20");
+
+  EndgameCtx *ctx = NULL;
+  BeforeSearchCaptured captured = {0};
+  atomic_store(&g_atomic_check_state_total, -1);
+  atomic_store(&g_atomic_check_state_completed, -1);
+  atomic_store(&g_atomic_check_state_depth, -1);
+  g_atomic_check_ctx_pp = &ctx;
+
+  EndgameArgs args = {0};
+  args.thread_control = config_get_thread_control(config);
+  args.game = config_get_game(config);
+  args.plies = 3;
+  args.tt_fraction_of_mem = config_get_tt_fraction_of_mem(config);
+  args.initial_small_move_arena_size = DEFAULT_INITIAL_SMALL_MOVE_ARENA_SIZE;
+  args.num_threads = 4;
+  args.num_top_moves = 1;
+  args.use_heuristics = true;
+  args.forced_pass_bypass = true;
+  args.enable_pv_display = true;
+  args.seed = 42;
+  args.before_search_callback = capture_and_poll_before_search_cb;
+  args.before_search_callback_data = &captured;
+
+  EndgameResults *results = config_get_endgame_results(config);
+  ErrorStack *error_stack = error_stack_create();
+  endgame_solve(&ctx, &args, results, error_stack);
+  assert(error_stack_is_empty(error_stack));
+
+  assert(captured.call_count == 1);
+  assert(captured.initial_move_count > 0);
+  assert(captured.solving_player == 0);
+  assert(captured.first_move_tiny != 0); // not PASS at slot 0
+  assert(captured.sorted_desc_by_estimate);
+
+  // Polled atomics seen from inside the callback must match the callback's
+  // own view of the candidate count, with no prior depth started.
+  const int polled_total = atomic_load(&g_atomic_check_state_total);
+  const int polled_completed = atomic_load(&g_atomic_check_state_completed);
+  const int polled_depth = atomic_load(&g_atomic_check_state_depth);
+  assert(polled_total == captured.initial_move_count);
+  assert(polled_completed == 0);
+  assert(polled_depth == 0);
+
+  endgame_ctx_destroy(ctx);
+  error_stack_destroy(error_stack);
+  config_destroy(config);
+}
+
+// ---------------------------------------------------------------------------
+// On-demand: streaming-progress test
+// ---------------------------------------------------------------------------
+
+// Two streaming modes for the on-demand demo. Both share the same
+// reader/printer thread; the difference is which signal source the
+// reader includes in each frame.
+typedef enum {
+  // Poll the ply2 atomics that are already exposed by
+  // endgame_ctx_get_progress. Adds intra-root sub-progress for the
+  // first root move's children.
+  STREAM_MODE_POLL_PLY2,
+  // Use the per_root_move_callback to track the last root completed.
+  // Gives per-root resolution across the whole top level, so the
+  // reader can describe live root-by-root completions.
+  STREAM_MODE_CALLBACK_PER_ROOT,
+} StreamMode;
+
+// Shared state between the main solver thread and the reader/printer thread.
+// All cross-thread fields are either atomic_* or guarded by `mutex`.
+typedef struct ProgressStream {
+  EndgameCtx **ctx_pp;        // populated by endgame_solve when it creates ctx
+  StreamMode mode;            // selects which signal the reader prints
+  cpthread_mutex_t mutex;     // guards the snapshot fields below
+  bool seen_initial;          // before_search_callback has fired
+  int last_completed_depth;   // most recent per_ply_callback's depth (0 = none)
+  int32_t last_completed_val; // and value
+  int initial_move_count;     // from before_search_callback
+  // Per-root callback snapshot (mode == STREAM_MODE_CALLBACK_PER_ROOT)
+  int last_root_depth;
+  int last_root_idx;
+  int32_t last_root_value;
+  uint64_t last_root_tiny;
+  int per_root_calls;
+  int64_t solve_start_ns;
+  atomic_int should_stop;   // main thread sets to 1 when endgame_solve returns
+  int frames_printed;       // bumped by the reader; used so we can verify
+                            // the test actually streamed something
+  int live_pv_change_count; // distinct live PVs the reader observed
+  int live_top_k_change_count; // distinct top-K snapshots observed
+  uint64_t last_topk_hash;     // hash of last top-K snapshot seen
+} ProgressStream;
+
+static void stream_before_search_cb(const Game *game,
+                                    const SmallMove *initial_moves,
+                                    int initial_move_count, int initial_spread,
+                                    int solving_player, void *user_data) {
+  (void)game;
+  (void)initial_moves;
+  (void)initial_spread;
+  (void)solving_player;
+  ProgressStream *s = (ProgressStream *)user_data;
+  cpthread_mutex_lock(&s->mutex);
+  s->seen_initial = true;
+  s->initial_move_count = initial_move_count;
+  // Start the elapsed-time clock here. Per-iteration setup before this
+  // point (TT memset, KWG pruning, worker pool spinup) is bookkeeping
+  // the user doesn't care about; only "time spent on actual estimates
+  // and search" is interesting to display.
+  s->solve_start_ns = ctimer_monotonic_ns();
+  cpthread_mutex_unlock(&s->mutex);
+}
+
+static void stream_per_ply_cb(int depth, int32_t value,
+                              const struct PVLine *pv_line,
+                              const struct Game *game,
+                              const struct PVLine *ranked_pvs,
+                              int num_ranked_pvs, void *user_data) {
+  (void)pv_line;
+  (void)game;
+  (void)ranked_pvs;
+  (void)num_ranked_pvs;
+  ProgressStream *s = (ProgressStream *)user_data;
+  cpthread_mutex_lock(&s->mutex);
+  s->last_completed_depth = depth;
+  s->last_completed_val = value;
+  cpthread_mutex_unlock(&s->mutex);
+}
+
+static void stream_per_root_cb(int depth, int root_index,
+                               const struct SmallMove *move, int32_t value,
+                               void *user_data) {
+  ProgressStream *s = (ProgressStream *)user_data;
+  cpthread_mutex_lock(&s->mutex);
+  s->last_root_depth = depth;
+  s->last_root_idx = root_index;
+  s->last_root_value = value;
+  s->last_root_tiny = move->tiny_move;
+  s->per_root_calls++;
+  cpthread_mutex_unlock(&s->mutex);
+}
+
+static void *stream_reader_thread(void *arg) {
+  ProgressStream *s = (ProgressStream *)arg;
+  uint64_t prev_nodes = 0;
+  int64_t prev_nodes_ns = 0;
+  // Track how often the live PV's content actually changes between
+  // poll frames (not just the seqlock seq, the displayed bytes).
+  uint64_t last_pv_hash = 0;
+  int live_pv_change_count = 0;
+  while (!atomic_load(&s->should_stop)) {
+    const EndgameCtx *ctx = *s->ctx_pp;
+    cpthread_mutex_lock(&s->mutex);
+    const bool seen_initial = s->seen_initial;
+    const int last_depth = s->last_completed_depth;
+    const int32_t last_val = s->last_completed_val;
+    const int initial_count = s->initial_move_count;
+    const int last_root_depth = s->last_root_depth;
+    const int last_root_idx = s->last_root_idx;
+    const int32_t last_root_value = s->last_root_value;
+    const uint64_t last_root_tiny = s->last_root_tiny;
+    const int per_root_calls = s->per_root_calls;
+    const int64_t solve_start_ns = s->solve_start_ns;
+    cpthread_mutex_unlock(&s->mutex);
+
+    int cur_depth = 0;
+    int done = 0;
+    int total = 0;
+    int ply2_done = 0;
+    int ply2_total = 0;
+    uint64_t nodes = 0;
+    uint64_t line[MAX_SEARCH_DEPTH];
+    int line_len = 0;
+    uint64_t live_pv[MAX_SEARCH_DEPTH];
+    int live_pv_len = 0;
+    int32_t live_pv_value = 0;
+    EndgameLivePvSnapshot live_top_k[10] = {0};
+    int live_top_k_n = 0;
+    if (ctx != NULL) {
+      endgame_ctx_get_progress(ctx, &cur_depth, &done, &total, &ply2_done,
+                               &ply2_total);
+    }
+    // The worker-array accessors (nodes/current-line/live-PV/top-K) read
+    // ctx->workers, which endgame_solve's prepare_workers may free and rebuild
+    // when the lexicon changes between solves. Only poll them once this solve's
+    // before_search_callback has fired (seen_initial) — by then prepare_workers
+    // has finished and the pool is stable for the duration of the search. This
+    // mirrors the contract that the accessors are valid only during an active
+    // solve.
+    if (ctx != NULL && seen_initial) {
+      nodes = endgame_ctx_get_nodes_searched(ctx);
+      line_len = endgame_ctx_get_current_line(ctx, 0, line, MAX_SEARCH_DEPTH);
+      live_pv_len = endgame_ctx_get_live_pv(ctx, 0, live_pv, MAX_SEARCH_DEPTH,
+                                            &live_pv_value);
+      live_top_k_n = endgame_ctx_get_live_top_k_pvs(ctx, 0, live_top_k, 10);
+    }
+    // Hash the live PV (length + moves + value) so we can count the
+    // number of distinct snapshots seen by the reader. This isn't the
+    // engine-side update count — it's "how often a polling display
+    // would observe a change."
+    uint64_t pv_hash = (uint64_t)live_pv_len * 0x9E3779B97F4A7C15ULL;
+    for (int i = 0; i < live_pv_len; i++) {
+      pv_hash ^=
+          live_pv[i] + 0x9E3779B97F4A7C15ULL + (pv_hash << 6) + (pv_hash >> 2);
+    }
+    pv_hash ^= (uint64_t)(uint32_t)live_pv_value;
+    if (pv_hash != last_pv_hash) {
+      live_pv_change_count++;
+      last_pv_hash = pv_hash;
+      s->live_pv_change_count = live_pv_change_count;
+    }
+    // Hash the multi-PV top-K snapshot (length + each entry's
+    // root_tiny + value + continuation) to count how often the
+    // observable leaderboard changes between polls.
+    uint64_t topk_hash = (uint64_t)live_top_k_n * 0x9E3779B97F4A7C15ULL;
+    for (int i = 0; i < live_top_k_n; i++) {
+      topk_hash ^=
+          live_top_k[i].root_tiny + (topk_hash << 6) + (topk_hash >> 2);
+      topk_hash ^= (uint64_t)(uint32_t)live_top_k[i].value;
+      for (int j = 0; j < live_top_k[i].continuation_len; j++) {
+        topk_hash ^= live_top_k[i].continuation_tiny[j] + (topk_hash << 6) +
+                     (topk_hash >> 2);
+      }
+    }
+    if (topk_hash != s->last_topk_hash) {
+      s->live_top_k_change_count++;
+      s->last_topk_hash = topk_hash;
+    }
+    const int64_t now_ns = ctimer_monotonic_ns();
+    double knodes_per_sec = 0.0;
+    if (prev_nodes_ns > 0 && now_ns > prev_nodes_ns && nodes >= prev_nodes) {
+      knodes_per_sec = (double)(nodes - prev_nodes) /
+                       ((double)(now_ns - prev_nodes_ns) / 1.0e6);
+    }
+    prev_nodes = nodes;
+    prev_nodes_ns = now_ns;
+
+    // Common prefix: timing + d=0 status + last completed depth + root
+    // counter. Mode-specific suffix appended below.  Pre-d=0 frames have
+    // no meaningful elapsed value (the timer is started by the d=0
+    // callback to exclude setup overhead like TT allocation).
+    char prefix[160];
+    if (!seen_initial) {
+      (void)snprintf(prefix, sizeof(prefix),
+                     "  [    --ms] (waiting for d=0 callback)");
+    } else {
+      const double elapsed_ms = (double)(now_ns - solve_start_ns) / 1.0e6;
+      if (last_depth == 0) {
+        (void)snprintf(
+            prefix, sizeof(prefix),
+            "  [%6.0fms] d=0 published (n=%d) cur_depth=%d searching %d/%d",
+            elapsed_ms, initial_count, cur_depth, done, total);
+      } else {
+        (void)snprintf(prefix, sizeof(prefix),
+                       "  [%6.0fms] last_completed=d%d val=%d "
+                       "cur_depth=%d searching %d/%d",
+                       elapsed_ms, last_depth, last_val, cur_depth, done,
+                       total);
+      }
+    }
+
+    // Format the live current-line as comma-separated tiny_moves.
+    char line_str[256];
+    int written = 0;
+    written += snprintf(line_str + written, sizeof(line_str) - written, "[");
+    for (int i = 0; i < line_len && written < (int)sizeof(line_str) - 32; i++) {
+      written +=
+          snprintf(line_str + written, sizeof(line_str) - written, "%s0x%llx",
+                   i == 0 ? "" : ",", (unsigned long long)line[i]);
+    }
+    (void)snprintf(line_str + written, sizeof(line_str) - written, "]");
+
+    // Always-on signals appended to every frame: nodes/sec (smoothed
+    // across the last poll interval) and the live current-line snapshot
+    // from worker thread 0. Either alone is enough to prove the engine
+    // is alive during a long single-root subtree where no other signal
+    // updates.
+    char pv_str[256];
+    int pv_written = 0;
+    pv_written +=
+        snprintf(pv_str + pv_written, sizeof(pv_str) - pv_written, "[");
+    for (int i = 0; i < live_pv_len && pv_written < (int)sizeof(pv_str) - 32;
+         i++) {
+      pv_written +=
+          snprintf(pv_str + pv_written, sizeof(pv_str) - pv_written, "%s0x%llx",
+                   i == 0 ? "" : ",", (unsigned long long)live_pv[i]);
+    }
+    (void)snprintf(pv_str + pv_written, sizeof(pv_str) - pv_written, "]");
+
+    // Compact "top-K" tail: show first-move tiny + value for each slot,
+    // then "+continuation_len" for the longest continuation. Reader
+    // verifies the leaderboard fills in as roots complete.
+    char topk_str[128];
+    int topk_written = 0;
+    topk_written +=
+        snprintf(topk_str + topk_written, sizeof(topk_str) - topk_written,
+                 "%d{", live_top_k_n);
+    for (int i = 0;
+         i < live_top_k_n && topk_written < (int)sizeof(topk_str) - 32; i++) {
+      topk_written +=
+          snprintf(topk_str + topk_written, sizeof(topk_str) - topk_written,
+                   "%s0x%llx=%d+%d", i == 0 ? "" : ",",
+                   (unsigned long long)live_top_k[i].root_tiny,
+                   live_top_k[i].value, live_top_k[i].continuation_len);
+    }
+    (void)snprintf(topk_str + topk_written, sizeof(topk_str) - topk_written,
+                   "}");
+
+    if (s->mode == STREAM_MODE_POLL_PLY2) {
+      printf("%s | ply2 %d/%d | %.0fk nps | t0_line %s | "
+             "live_pv val=%d %s | top_k %s\n",
+             prefix, ply2_done, ply2_total, knodes_per_sec, line_str,
+             live_pv_value, pv_str, topk_str);
+    } else {
+      if (per_root_calls == 0) {
+        printf("%s | per_root: 0 calls | %.0fk nps | t0_line %s | "
+               "live_pv val=%d %s | top_k %s\n",
+               prefix, knodes_per_sec, line_str, live_pv_value, pv_str,
+               topk_str);
+      } else {
+        printf("%s | per_root: %d calls, last d%d idx=%d val=%d tiny=0x%llx | "
+               "%.0fk nps | t0_line %s | live_pv val=%d %s | top_k %s\n",
+               prefix, per_root_calls, last_root_depth, last_root_idx,
+               last_root_value, (unsigned long long)last_root_tiny,
+               knodes_per_sec, line_str, live_pv_value, pv_str, topk_str);
+      }
+    }
+    (void)fflush(stdout);
+    s->frames_printed++;
+    ctime_nap(0.016); // ~60fps
+  }
+  return NULL;
+}
+
+void test_endgame_progress_stream(void) {
+  // Hand-picked positions tuned so each solve runs for ~1-3 seconds with
+  // multiple completed depths visible in the stream.  Don't crank
+  // eplies higher: deep searches on a wide root (n>500) blow past 30s
+  // per iteration and the test stops being useful as a demo.
+  static const struct {
+    const char *cgp;
+    const char *lex;
+    int eplies;
+  } positions[] = {
+      // Tight 7-tile endgame, ~60-100 root moves, completes through d=5
+      // quickly enough to show many depth transitions in the stream.
+      {"9A1PIXY/9S1L3/2ToWNLETS1O3/9U1DA1R/3GERANIAL1U1I/9g2T1C/8WE2OBI/"
+       "6EMU4ON/6AID3GO1/5HUN4ET1/4ZA1T4ME1/1Q1FAKEY3JOES/FIVE1E5IT1C/"
+       "5SPORRAN2A/6ORE2N2D BGIV/DEHILOR 384/389 0",
+       "NWL20", 6},
+      // Stuck-tile (Z) position, asymmetric racks, slower per-ply.
+      {"GATELEGs1POGOED/R4MOOLI3X1/AA10U2/YU4BREDRIN2/1TITULE3E1IN1/"
+       "1E4N3c1BOK/1C2O4CHARD1/QI1FLAWN2E1OE1/IS2E1HIN1A1W2/"
+       "1MOTIVATE1T1S2/1S2N5S4/3PERJURY5/15/15/15 FV/AADIZ 442/388 0",
+       "CSW21", 5},
+  };
+  static const int npos = (int)(sizeof(positions) / sizeof(positions[0]));
+  static const StreamMode modes[] = {STREAM_MODE_POLL_PLY2,
+                                     STREAM_MODE_CALLBACK_PER_ROOT};
+  static const int nmodes = (int)(sizeof(modes) / sizeof(modes[0]));
+  static const char *mode_labels[] = {"poll_ply2", "callback_per_root"};
+
+  // Use system time as the RNG seed only for choosing thread counts.
+  // (Position and mode are cycled deterministically so the test always
+  // exercises every combination.)
+  XoshiroPRNG *prng = prng_create((uint64_t)ctime_get_current_time());
+
+  // Allocate the EndgameCtx (and its transposition table) once, outside
+  // the iteration loop. Subsequent iterations reuse it, so the
+  // ~200ms one-off TT memset doesn't get counted into per-iteration
+  // streaming output. The elapsed-time clock in each iteration is
+  // started by stream_before_search_cb, so even the first iteration's
+  // streaming numbers exclude setup overhead.
+  EndgameCtx *ctx = NULL;
+  {
+    // Warmup: one quick solve with eplies=1 to force ctx + TT allocation.
+    // Its stream output is suppressed (no reader thread); we just care
+    // about getting the TT on the heap.
+    Config *warmup_config = config_create_or_die("set -s1 score -s2 score");
+    char warmup_cmd[1024];
+    (void)snprintf(warmup_cmd, sizeof(warmup_cmd), "cgp %s -lex %s",
+                   positions[0].cgp, positions[0].lex);
+    load_and_exec_config_or_die(warmup_config, warmup_cmd);
+    EndgameArgs warmup_args = {0};
+    warmup_args.thread_control = config_get_thread_control(warmup_config);
+    warmup_args.game = config_get_game(warmup_config);
+    warmup_args.plies = 1;
+    warmup_args.tt_fraction_of_mem =
+        config_get_tt_fraction_of_mem(warmup_config);
+    warmup_args.initial_small_move_arena_size =
+        DEFAULT_INITIAL_SMALL_MOVE_ARENA_SIZE;
+    warmup_args.num_threads = 1;
+    warmup_args.num_top_moves = 1;
+    warmup_args.use_heuristics = true;
+    warmup_args.forced_pass_bypass = true;
+    warmup_args.enable_pv_display = true;
+    warmup_args.seed = 1;
+    EndgameResults *warmup_results = config_get_endgame_results(warmup_config);
+    ErrorStack *warmup_err = error_stack_create();
+    endgame_solve(&ctx, &warmup_args, warmup_results, warmup_err);
+    assert(error_stack_is_empty(warmup_err));
+    error_stack_destroy(warmup_err);
+    config_destroy(warmup_config);
+    printf("(warmup complete; TT pre-allocated)\n");
+  }
+
+  const int kIterations = npos * nmodes;
+  int iter = 0;
+  for (int pos_idx = 0; pos_idx < npos; pos_idx++) {
+    for (int mode_idx = 0; mode_idx < nmodes; mode_idx++) {
+      iter++;
+      const int threads = 2 + (int)prng_get_random_number(prng, 5); // 2..6
+      const StreamMode mode = modes[mode_idx];
+
+      Config *config = config_create_or_die("set -s1 score -s2 score");
+      char cmd[1024];
+      (void)snprintf(cmd, sizeof(cmd), "cgp %s -lex %s", positions[pos_idx].cgp,
+                     positions[pos_idx].lex);
+      load_and_exec_config_or_die(config, cmd);
+
+      printf(
+          "\n=== iter %d/%d: pos=%d mode=%s threads=%d plies=%d lex=%s ===\n",
+          iter, kIterations, pos_idx, mode_labels[mode_idx], threads,
+          positions[pos_idx].eplies, positions[pos_idx].lex);
+
+      ProgressStream stream = {0};
+      cpthread_mutex_init(&stream.mutex);
+      atomic_store(&stream.should_stop, 0);
+      stream.ctx_pp = &ctx;
+      stream.mode = mode;
+      // solve_start_ns will be filled in by stream_before_search_cb.
+
+      EndgameArgs args = {0};
+      args.thread_control = config_get_thread_control(config);
+      args.game = config_get_game(config);
+      args.plies = positions[pos_idx].eplies;
+      args.tt_fraction_of_mem = config_get_tt_fraction_of_mem(config);
+      args.initial_small_move_arena_size =
+          DEFAULT_INITIAL_SMALL_MOVE_ARENA_SIZE;
+      args.num_threads = threads;
+      args.num_top_moves = 5;
+      args.use_heuristics = true;
+      args.forced_pass_bypass = true;
+      args.enable_pv_display = true;
+      args.seed = 42;
+      args.before_search_callback = stream_before_search_cb;
+      args.before_search_callback_data = &stream;
+      args.per_ply_callback = stream_per_ply_cb;
+      args.per_ply_callback_data = &stream;
+      // Only install the per-root callback when the mode actually wants it,
+      // so each mode runs with only its own signal active and the comparison
+      // is honest.
+      if (mode == STREAM_MODE_CALLBACK_PER_ROOT) {
+        args.per_root_move_callback = stream_per_root_cb;
+        args.per_root_move_callback_data = &stream;
+      }
+
+      // Clear the TT before each timed iteration so each one searches
+      // from a cold cache. This costs a 2GB memset (~200ms) on this
+      // host but happens BEFORE the reader thread is spawned and before
+      // the timer is started by the d=0 callback, so it isn't counted
+      // in any displayed elapsed time.
+      endgame_ctx_clear_transposition_table(ctx);
+
+      cpthread_t reader;
+      cpthread_create(&reader, stream_reader_thread, &stream);
+
+      EndgameResults *results = config_get_endgame_results(config);
+      ErrorStack *error_stack = error_stack_create();
+      endgame_solve(&ctx, &args, results, error_stack);
+      assert(error_stack_is_empty(error_stack));
+
+      atomic_store(&stream.should_stop, 1);
+      cpthread_join(reader);
+
+      printf("  [done] frames_printed=%d final_completed_depth=%d "
+             "per_root_calls=%d live_pv_changes=%d "
+             "live_top_k_changes=%d\n",
+             stream.frames_printed, stream.last_completed_depth,
+             stream.per_root_calls, stream.live_pv_change_count,
+             stream.live_top_k_change_count);
+      assert(stream.frames_printed > 0);
+      assert(stream.seen_initial);
+      if (mode == STREAM_MODE_CALLBACK_PER_ROOT) {
+        // Should fire at least once per completed depth.
+        assert(stream.per_root_calls >= stream.last_completed_depth);
+      }
+
+      error_stack_destroy(error_stack);
+      config_destroy(config);
+    }
+  }
+  endgame_ctx_destroy(ctx);
+  prng_destroy(prng);
+}
+
 void test_endgame(void) {
+  test_before_search_callback();
   test_single_pv_display();
   test_ctx_reuse();
   test_solve_standard();

--- a/test/endgame_test.c
+++ b/test/endgame_test.c
@@ -1403,7 +1403,7 @@ void test_endgame_progress_stream(void) {
     printf("(warmup complete; TT pre-allocated)\n");
   }
 
-  const int kIterations = npos * nmodes;
+  const int total_iterations = npos * nmodes;
   int iter = 0;
   for (int pos_idx = 0; pos_idx < npos; pos_idx++) {
     for (int mode_idx = 0; mode_idx < nmodes; mode_idx++) {
@@ -1419,7 +1419,7 @@ void test_endgame_progress_stream(void) {
 
       printf(
           "\n=== iter %d/%d: pos=%d mode=%s threads=%d plies=%d lex=%s ===\n",
-          iter, kIterations, pos_idx, mode_labels[mode_idx], threads,
+          iter, total_iterations, pos_idx, mode_labels[mode_idx], threads,
           positions[pos_idx].eplies, positions[pos_idx].lex);
 
       ProgressStream stream = {0};

--- a/test/endgame_test.h
+++ b/test/endgame_test.h
@@ -13,5 +13,7 @@ void test_via_opp_must_block_every_depth(void);
 void test_via_interrupted_reasonable_under_time_pressure(void);
 void test_endgame_dynamic_worker_injection(void);
 void test_endgame_first_win_sign(void);
+void test_before_search_callback(void);
+void test_endgame_progress_stream(void);
 
 #endif

--- a/test/test.c
+++ b/test/test.c
@@ -163,6 +163,7 @@ static TestEntry on_demand_test_table[] = {
     {"kwgtailreorder", test_kwg_tail_reorder},
     {"dawgpacked", test_dawg_packed},
     {"kwgmergebench", test_kwg_merge_build_bench},
+    {"endgame_stream", test_endgame_progress_stream},
     {"kue", test_kue},
     {"monsterq", test_monster_q},
     {"simbench", test_sim_benchmark},


### PR DESCRIPTION
## Summary

Adds read-only observability into the running endgame search — for driving a
live UI view of the search — **without changing the search algorithm or its
results**. Everything here is additive; main's existing endgame solve-value
tests pass unchanged.

## Why this PR now (the UI it serves isn't merged yet)

These hooks exist to drive a live analysis view in a work-in-progress terminal
UI that lives on a separate long-running branch. **That UI is not ready and is
not part of this PR** — only the engine-side support is. It's being upstreamed
now, ahead of the UI, specifically because it touches the endgame core
(`abdada_negamax`, the worker struct, `EndgameArgs`): main has been moving fast
there (worker injection, first-win, the PEG solver), and letting the engine
changes sit on a fork only makes the eventual reconciliation worse. Landing the
engine-side contract early keeps the branches from drifting apart. The API is
deliberately UI-agnostic — nothing terminal-specific leaks in — so it can drive
any front end, not just the one being built.

## The interface (see the overview block at the top of `endgame.h`)

The header now documents the whole model up front, for a reviewer with no UI
context. In short, there are two complementary ways to observe a solve:

- **Push** — callbacks on `EndgameArgs`, fired synchronously on the main
  worker (ordinal 0) at defined moments:
  - `before_search_callback` — once, with the sorted d=0 root-move list (render
    an initial leaderboard before any depth completes).
  - `per_root_move_callback` — each time a root move finishes at the current
    iterative-deepening depth (live re-ranking).
  - `per_ply_callback` — pre-existing; per completed depth.
- **Pull** — lock-free `endgame_ctx_get_*` accessors polled from a render
  thread while the solve runs on another:
  - `endgame_ctx_get_nodes_searched` — summed node count (NPS heartbeat).
  - `endgame_ctx_get_current_line` — the line worker N is exploring right now.
  - `endgame_ctx_get_live_pv` — worker N's evolving best PV (seqlock snapshot).
  - `endgame_ctx_get_live_top_k_pvs` — the live top-K leaderboard
    (`EndgameLivePvSnapshot[]`, a flat copy-safe value type).
  - `endgame_ctx_clear_transposition_table` — cold-cache reset keeping the alloc.

Shared conventions (documented once in the header): values are spreads in
**whole points** from the solving player's perspective (matching `PVLine.score`,
**not** the millipoint `Equity` used elsewhere); moves come back as `tiny_move`
codes that decode via `small_move_to_move`; `worker_index 0` is the canonical
main-worker view. The main worker is identified by worker **ordinal 0**, not an OS thread
id — and it isn't always a dedicated thread: `endgame_solve` runs it on a
spawned worker thread, but `endgame_solve_inline` (the entry point the PEG
solver drives) runs it on the *calling* thread. So callbacks fire from the
main worker but may execute on any thread; handlers must not assume a fixed
one. It's observation only — reading it never affects the result.

## Implementation

Per-worker live-progress state on `EndgameCtxWorker` (node counter flushed at
the deadline-check cadence; current-line release/acquire; live-PV and top-K
seqlocks), published from the main worker inside `abdada_negamax` and reset
per IDS depth. `num_top_moves` is clamped to `MAX_ENDGAME_DISPLAY_PVS` and the
in-search top-K array sized to match. No change to move generation, ordering,
first-win, injection, or TT behavior. Always-on cost (a per-node counter and a
couple of thread-local cache stores per move) is below the measurement noise
floor of a single-threaded fixed-depth solve.

## Tests

- `test_before_search_callback` (run in-suite from `test_endgame`): asserts the
  callback fires exactly once with the sorted d=0 root list and that the
  progress atomics polled from inside it agree.
- `test_endgame_progress_stream` (on-demand `endgame_stream`): a reader thread
  polls every accessor + both new callbacks while a solve runs. It only touches
  the worker-array accessors once `before_search` has fired, since
  `prepare_workers` may rebuild the pool on a lexicon change between solves —
  the accessors are valid only during an active solve.

## Validation

format.py (no changes) · cppcheck (0 findings) · clang-tidy + include-cleaner
(clean) · circular-deps (none) · `run_all` BOARD_DIM=15 and 21 under ASAN/UBSAN
(rc 0) · WASM `endgame` / `endgame_wasm` / `tt` / `zobrist` (pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


