### PR TITLE
Add KWG_MAKER_MERGE_TAIL_REORDER: child-list reordering for smaller DAWGs

### DIFF
--- a/src/def/convert_defs.h
+++ b/src/def/convert_defs.h
@@ -8,6 +8,10 @@ typedef enum {
   // Like CONVERT_TEXT2KWG but uses wolges-style tail merging for a smaller
   // (but slightly slower to traverse) node array.
   CONVERT_TEXT2KWG_TAIL_MERGE,
+  // DAWG-only output that additionally reorders each node's child list to
+  // maximize tail merging (smallest node array). NOT valid for the Alpha
+  // cross-set path; for linear-scan readers / export only.
+  CONVERT_TEXT2DAWG_TAIL_REORDER,
   CONVERT_DAWG2TEXT,
   CONVERT_GADDAG2TEXT,
   CONVERT_CSV2KLV,

--- a/src/def/kwg_defs.h
+++ b/src/def/kwg_defs.h
@@ -35,6 +35,14 @@ typedef enum {
   // producing a smaller node array at the cost of cache locality during
   // movegen.
   KWG_MAKER_MERGE_TAIL,
+  // Like KWG_MAKER_MERGE_TAIL, but first PERMUTES each node's child order so
+  // that a child list that is merely a SUBSET of another can be reordered to
+  // become its tail (e.g. {A,C} laid out as the tail of {B,A,C}). Smaller
+  // still, but the resulting child lists are NOT in ascending tile order, so
+  // the KWG is invalid for kwg_compute_alpha_cross_set (the Alpha variant). It
+  // remains valid for all linear-scan readers (standard movegen, word lookup).
+  // DAWG output only.
+  KWG_MAKER_MERGE_TAIL_REORDER,
 } kwg_maker_merge_t;
 
 #endif

--- a/src/impl/convert.c
+++ b/src/impl/convert.c
@@ -125,15 +125,18 @@ void convert_from_text_with_dwl(const LetterDistribution *ld,
       return;
     }
     kwg_maker_output_t output_type = KWG_MAKER_OUTPUT_DAWG_AND_GADDAG;
-    if (conversion_type == CONVERT_TEXT2DAWG) {
+    if (conversion_type == CONVERT_TEXT2DAWG ||
+        conversion_type == CONVERT_TEXT2DAWG_TAIL_REORDER) {
       output_type = KWG_MAKER_OUTPUT_DAWG;
     } else if (conversion_type == CONVERT_TEXT2GADDAG) {
       output_type = KWG_MAKER_OUTPUT_GADDAG;
     }
-    const kwg_maker_merge_t merge_type =
-        (conversion_type == CONVERT_TEXT2KWG_TAIL_MERGE)
-            ? KWG_MAKER_MERGE_TAIL
-            : KWG_MAKER_MERGE_EXACT;
+    kwg_maker_merge_t merge_type = KWG_MAKER_MERGE_EXACT;
+    if (conversion_type == CONVERT_TEXT2KWG_TAIL_MERGE) {
+      merge_type = KWG_MAKER_MERGE_TAIL;
+    } else if (conversion_type == CONVERT_TEXT2DAWG_TAIL_REORDER) {
+      merge_type = KWG_MAKER_MERGE_TAIL_REORDER;
+    }
     KWG *kwg = make_kwg_from_words(strings, output_type, merge_type);
     kwg_write_to_file(kwg, kwg_output_filename, error_stack);
     if (!error_stack_is_empty(error_stack)) {
@@ -160,6 +163,7 @@ void convert_with_names(const LetterDistribution *ld,
       (conversion_type == CONVERT_TEXT2GADDAG) ||
       (conversion_type == CONVERT_TEXT2KWG) ||
       (conversion_type == CONVERT_TEXT2KWG_TAIL_MERGE) ||
+      (conversion_type == CONVERT_TEXT2DAWG_TAIL_REORDER) ||
       (conversion_type == CONVERT_TEXT2WORDMAP)) {
     DictionaryWordList *strings = dictionary_word_list_create();
     convert_from_text_with_dwl(ld, conversion_type, data_paths, input_name,
@@ -263,6 +267,8 @@ get_conversion_type_from_string(const char *conversion_type_string) {
     conversion_type = CONVERT_TEXT2KWG;
   } else if (strings_equal(conversion_type_string, "text2kwgtailmerge")) {
     conversion_type = CONVERT_TEXT2KWG_TAIL_MERGE;
+  } else if (strings_equal(conversion_type_string, "text2dawgtailreorder")) {
+    conversion_type = CONVERT_TEXT2DAWG_TAIL_REORDER;
   } else if (strings_equal(conversion_type_string, "dawg2text")) {
     conversion_type = CONVERT_DAWG2TEXT;
   } else if (strings_equal(conversion_type_string, "gaddag2text")) {

--- a/src/impl/kwg_maker.c
+++ b/src/impl/kwg_maker.c
@@ -751,35 +751,16 @@ static uint32_t wolges_convert_chain(WolgesConverter *converter,
   return ret;
 }
 
-static void serialize_states_to_kwg_tail_merged(const StateList *src_states,
-                                                uint32_t dawg_root,
-                                                uint32_t gaddag_root,
-                                                bool output_dawg,
-                                                bool output_gaddag, KWG *kwg) {
-  // Reorient into wolges' convention.
-  StateList states;
-  state_list_create(&states, src_states->count);
-  StateHashTable convert_table;
-  state_hash_table_create(&convert_table, src_states->count * 2 + 1,
-                          src_states->count);
-  uint32_t *memo = malloc_or_die(sizeof(uint32_t) * src_states->count);
-  for (size_t i = 0; i < src_states->count; i++) {
-    memo[i] = UINT32_MAX;
-  }
-  WolgesConverter converter = {
-      .src = src_states, .dst = &states, .table = &convert_table, .memo = memo};
-  if (output_dawg) {
-    dawg_root = wolges_convert_chain(&converter, dawg_root);
-  }
-  if (output_gaddag) {
-    gaddag_root = wolges_convert_chain(&converter, gaddag_root);
-  }
-  free(memo);
-  state_hash_table_destroy(&convert_table);
-
-  const size_t count = states.count;
+// Runs the wolges tail-merge defragger over an already wolges-convention state
+// graph (head = lowest/first-forward sibling, next_index ascending to the
+// is_end sibling which carries next_index 0) and writes the packed KWG. Does
+// not take ownership of `states`.
+static void tail_defrag_and_emit(const StateList *states, uint32_t dawg_root,
+                                 uint32_t gaddag_root, bool output_dawg,
+                                 bool output_gaddag, KWG *kwg) {
+  const size_t count = states->count;
   TailDefragger defragger = {
-      .states = states.states,
+      .states = states->states,
       .head_indexes = malloc_or_die(sizeof(uint32_t) * count),
       .to_end_lens = malloc_or_die(sizeof(uint32_t) * count),
       .destination = calloc_or_die(count, sizeof(uint32_t)),
@@ -787,8 +768,8 @@ static void serialize_states_to_kwg_tail_merged(const StateList *src_states,
       // MAGPIE readers expect both to be present.
       .num_written = 2,
   };
-  tail_compute_head_indexes(&states, defragger.head_indexes);
-  tail_compute_to_end_lens(&states, defragger.to_end_lens);
+  tail_compute_head_indexes(states, defragger.head_indexes);
+  tail_compute_to_end_lens(states, defragger.to_end_lens);
 
   // Mark the null state as placed so arc_index 0 resolves to a 0 pointer and
   // self-cycles during the walk terminate.
@@ -827,7 +808,369 @@ static void serialize_states_to_kwg_tail_merged(const StateList *src_states,
   free(defragger.head_indexes);
   free(defragger.to_end_lens);
   free(defragger.destination);
+}
+
+static void serialize_states_to_kwg_tail_merged(const StateList *src_states,
+                                                uint32_t dawg_root,
+                                                uint32_t gaddag_root,
+                                                bool output_dawg,
+                                                bool output_gaddag, KWG *kwg) {
+  // Reorient into wolges' convention.
+  StateList states;
+  state_list_create(&states, src_states->count);
+  StateHashTable convert_table;
+  state_hash_table_create(&convert_table, src_states->count * 2 + 1,
+                          src_states->count);
+  uint32_t *memo = malloc_or_die(sizeof(uint32_t) * src_states->count);
+  for (size_t i = 0; i < src_states->count; i++) {
+    memo[i] = UINT32_MAX;
+  }
+  WolgesConverter converter = {
+      .src = src_states, .dst = &states, .table = &convert_table, .memo = memo};
+  if (output_dawg) {
+    dawg_root = wolges_convert_chain(&converter, dawg_root);
+  }
+  if (output_gaddag) {
+    gaddag_root = wolges_convert_chain(&converter, gaddag_root);
+  }
+  free(memo);
+  state_hash_table_destroy(&convert_table);
+
+  tail_defrag_and_emit(&states, dawg_root, gaddag_root, output_dawg,
+                       output_gaddag, kwg);
   state_list_destroy(&states);
+}
+
+// ============================================================================
+// DAWG child-list reordering (KWG_MAKER_MERGE_TAIL_REORDER)
+//
+// Standard tail merging only overlaps a child list that is an (ascending-tile)
+// suffix of another. Sibling order is not load-bearing for linear-scan readers
+// (movegen, lookup), so we may freely PERMUTE each node's child order; then a
+// child list that is merely a SUBSET of another can be reordered to become its
+// tail. e.g. {A,C} cannot tail-merge into ascending {A,B,C}, but can if the
+// latter is laid out [B,A,C]. We pick orders with a greedy subset path-cover,
+// rebuild the state graph in those orders, and reuse the verified tail_defrag.
+//
+// Correctness rests on two facts: (1) permuting a node's children never changes
+// the accepted word set for a linear-scan reader; (2) tail_defrag only ever
+// overlaps byte-identical suffix states, so a bad ordering loses merging but is
+// never wrong. Verified by the kwgtailreorder test (word-set equality).
+//
+// WARNING: output child lists are NOT in ascending tile order, so the KWG is
+// invalid for kwg_compute_alpha_cross_set (Alpha variant). DAWG output only.
+// ============================================================================
+
+// item key (one child entry): tile in bits 48+, accepts in bit 40, arc (a full
+// 32-bit StateList index, not a serialized KWG node index) in bits 0..31.
+static inline uint64_t reorder_item_key(uint8_t tile, uint8_t accepts,
+                                        uint32_t arc) {
+  return ((uint64_t)tile << 48) | ((uint64_t)accepts << 40) | (uint64_t)arc;
+}
+static inline uint8_t reorder_key_tile(uint64_t key) {
+  return (uint8_t)(key >> 48);
+}
+static inline uint8_t reorder_key_accepts(uint64_t key) {
+  return (uint8_t)((key >> 40) & 1);
+}
+static inline uint32_t reorder_key_arc(uint64_t key) {
+  // Full 32-bit StateList index (bits 0..31); accepts/tile sit at bits 40/48.
+  return (uint32_t)key;
+}
+
+static int reorder_u64_cmp(const void *a, const void *b) {
+  const uint64_t x = *(const uint64_t *)a;
+  const uint64_t y = *(const uint64_t *)b;
+  return (x > y) - (x < y);
+}
+
+typedef struct ReorderItemHead {
+  uint64_t key;
+  uint32_t head;
+} ReorderItemHead;
+
+static int reorder_pair_cmp(const void *a, const void *b) {
+  const uint64_t x = ((const ReorderItemHead *)a)->key;
+  const uint64_t y = ((const ReorderItemHead *)b)->key;
+  return (x > y) - (x < y);
+}
+
+// Returns true if `key` is present in the sorted item array of head `h`.
+static bool reorder_head_has_item(uint64_t *const *items,
+                                  const uint32_t *item_count, uint32_t head,
+                                  uint64_t key) {
+  const uint64_t *item_keys = items[head];
+  uint32_t low_idx = 0;
+  uint32_t high_idx = item_count[head];
+  while (low_idx < high_idx) {
+    const uint32_t mid_idx = low_idx + (high_idx - low_idx) / 2;
+    if (item_keys[mid_idx] < key) {
+      low_idx = mid_idx + 1;
+    } else if (item_keys[mid_idx] > key) {
+      high_idx = mid_idx;
+    } else {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Returns true if every item of `subset_head` is also an item of
+// `superset_head`.
+static bool reorder_is_subset(uint64_t *const *items,
+                              const uint32_t *item_count, uint32_t subset_head,
+                              uint32_t superset_head) {
+  const uint64_t *subset_items = items[subset_head];
+  const uint32_t subset_count = item_count[subset_head];
+  for (uint32_t item_idx = 0; item_idx < subset_count; item_idx++) {
+    if (!reorder_head_has_item(items, item_count, superset_head,
+                               subset_items[item_idx])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+typedef struct ReorderCtx {
+  uint64_t **items; // items[h] = sorted item-key array (NULL if non-head)
+  const uint32_t *item_count;
+  const uint32_t *tail_child; // head absorbed as h's tail (UINT32_MAX = none)
+  uint32_t *new_head; // dst head index per src head (UINT32_MAX = unbuilt)
+  StateList *dst;
+  StateHashTable *table;
+} ReorderCtx;
+
+// Builds head `h`'s child chain in the dst graph in its chosen order (its tail
+// child as the suffix, the remaining items ascending in front) and returns the
+// dst index of the chain head. Recurses into the tail child and into each
+// item's subtree. Memoized via new_head.
+static uint32_t reorder_build_chain(ReorderCtx *ctx, uint32_t head) {
+  if (head == 0) {
+    return 0;
+  }
+  if (ctx->new_head[head] != UINT32_MAX) {
+    return ctx->new_head[head];
+  }
+  const uint32_t member_count = ctx->item_count[head];
+  const uint64_t *head_items = ctx->items[head];
+  const uint32_t tail_head = ctx->tail_child[head];
+  uint32_t chain_head;
+  if (tail_head != UINT32_MAX) {
+    // Lay the tail child as the suffix, then prepend the remaining items
+    // (built in descending tile order so the forward order is ascending).
+    chain_head = reorder_build_chain(ctx, tail_head);
+    for (uint32_t item_idx = member_count; item_idx-- > 0;) {
+      const uint64_t key = head_items[item_idx];
+      if (reorder_head_has_item(ctx->items, ctx->item_count, tail_head, key)) {
+        continue;
+      }
+      const uint32_t new_arc = reorder_build_chain(ctx, reorder_key_arc(key));
+      chain_head = state_hash_table_find_or_insert(
+          ctx->table, ctx->dst, reorder_key_tile(key), reorder_key_accepts(key),
+          new_arc, chain_head);
+    }
+  } else {
+    chain_head = 0;
+    for (uint32_t item_idx = member_count; item_idx-- > 0;) {
+      const uint64_t key = head_items[item_idx];
+      const uint32_t new_arc = reorder_build_chain(ctx, reorder_key_arc(key));
+      chain_head = state_hash_table_find_or_insert(
+          ctx->table, ctx->dst, reorder_key_tile(key), reorder_key_accepts(key),
+          new_arc, chain_head);
+    }
+  }
+  ctx->new_head[head] = chain_head;
+  return chain_head;
+}
+
+static KWG *make_dawg_tail_reorder(const DictionaryWordList *words) {
+  const int words_count = dictionary_word_list_get_count(words);
+  const size_t estimated_states = (size_t)words_count * 8 + 100;
+  const size_t num_buckets = estimated_states * 2 + 1;
+
+  // Build the minimal DAWG state graph (MAGPIE convention).
+  StateList states;
+  state_list_create(&states, estimated_states);
+  StateHashTable build_table;
+  state_hash_table_create(&build_table, num_buckets, estimated_states);
+  TransitionStack stack;
+  transition_stack_create(&stack, (size_t)MAX_KWG_STRING_LENGTH * 2,
+                          (size_t)MAX_KWG_STRING_LENGTH + 1);
+  const uint32_t dawg_root =
+      build_dawg_from_sorted_words(words, &states, &build_table, &stack);
+  transition_stack_destroy(&stack);
+  state_hash_table_destroy(&build_table);
+
+  const uint32_t count = (uint32_t)states.count;
+
+  // Identify distinct child lists (chain heads) and collect their item sets.
+  bool *is_head = calloc_or_die(count, sizeof(bool));
+  if (dawg_root != 0) {
+    is_head[dawg_root] = true;
+  }
+  for (uint32_t state_idx = 1; state_idx < count; state_idx++) {
+    const uint32_t arc_index = states.states[state_idx].arc_index;
+    if (arc_index != 0) {
+      is_head[arc_index] = true;
+    }
+  }
+  uint64_t **items = calloc_or_die(count, sizeof(uint64_t *));
+  uint32_t *item_count = calloc_or_die(count, sizeof(uint32_t));
+  uint32_t *tail_child = malloc_or_die(count * sizeof(uint32_t));
+  for (uint32_t head = 0; head < count; head++) {
+    tail_child[head] = UINT32_MAX;
+  }
+  size_t total_items = 0;
+  for (uint32_t head = 1; head < count; head++) {
+    if (!is_head[head]) {
+      continue;
+    }
+    uint32_t member_count = 0;
+    for (uint32_t member = head; member != 0;
+         member = states.states[member].next_index) {
+      member_count++;
+    }
+    item_count[head] = member_count;
+    total_items += member_count;
+    uint64_t *item_keys = malloc_or_die(member_count * sizeof(uint64_t));
+    uint32_t member_idx = 0;
+    for (uint32_t member = head; member != 0;
+         member = states.states[member].next_index) {
+      item_keys[member_idx++] = reorder_item_key(
+          states.states[member].tile, states.states[member].accepts,
+          states.states[member].arc_index);
+    }
+    qsort(item_keys, member_count, sizeof(uint64_t), reorder_u64_cmp);
+    items[head] = item_keys;
+  }
+
+  // Index: (item -> heads containing it), as pairs sorted by item key.
+  ReorderItemHead *pairs = malloc_or_die(total_items * sizeof(ReorderItemHead));
+  size_t pair_idx = 0;
+  for (uint32_t head = 1; head < count; head++) {
+    if (!is_head[head]) {
+      continue;
+    }
+    for (uint32_t item_idx = 0; item_idx < item_count[head]; item_idx++) {
+      pairs[pair_idx].key = items[head][item_idx];
+      pairs[pair_idx].head = head;
+      pair_idx++;
+    }
+  }
+  qsort(pairs, total_items, sizeof(ReorderItemHead), reorder_pair_cmp);
+
+  // Heads in ascending size order: absorb the smallest child lists first.
+  // Sort without a context-carrying comparator by packing (size << 32 | head)
+  // into a 64-bit key, plain-sort, then read the head index back from the low
+  // 32 bits. Full-width, so it is safe for state graphs beyond 2^22 states.
+  uint64_t *heads_by_size = malloc_or_die(count * sizeof(uint64_t));
+  uint32_t num_heads = 0;
+  for (uint32_t head = 1; head < count; head++) {
+    if (is_head[head]) {
+      heads_by_size[num_heads++] = ((uint64_t)item_count[head] << 32) | head;
+    }
+  }
+  qsort(heads_by_size, num_heads, sizeof(uint64_t), reorder_u64_cmp);
+
+  bool *has_tail = calloc_or_die(count, sizeof(bool));
+  // Greedy: for each child list (smallest first), find the smallest proper
+  // superset child list whose tail is still free, and absorb into it.
+  for (uint32_t head_rank = 0; head_rank < num_heads; head_rank++) {
+    const uint32_t subset_head = (uint32_t)heads_by_size[head_rank];
+    const uint32_t subset_size = item_count[subset_head];
+    if (subset_size == 0) {
+      continue;
+    }
+    // Bound the candidate scan by the rarest item of subset_head: the item key
+    // whose group of containing heads (a contiguous run in `pairs`) is
+    // smallest.
+    uint32_t rarest_len = UINT32_MAX;
+    uint32_t rarest_start = 0;
+    for (uint32_t item_idx = 0; item_idx < subset_size; item_idx++) {
+      const uint64_t key = items[subset_head][item_idx];
+      uint32_t low_idx = 0;
+      uint32_t high_idx = (uint32_t)total_items;
+      while (low_idx < high_idx) {
+        const uint32_t mid_idx = low_idx + (high_idx - low_idx) / 2;
+        if (pairs[mid_idx].key < key) {
+          low_idx = mid_idx + 1;
+        } else {
+          high_idx = mid_idx;
+        }
+      }
+      uint32_t group_end = low_idx;
+      while (group_end < total_items && pairs[group_end].key == key) {
+        group_end++;
+      }
+      const uint32_t group_len = group_end - low_idx;
+      if (group_len < rarest_len) {
+        rarest_len = group_len;
+        rarest_start = low_idx;
+      }
+    }
+    uint32_t best_superset = UINT32_MAX;
+    uint32_t best_superset_size = UINT32_MAX;
+    for (uint32_t pair_pos = rarest_start; pair_pos < rarest_start + rarest_len;
+         pair_pos++) {
+      const uint32_t candidate = pairs[pair_pos].head;
+      if (candidate == subset_head || has_tail[candidate] ||
+          item_count[candidate] <= subset_size) {
+        continue;
+      }
+      if (item_count[candidate] < best_superset_size &&
+          reorder_is_subset(items, item_count, subset_head, candidate)) {
+        best_superset = candidate;
+        best_superset_size = item_count[candidate];
+      }
+    }
+    if (best_superset != UINT32_MAX) {
+      tail_child[best_superset] = subset_head;
+      has_tail[best_superset] = true;
+    }
+  }
+
+  // Rebuild the state graph in the chosen orders, then tail-merge + emit.
+  StateList dst;
+  state_list_create(&dst, estimated_states);
+  StateHashTable dst_table;
+  state_hash_table_create(&dst_table, num_buckets, estimated_states);
+  uint32_t *new_head = malloc_or_die(count * sizeof(uint32_t));
+  for (uint32_t head = 0; head < count; head++) {
+    new_head[head] = UINT32_MAX;
+  }
+  ReorderCtx ctx = {.items = items,
+                    .item_count = item_count,
+                    .tail_child = tail_child,
+                    .new_head = new_head,
+                    .dst = &dst,
+                    .table = &dst_table};
+  // Build every head (ascending src index keeps subtree arcs already built).
+  for (uint32_t head = 1; head < count; head++) {
+    if (is_head[head] && new_head[head] == UINT32_MAX) {
+      reorder_build_chain(&ctx, head);
+    }
+  }
+  const uint32_t new_dawg_root =
+      (dawg_root == 0) ? 0 : reorder_build_chain(&ctx, dawg_root);
+
+  KWG *kwg = kwg_create_empty();
+  tail_defrag_and_emit(&dst, new_dawg_root, 0, true, false, kwg);
+
+  for (uint32_t head = 0; head < count; head++) {
+    free(items[head]);
+  }
+  free(items);
+  free(item_count);
+  free(tail_child);
+  free(is_head);
+  free(pairs);
+  free(heads_by_size);
+  free(has_tail);
+  free(new_head);
+  state_hash_table_destroy(&dst_table);
+  state_list_destroy(&dst);
+  state_list_destroy(&states);
+  return kwg;
 }
 
 // Fast KWG builder using compact states and transition stack
@@ -1475,6 +1818,12 @@ static inline int get_letters_in_common(const DictionaryWord *word,
 // The dictionary word list must be in alphabetical order.
 KWG *make_kwg_from_words(const DictionaryWordList *words,
                          kwg_maker_output_t output, kwg_maker_merge_t merging) {
+  if (merging == KWG_MAKER_MERGE_TAIL_REORDER) {
+    if (output != KWG_MAKER_OUTPUT_DAWG) {
+      log_fatal("KWG_MAKER_MERGE_TAIL_REORDER supports DAWG output only");
+    }
+    return make_dawg_tail_reorder(words);
+  }
   // Use the fast compact-state builder when merging is enabled
   if (merging == KWG_MAKER_MERGE_EXACT || merging == KWG_MAKER_MERGE_TAIL) {
     return make_kwg_from_words_fast(words, output, merging);
@@ -1563,6 +1912,12 @@ KWG *make_kwg_from_words(const DictionaryWordList *words,
 KWG *make_kwg_from_words_small(const DictionaryWordList *words,
                                kwg_maker_output_t output,
                                kwg_maker_merge_t merging) {
+  if (merging == KWG_MAKER_MERGE_TAIL_REORDER) {
+    if (output != KWG_MAKER_OUTPUT_DAWG) {
+      log_fatal("KWG_MAKER_MERGE_TAIL_REORDER supports DAWG output only");
+    }
+    return make_dawg_tail_reorder(words);
+  }
   // Use the fast compact-state builder when merging is enabled
   if (merging == KWG_MAKER_MERGE_EXACT || merging == KWG_MAKER_MERGE_TAIL) {
     return make_kwg_from_words_fast(words, output, merging);

--- a/test/kwg_maker_test.c
+++ b/test/kwg_maker_test.c
@@ -484,6 +484,56 @@ void test_kwg_tail_merge(void) {
   config_destroy(config);
 }
 
+// Builds the CSW21 DAWG with KWG_MAKER_MERGE_TAIL and the child-reordering
+// KWG_MAKER_MERGE_TAIL_REORDER, confirms the reordered DAWG accepts the exact
+// same word SET (child order now differs by design, so it is compared as a
+// sorted set, not position-by-position), that every node is reachable, and
+// reports the extra node-count savings from reordering.
+void test_kwg_tail_reorder(void) {
+  Config *config = config_create_or_die("set -lex CSW21");
+  Game *game = config_game_create(config);
+  const Player *player = game_get_player(game, 0);
+  const KWG *csw_kwg = player_get_kwg(player);
+  DictionaryWordList *words = dictionary_word_list_create();
+  kwg_write_words(csw_kwg, kwg_get_dawg_root_node_index(csw_kwg), words, NULL);
+
+  KWG *tail_kwg =
+      make_kwg_from_words(words, KWG_MAKER_OUTPUT_DAWG, KWG_MAKER_MERGE_TAIL);
+  KWG *reorder_kwg = make_kwg_from_words(words, KWG_MAKER_OUTPUT_DAWG,
+                                         KWG_MAKER_MERGE_TAIL_REORDER);
+
+  const int tail_nodes = kwg_get_number_of_nodes(tail_kwg);
+  const int reorder_nodes = kwg_get_number_of_nodes(reorder_kwg);
+  printf("kwg tail reorder (DAWG): tail=%d nodes, reorder=%d nodes (saved %d, "
+         "%.2f%%)\n",
+         tail_nodes, reorder_nodes, tail_nodes - reorder_nodes,
+         100.0 * (tail_nodes - reorder_nodes) / tail_nodes);
+  assert(reorder_nodes <= tail_nodes);
+
+  // Reordered DAWG must encode the identical word set.
+  bool *nodes_reached = calloc_or_die(reorder_nodes, sizeof(bool));
+  DictionaryWordList *encoded = dictionary_word_list_create();
+  kwg_write_words(reorder_kwg, kwg_get_dawg_root_node_index(reorder_kwg),
+                  encoded, nodes_reached);
+  // Compare as sets: reordering changes the DFS emission order.
+  dictionary_word_list_sort(words);
+  dictionary_word_list_sort(encoded);
+  assert_word_lists_are_equal(words, encoded);
+
+  // Every node (past the two root pointers) must be reachable: no orphans.
+  for (int node_idx = 2; node_idx < reorder_nodes; node_idx++) {
+    assert(nodes_reached[node_idx]);
+  }
+
+  free(nodes_reached);
+  dictionary_word_list_destroy(encoded);
+  dictionary_word_list_destroy(words);
+  kwg_destroy(reorder_kwg);
+  kwg_destroy(tail_kwg);
+  game_destroy(game);
+  config_destroy(config);
+}
+
 // Builds a GADDAG from `word_list` with each merge style, timing build speed.
 // This is the endgame/PEG word-prune code path (make_kwg_from_words_small,
 // OUTPUT_GADDAG), where build time — not node count — is what matters.

--- a/test/kwg_maker_test.h
+++ b/test/kwg_maker_test.h
@@ -3,6 +3,7 @@
 
 void test_kwg_maker(void);
 void test_kwg_tail_merge(void);
+void test_kwg_tail_reorder(void);
 void test_kwg_merge_build_bench(void);
 
 #endif

--- a/test/test.c
+++ b/test/test.c
@@ -159,6 +159,7 @@ static TestEntry on_demand_test_table[] = {
     {"benchns3v3", test_benchmark_nonstuck_3v3},
     {"multipv", test_multi_pv},
     {"kwgtailmerge", test_kwg_tail_merge},
+    {"kwgtailreorder", test_kwg_tail_reorder},
     {"kwgmergebench", test_kwg_merge_build_bench},
     {"kue", test_kue},
     {"monsterq", test_monster_q},


### PR DESCRIPTION
## Summary

Standard tail merging (`KWG_MAKER_MERGE_TAIL`) only overlaps a child list that is an **(ascending-tile) suffix** of another. Sibling order is not load-bearing for linear-scan readers (movegen, word lookup), so we can freely **permute** each node's child order — then a child list that is merely a **subset** of another can be reordered to become its tail. e.g. `{A,C}` cannot tail-merge into ascending `{A,B,C}`, but can if the latter is laid out `[B,A,C]`.

`KWG_MAKER_MERGE_TAIL_REORDER` (DAWG output only) picks per-node orders with a **greedy subset path-cover** (each child list absorbed as the tail of the smallest still-free superset), rebuilds the state graph in those orders, and reuses the verified `tail_defrag` layout. Exposed via `convert text2dawgtailreorder`.

## Result (CSW21 DAWG)

| layout | nodes | file |
|---|---|---|
| exact | 190,167 | 761 KB |
| tail merge | 181,991 | 728 KB |
| **tail + reorder** | **171,615** | **686 KB** |

**−5.7% vs tail merge, −9.8% vs exact (~74 KB).** The C result matches a Python prototype (171,563) within 0.03%, and the greedy lands within ~1% of the optimistic subset-maximal ceiling, so a fancier greedy won't add much.

## Correctness

Two facts make this safe, and both are tested:
1. Permuting a node's children never changes the accepted word set for a linear-scan reader.
2. `tail_defrag` only ever overlaps **byte-identical** suffix states — a bad ordering loses merging but is never wrong.

The `kwgtailreorder` on-demand test builds the CSW21 DAWG with `MERGE_TAIL` and `MERGE_TAIL_REORDER`, asserts the reordered DAWG accepts the **identical word set** (compared as a sorted set, since DFS emission order now differs by design), that **every node is reachable**, and that the node count dropped. Independently confirmed end-to-end: `convert text2dawgtailreorder` output and a plain DAWG produce the same word-set md5.

## ⚠️ Ordering caveat

Output child lists are **not** in ascending tile order, so the result is **invalid for `kwg_compute_alpha_cross_set`** (the Alpha/anagram variant, which early-exits on `tile > letter`). It is valid for all linear-scan readers (standard movegen, word lookup). Intended for **compact DAWG export** (e.g. fitting a word list on retro hardware). The mode `log_fatal`s if GADDAG output is requested.

## Notes
- Reuses the existing tail-merge defragger (factored out `tail_defrag_and_emit`); the new code is the greedy reorder + state-graph rebuild, kept in its own clearly-delimited section.
- The GADDAG already tail-merges well (separator-rooted suffixes), so reordering buys little there (~1.8% on the full gaddawg) — hence DAWG-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)