### PR TITLE
Add packed DAWG: minimal-width node serialization for small/retro targets

### DIFF
--- a/src/def/convert_defs.h
+++ b/src/def/convert_defs.h
@@ -12,6 +12,11 @@ typedef enum {
   // maximize tail merging (smallest node array). NOT valid for the Alpha
   // cross-set path; for linear-scan readers / export only.
   CONVERT_TEXT2DAWG_TAIL_REORDER,
+  // Like CONVERT_TEXT2DAWG_TAIL_REORDER, but additionally re-encodes the
+  // reorder DAWG into a "packed DAWG": each node uses only the bits it needs
+  // (minimal arc width + minimal tile width) rather than a full 32-bit word.
+  // Niche, opt-in output for fitting a word list onto small/retro hardware.
+  CONVERT_TEXT2DAWG_PACKED,
   CONVERT_DAWG2TEXT,
   CONVERT_GADDAG2TEXT,
   CONVERT_CSV2KLV,

--- a/src/ent/data_filepaths.c
+++ b/src/ent/data_filepaths.c
@@ -7,9 +7,17 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-static const char *const filepath_type_names[] = {
-    "kwg", "klv",    "board layout", "win percentage", "letter distribution",
-    "gcg", "leaves", "lexicon",      "wordmap",        "rack info table"};
+static const char *const filepath_type_names[] = {"kwg",
+                                                  "klv",
+                                                  "board layout",
+                                                  "win percentage",
+                                                  "letter distribution",
+                                                  "gcg",
+                                                  "leaves",
+                                                  "lexicon",
+                                                  "wordmap",
+                                                  "rack info table",
+                                                  "packed dawg"};
 
 void string_builder_add_directory_for_data_type(StringBuilder *sb,
                                                 const char *data_path,
@@ -21,6 +29,7 @@ void string_builder_add_directory_for_data_type(StringBuilder *sb,
   case DATA_FILEPATH_TYPE_WORDMAP:
   case DATA_FILEPATH_TYPE_LEAVES:
   case DATA_FILEPATH_TYPE_RACK_INFO_TABLE:
+  case DATA_FILEPATH_TYPE_DAWG_PACKED:
     string_builder_add_formatted_string(sb, "%s/lexica/", data_path);
     break;
   case DATA_FILEPATH_TYPE_LAYOUT:
@@ -57,6 +66,9 @@ char *get_filepath(const char *data_path, const char *data_name,
     break;
   case DATA_FILEPATH_TYPE_RACK_INFO_TABLE:
     file_ext = RACK_INFO_TABLE_EXTENSION;
+    break;
+  case DATA_FILEPATH_TYPE_DAWG_PACKED:
+    file_ext = DAWG_PACKED_EXTENSION;
     break;
   case DATA_FILEPATH_TYPE_LAYOUT:
     file_ext = TXT_EXTENSION;

--- a/src/ent/data_filepaths.h
+++ b/src/ent/data_filepaths.h
@@ -5,6 +5,7 @@
 #include "../util/string_util.h"
 
 #define KWG_EXTENSION ".kwg"
+#define DAWG_PACKED_EXTENSION ".pdawg"
 #define WORDMAP_EXTENSION ".wmp"
 #define KLV_EXTENSION ".klv2"
 #define RACK_INFO_TABLE_EXTENSION ".rit"
@@ -24,6 +25,7 @@ typedef enum {
   DATA_FILEPATH_TYPE_LEXICON,
   DATA_FILEPATH_TYPE_WORDMAP,
   DATA_FILEPATH_TYPE_RACK_INFO_TABLE,
+  DATA_FILEPATH_TYPE_DAWG_PACKED,
 } data_filepath_t;
 
 char *data_filepaths_get_readable_filename(const char *data_paths,

--- a/src/ent/dawg_packed.c
+++ b/src/ent/dawg_packed.c
@@ -1,0 +1,176 @@
+#include "dawg_packed.h"
+
+#include "../def/board_defs.h"
+#include "../def/letter_distribution_defs.h"
+#include "../util/fileproxy.h"
+#include "../util/io_util.h"
+#include "dictionary_word.h"
+#include "kwg.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Number of bits needed to represent every value in [0, max_value].
+static inline uint8_t bits_needed(uint32_t max_value) {
+  uint8_t bits = 1;
+  while ((max_value >> bits) != 0) {
+    bits++;
+  }
+  return bits;
+}
+
+DawgPacked *dawg_packed_create_from_kwg(const KWG *kwg,
+                                        bool prefer_byte_alignment) {
+  const int node_count = kwg_get_number_of_nodes(kwg);
+  uint32_t max_tile = 0;
+  for (int node_idx = 0; node_idx < node_count; node_idx++) {
+    const uint32_t tile = kwg_node_tile(kwg_node(kwg, (uint32_t)node_idx));
+    if (tile > max_tile) {
+      max_tile = tile;
+    }
+  }
+  const uint8_t tile_bits = bits_needed(max_tile);
+  // Arc indices and the root index all fall in [0, node_count - 1].
+  const uint8_t arc_bits = bits_needed((uint32_t)(node_count - 1));
+  const uint8_t raw_width = (uint8_t)(tile_bits + 2 + arc_bits);
+  uint8_t stored_width = raw_width;
+  if (prefer_byte_alignment) {
+    stored_width = (uint8_t)((raw_width + 7U) & ~7U);
+  }
+  const bool byte_aligned = (stored_width % 8U) == 0U;
+
+  const size_t total_bits = (size_t)node_count * stored_width;
+  const size_t node_bytes = (total_bits + 7U) / 8U;
+  uint8_t *node_bits = (uint8_t *)calloc_or_die(node_bytes, 1);
+
+  for (int node_idx = 0; node_idx < node_count; node_idx++) {
+    const uint32_t node = kwg_node(kwg, (uint32_t)node_idx);
+    const uint32_t arc = kwg_node_arc_index(node);
+    const uint32_t is_end = kwg_node_is_end(node) ? 1U : 0U;
+    const uint32_t accepts = kwg_node_accepts(node) ? 1U : 0U;
+    const uint32_t tile = kwg_node_tile(node);
+    const uint32_t value = arc | (is_end << arc_bits) |
+                           (accepts << (arc_bits + 1)) |
+                           (tile << (arc_bits + 2));
+    dawg_packed_bits_write(node_bits, (size_t)node_idx * stored_width,
+                           raw_width, value);
+  }
+
+  DawgPacked *dp = (DawgPacked *)malloc_or_die(sizeof(DawgPacked));
+  dp->node_bits = node_bits;
+  dp->node_bytes = node_bytes;
+  dp->node_count = (uint32_t)node_count;
+  dp->root_index = kwg_get_dawg_root_node_index(kwg);
+  dp->tile_bits = tile_bits;
+  dp->arc_bits = arc_bits;
+  dp->stored_width = stored_width;
+  dp->byte_aligned = byte_aligned;
+  return dp;
+}
+
+void dawg_packed_destroy(DawgPacked *dp) {
+  if (dp == NULL) {
+    return;
+  }
+  free(dp->node_bits);
+  free(dp);
+}
+
+void dawg_packed_write_to_file(const DawgPacked *dp, const char *filename,
+                               ErrorStack *error_stack) {
+  FILE *stream = fopen_safe(filename, "wb", error_stack);
+  if (!error_stack_is_empty(error_stack)) {
+    return;
+  }
+  uint8_t header[DAWG_PACKED_HEADER_BYTES];
+  memset(header, 0, sizeof(header));
+  memcpy(header, DAWG_PACKED_MAGIC, 4);
+  header[4] = DAWG_PACKED_VERSION;
+  header[5] = dp->tile_bits;
+  header[6] = dp->arc_bits;
+  header[7] = dp->stored_width;
+  header[8] = dp->byte_aligned ? DAWG_PACKED_FLAG_BYTE_ALIGNED : 0;
+  // header[9..11] reserved padding (already zero). Multi-byte fields are
+  // stored in the writer's native byte order: a packed DAWG is meant to be
+  // read back on the same machine, not transported across endiannesses.
+  memcpy(header + 12, &dp->node_count, sizeof(uint32_t));
+  memcpy(header + 16, &dp->root_index, sizeof(uint32_t));
+  fwrite_or_die(header, 1, sizeof(header), stream, "packed dawg header");
+  fwrite_or_die(dp->node_bits, 1, dp->node_bytes, stream, "packed dawg nodes");
+  fclose_or_die(stream);
+}
+
+DawgPacked *dawg_packed_read_from_file(const char *filename,
+                                       ErrorStack *error_stack) {
+  FILE *stream = stream_from_filename(filename, error_stack);
+  if (!error_stack_is_empty(error_stack)) {
+    return NULL;
+  }
+  uint8_t header[DAWG_PACKED_HEADER_BYTES];
+  if (fread(header, 1, sizeof(header), stream) != sizeof(header) ||
+      memcmp(header, DAWG_PACKED_MAGIC, 4) != 0 ||
+      header[4] != DAWG_PACKED_VERSION) {
+    fclose_or_die(stream);
+    error_stack_push(error_stack, ERROR_STATUS_CONVERT_MALFORMED_KWG,
+                     get_formatted_string(
+                         "malformed packed dawg header in file: %s", filename));
+    return NULL;
+  }
+  DawgPacked *dp = (DawgPacked *)malloc_or_die(sizeof(DawgPacked));
+  dp->tile_bits = header[5];
+  dp->arc_bits = header[6];
+  dp->stored_width = header[7];
+  dp->byte_aligned = (header[8] & DAWG_PACKED_FLAG_BYTE_ALIGNED) != 0;
+  memcpy(&dp->node_count, header + 12, sizeof(uint32_t));
+  memcpy(&dp->root_index, header + 16, sizeof(uint32_t));
+
+  const size_t total_bits = (size_t)dp->node_count * dp->stored_width;
+  dp->node_bytes = (total_bits + 7U) / 8U;
+  dp->node_bits = (uint8_t *)malloc_or_die(dp->node_bytes);
+  if (fread(dp->node_bits, 1, dp->node_bytes, stream) != dp->node_bytes) {
+    fclose_or_die(stream);
+    dawg_packed_destroy(dp);
+    error_stack_push(
+        error_stack, ERROR_STATUS_CONVERT_MALFORMED_KWG,
+        get_formatted_string("truncated packed dawg node data in file: %s",
+                             filename));
+    return NULL;
+  }
+  fclose_or_die(stream);
+  return dp;
+}
+
+static void dawg_packed_write_words_aux(const DawgPacked *dp,
+                                        uint32_t node_index,
+                                        MachineLetter *prefix,
+                                        int prefix_length, bool accepts,
+                                        DictionaryWordList *words) {
+  if (accepts) {
+    dictionary_word_list_add_word(words, prefix, prefix_length);
+  }
+  if (node_index == 0) {
+    return;
+  }
+  for (uint32_t node_idx = node_index;; node_idx++) {
+    const uint32_t node = dawg_packed_get_node(dp, node_idx);
+    const MachineLetter ml = (MachineLetter)kwg_node_tile(node);
+    const uint32_t arc = kwg_node_arc_index(node);
+    const bool node_accepts = kwg_node_accepts(node);
+    if (prefix_length < BOARD_DIM) {
+      prefix[prefix_length] = ml;
+    }
+    dawg_packed_write_words_aux(dp, arc, prefix, prefix_length + 1,
+                                node_accepts, words);
+    if (kwg_node_is_end(node)) {
+      break;
+    }
+  }
+}
+
+void dawg_packed_write_words(const DawgPacked *dp, DictionaryWordList *words) {
+  MachineLetter prefix[BOARD_DIM];
+  dawg_packed_write_words_aux(dp, dp->root_index, prefix, 0, false, words);
+}

--- a/src/ent/dawg_packed.c
+++ b/src/ent/dawg_packed.c
@@ -95,7 +95,12 @@ void dawg_packed_write_to_file(const DawgPacked *dp, const char *filename,
   }
   uint8_t header[DAWG_PACKED_HEADER_BYTES];
   memset(header, 0, sizeof(header));
-  memcpy(header, DAWG_PACKED_MAGIC, 4);
+  // Write the 4-byte magic tag byte-by-byte: memcpy from the string literal
+  // trips bugprone-not-null-terminated-result, since this is a binary tag, not
+  // a NUL-terminated string.
+  for (int magic_idx = 0; magic_idx < 4; magic_idx++) {
+    header[magic_idx] = (uint8_t)DAWG_PACKED_MAGIC[magic_idx];
+  }
   header[4] = DAWG_PACKED_VERSION;
   header[5] = dp->tile_bits;
   header[6] = dp->arc_bits;

--- a/src/ent/dawg_packed.c
+++ b/src/ent/dawg_packed.c
@@ -13,6 +13,14 @@
 #include <stdlib.h>
 #include <string.h>
 
+enum {
+  // A decoded node is a 32-bit KWG word: the tile occupies bits 24..31 (8
+  // bits) and the arc index bits 0..21 (KWG_ARC_INDEX_MASK, 22 bits).
+  DAWG_PACKED_MAX_TILE_BITS = 8,
+  DAWG_PACKED_MAX_ARC_BITS = 22,
+  DAWG_PACKED_MAX_NODE_BITS = 32,
+};
+
 // Number of bits needed to represent every value in [0, max_value].
 static inline uint8_t bits_needed(uint32_t max_value) {
   uint8_t bits = 1;
@@ -126,6 +134,27 @@ DawgPacked *dawg_packed_read_from_file(const char *filename,
   dp->byte_aligned = (header[8] & DAWG_PACKED_FLAG_BYTE_ALIGNED) != 0;
   memcpy(&dp->node_count, header + 12, sizeof(uint32_t));
   memcpy(&dp->root_index, header + 16, sizeof(uint32_t));
+
+  // Reject corrupt/malicious headers before trusting the fields for sizing,
+  // allocation, and bit-shift widths. arc_bits <= 22 keeps node decoding
+  // shift-safe; node_count <= 2^arc_bits (arc indices must address every node)
+  // bounds the allocation; stored_width in [raw_width, 32] keeps reads in
+  // range.
+  const uint8_t raw_width = (uint8_t)(dp->tile_bits + 2 + dp->arc_bits);
+  if (dp->tile_bits < 1 || dp->tile_bits > DAWG_PACKED_MAX_TILE_BITS ||
+      dp->arc_bits < 1 || dp->arc_bits > DAWG_PACKED_MAX_ARC_BITS ||
+      dp->stored_width < raw_width ||
+      dp->stored_width > DAWG_PACKED_MAX_NODE_BITS || dp->node_count == 0 ||
+      dp->node_count > (1U << dp->arc_bits) ||
+      dp->root_index >= dp->node_count) {
+    fclose_or_die(stream);
+    free(dp);
+    error_stack_push(
+        error_stack, ERROR_STATUS_CONVERT_MALFORMED_KWG,
+        get_formatted_string("invalid packed dawg header fields in file: %s",
+                             filename));
+    return NULL;
+  }
 
   const size_t total_bits = (size_t)dp->node_count * dp->stored_width;
   dp->node_bytes = (total_bits + 7U) / 8U;

--- a/src/ent/dawg_packed.h
+++ b/src/ent/dawg_packed.h
@@ -94,7 +94,9 @@ static inline uint32_t dawg_packed_get_node(const DawgPacked *dp,
   const uint8_t raw_width = (uint8_t)(dp->arc_bits + 2 + dp->tile_bits);
   const uint32_t value =
       dawg_packed_bits_read(dp->node_bits, bit_off, raw_width);
-  const uint32_t arc = value & ((1U << dp->arc_bits) - 1U);
+  // 64-bit shift keeps the mask well-defined even for an out-of-range
+  // arc_bits; dawg_packed_read_from_file additionally rejects such headers.
+  const uint32_t arc = value & (uint32_t)(((uint64_t)1 << dp->arc_bits) - 1U);
   const uint32_t is_end = (value >> dp->arc_bits) & 1U;
   const uint32_t accepts = (value >> (dp->arc_bits + 1)) & 1U;
   const uint32_t tile = value >> (dp->arc_bits + 2);
@@ -123,9 +125,10 @@ static inline size_t dawg_packed_get_node_bytes(const DawgPacked *dp) {
 
 void dawg_packed_destroy(DawgPacked *dp);
 
-// Builds a packed DAWG from a DAWG-only KWG. prefer_byte_alignment requests the
-// byte-aligned strategy when its overhead is small; otherwise (or when it would
-// not help) the bit-packed strategy is used.
+// Builds a packed DAWG from a DAWG-only KWG. When prefer_byte_alignment is
+// true, stored_width is rounded up to a whole number of bytes (whole-byte
+// nodes, cheaper to decode on 8-bit CPUs); when false, nodes are bit-packed at
+// the minimal width.
 DawgPacked *dawg_packed_create_from_kwg(const KWG *kwg,
                                         bool prefer_byte_alignment);
 

--- a/src/ent/dawg_packed.h
+++ b/src/ent/dawg_packed.h
@@ -1,0 +1,141 @@
+#ifndef DAWG_PACKED_H
+#define DAWG_PACKED_H
+
+#include "../def/kwg_defs.h"
+#include "../util/io_util.h"
+#include "dictionary_word.h"
+#include "kwg.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// A "packed DAWG" is a niche, opt-in serialization of a DAWG-only KWG whose
+// 32-bit nodes have been re-encoded into the minimum number of bits each node
+// actually needs. It is intended for fitting a full word list onto retro
+// hardware, NOT for mainline MAGPIE: the regular 32-bit KWG remains the default
+// everywhere and is produced unchanged.
+//
+// Each node carries the same four fields as a KWG node -- tile, accepts,
+// is_end, and a first-child arc index -- but the arc index is widened only to
+// cover the real node count and the tile only to cover the lexicon's largest
+// machine letter. The fields are laid out low-to-high exactly like the 32-bit
+// KWG layout (arc, then is_end, then accepts, then tile) so that a decoded
+// node can be handed straight to the kwg_node_* accessors.
+//
+// The serializer picks one of two storage strategies and records the choice in
+// the header so the reader stays trivial:
+//   * bit-packed: node i begins at bit i * stored_width (smallest output);
+//   * byte-aligned: stored_width is rounded up to a whole number of bytes so
+//     node i begins at byte i * (stored_width / 8) -- a few wasted bits in
+//     exchange for decoding that costs no cross-byte shifting (cheap on 8-bit
+//     CPUs).
+//
+// The node array is a bit-stream packed LSB-first into bytes, so it is
+// identical on any CPU. The few multi-byte header fields are written in the
+// machine's native byte order: a packed DAWG reads back correctly on a machine
+// of the same endianness (the intended use), but is not portable across
+// endiannesses -- which is fine, since it never needs to be transported.
+//
+// Because child order within a node's list is preserved verbatim from the
+// source KWG, a packed DAWG built from a KWG_MAKER_MERGE_TAIL_REORDER DAWG
+// inherits that DAWG's caveat: it is valid for linear-scan readers and word
+// lookup, but NOT for the Alpha cross-set path.
+
+enum {
+  DAWG_PACKED_VERSION = 1,
+  // 4 magic + 1 version + 1 tile_bits + 1 arc_bits + 1 stored_width + 1 flags +
+  // 3 pad + 4 node_count + 4 root_index.
+  DAWG_PACKED_HEADER_BYTES = 20,
+  DAWG_PACKED_FLAG_BYTE_ALIGNED = 0x1,
+};
+
+#define DAWG_PACKED_MAGIC "PDWG"
+
+typedef struct DawgPacked {
+  uint8_t *node_bits;
+  size_t node_bytes;
+  uint32_t node_count;
+  uint32_t root_index;
+  uint8_t tile_bits;
+  uint8_t arc_bits;
+  uint8_t stored_width;
+  bool byte_aligned;
+} DawgPacked;
+
+// Reads nbits (<= 32) starting at bit_off from a little-bit-endian (LSB-first
+// within each byte) packed array.
+static inline uint32_t dawg_packed_bits_read(const uint8_t *bits,
+                                             size_t bit_off, uint8_t nbits) {
+  uint32_t result = 0;
+  for (uint8_t bit_idx = 0; bit_idx < nbits; bit_idx++) {
+    const size_t pos = bit_off + bit_idx;
+    const uint32_t bit = (bits[pos >> 3] >> (pos & 7)) & 1U;
+    result |= bit << bit_idx;
+  }
+  return result;
+}
+
+static inline void dawg_packed_bits_write(uint8_t *bits, size_t bit_off,
+                                          uint8_t nbits, uint32_t value) {
+  for (uint8_t bit_idx = 0; bit_idx < nbits; bit_idx++) {
+    const size_t pos = bit_off + bit_idx;
+    const uint32_t bit = (value >> bit_idx) & 1U;
+    bits[pos >> 3] =
+        (uint8_t)((bits[pos >> 3] & ~(1U << (pos & 7))) | (bit << (pos & 7)));
+  }
+}
+
+// Decodes packed node node_index back into a 32-bit value using the standard
+// KWG node layout, so kwg_node_is_end / kwg_node_accepts / kwg_node_arc_index /
+// kwg_node_tile all apply.
+static inline uint32_t dawg_packed_get_node(const DawgPacked *dp,
+                                            uint32_t node_index) {
+  const size_t bit_off = (size_t)node_index * dp->stored_width;
+  const uint8_t raw_width = (uint8_t)(dp->arc_bits + 2 + dp->tile_bits);
+  const uint32_t value =
+      dawg_packed_bits_read(dp->node_bits, bit_off, raw_width);
+  const uint32_t arc = value & ((1U << dp->arc_bits) - 1U);
+  const uint32_t is_end = (value >> dp->arc_bits) & 1U;
+  const uint32_t accepts = (value >> (dp->arc_bits + 1)) & 1U;
+  const uint32_t tile = value >> (dp->arc_bits + 2);
+  uint32_t node = arc;
+  if (is_end != 0) {
+    node |= KWG_NODE_IS_END_FLAG;
+  }
+  if (accepts != 0) {
+    node |= KWG_NODE_ACCEPTS_FLAG;
+  }
+  node |= tile << KWG_TILE_BIT_OFFSET;
+  return node;
+}
+
+static inline uint32_t dawg_packed_get_node_count(const DawgPacked *dp) {
+  return dp->node_count;
+}
+
+static inline uint32_t dawg_packed_get_root_index(const DawgPacked *dp) {
+  return dp->root_index;
+}
+
+static inline size_t dawg_packed_get_node_bytes(const DawgPacked *dp) {
+  return dp->node_bytes;
+}
+
+void dawg_packed_destroy(DawgPacked *dp);
+
+// Builds a packed DAWG from a DAWG-only KWG. prefer_byte_alignment requests the
+// byte-aligned strategy when its overhead is small; otherwise (or when it would
+// not help) the bit-packed strategy is used.
+DawgPacked *dawg_packed_create_from_kwg(const KWG *kwg,
+                                        bool prefer_byte_alignment);
+
+void dawg_packed_write_to_file(const DawgPacked *dp, const char *filename,
+                               ErrorStack *error_stack);
+
+DawgPacked *dawg_packed_read_from_file(const char *filename,
+                                       ErrorStack *error_stack);
+
+// Appends every word reachable from the packed DAWG's root to words.
+void dawg_packed_write_words(const DawgPacked *dp, DictionaryWordList *words);
+
+#endif

--- a/src/impl/convert.c
+++ b/src/impl/convert.c
@@ -6,6 +6,7 @@
 #include "../def/letter_distribution_defs.h"
 #include "../ent/conversion_results.h"
 #include "../ent/data_filepaths.h"
+#include "../ent/dawg_packed.h"
 #include "../ent/dictionary_word.h"
 #include "../ent/klv.h"
 #include "../ent/klv_csv.h"
@@ -118,6 +119,31 @@ void convert_from_text_with_dwl(const LetterDistribution *ld,
     }
     wmp_destroy(wmp);
     free(wmp_output_filename);
+  } else if (conversion_type == CONVERT_TEXT2DAWG_PACKED) {
+    char *packed_output_filename = data_filepaths_get_writable_filename(
+        data_paths, output_name, DATA_FILEPATH_TYPE_DAWG_PACKED, error_stack);
+    if (!error_stack_is_empty(error_stack)) {
+      return;
+    }
+    // Build the reorder DAWG, then re-encode it into minimal-width nodes. The
+    // CLI default is bit-packed (smallest); the byte-aligned strategy is for
+    // callers who decode on hardware that pays for cross-byte shifts.
+    KWG *kwg = make_kwg_from_words(strings, KWG_MAKER_OUTPUT_DAWG,
+                                   KWG_MAKER_MERGE_TAIL_REORDER);
+    DawgPacked *dp = dawg_packed_create_from_kwg(kwg, false);
+    dawg_packed_write_to_file(dp, packed_output_filename, error_stack);
+    if (!error_stack_is_empty(error_stack)) {
+      error_stack_push(
+          error_stack, ERROR_STATUS_CONVERT_OUTPUT_FILE_NOT_WRITABLE,
+          get_formatted_string("could not write packed dawg to output file: %s",
+                               packed_output_filename));
+    } else {
+      conversion_results_set_number_of_strings(
+          conversion_results, dictionary_word_list_get_count(strings));
+    }
+    dawg_packed_destroy(dp);
+    kwg_destroy(kwg);
+    free(packed_output_filename);
   } else {
     char *kwg_output_filename = data_filepaths_get_writable_filename(
         data_paths, output_name, DATA_FILEPATH_TYPE_KWG, error_stack);
@@ -164,6 +190,7 @@ void convert_with_names(const LetterDistribution *ld,
       (conversion_type == CONVERT_TEXT2KWG) ||
       (conversion_type == CONVERT_TEXT2KWG_TAIL_MERGE) ||
       (conversion_type == CONVERT_TEXT2DAWG_TAIL_REORDER) ||
+      (conversion_type == CONVERT_TEXT2DAWG_PACKED) ||
       (conversion_type == CONVERT_TEXT2WORDMAP)) {
     DictionaryWordList *strings = dictionary_word_list_create();
     convert_from_text_with_dwl(ld, conversion_type, data_paths, input_name,
@@ -269,6 +296,8 @@ get_conversion_type_from_string(const char *conversion_type_string) {
     conversion_type = CONVERT_TEXT2KWG_TAIL_MERGE;
   } else if (strings_equal(conversion_type_string, "text2dawgtailreorder")) {
     conversion_type = CONVERT_TEXT2DAWG_TAIL_REORDER;
+  } else if (strings_equal(conversion_type_string, "text2dawgpacked")) {
+    conversion_type = CONVERT_TEXT2DAWG_PACKED;
   } else if (strings_equal(conversion_type_string, "dawg2text")) {
     conversion_type = CONVERT_DAWG2TEXT;
   } else if (strings_equal(conversion_type_string, "gaddag2text")) {

--- a/test/dawg_packed_test.c
+++ b/test/dawg_packed_test.c
@@ -108,7 +108,9 @@ static void assert_rejects_bad_header(void) {
   const char *filename = "dawg_packed_bad_header_test.pdawg";
   uint8_t header[DAWG_PACKED_HEADER_BYTES];
   memset(header, 0, sizeof(header));
-  memcpy(header, DAWG_PACKED_MAGIC, 4);
+  for (int magic_idx = 0; magic_idx < 4; magic_idx++) {
+    header[magic_idx] = (uint8_t)DAWG_PACKED_MAGIC[magic_idx];
+  }
   header[4] = DAWG_PACKED_VERSION;
   header[5] = 5;  // tile_bits
   header[6] = 99; // arc_bits: out of range

--- a/test/dawg_packed_test.c
+++ b/test/dawg_packed_test.c
@@ -66,7 +66,7 @@ static void check_packed_mode(const KWG *reorder_kwg,
   }
 
   // File round-trip.
-  const char *filename = "dawg_packed_round_trip_test.pdwg";
+  const char *filename = "dawg_packed_round_trip_test.pdawg";
   ErrorStack *error_stack = error_stack_create();
   dawg_packed_write_to_file(dp, filename, error_stack);
   assert(error_stack_is_empty(error_stack));
@@ -100,6 +100,30 @@ static void check_packed_mode(const KWG *reorder_kwg,
   dawg_packed_destroy(loaded);
   error_stack_destroy(error_stack);
   dawg_packed_destroy(dp);
+}
+
+// A corrupt header (here, an out-of-range arc_bits) must be rejected cleanly
+// rather than triggering a huge allocation or an out-of-range shift.
+static void assert_rejects_bad_header(void) {
+  const char *filename = "dawg_packed_bad_header_test.pdawg";
+  uint8_t header[DAWG_PACKED_HEADER_BYTES];
+  memset(header, 0, sizeof(header));
+  memcpy(header, DAWG_PACKED_MAGIC, 4);
+  header[4] = DAWG_PACKED_VERSION;
+  header[5] = 5;  // tile_bits
+  header[6] = 99; // arc_bits: out of range
+  header[7] = 24; // stored_width
+  ErrorStack *error_stack = error_stack_create();
+  FILE *stream = fopen_safe(filename, "wb", error_stack);
+  assert(error_stack_is_empty(error_stack));
+  fwrite_or_die(header, 1, sizeof(header), stream, "bad packed dawg header");
+  fclose_or_die(stream);
+
+  const DawgPacked *dp = dawg_packed_read_from_file(filename, error_stack);
+  assert(dp == NULL);
+  assert(!error_stack_is_empty(error_stack));
+  error_stack_destroy(error_stack);
+  (void)remove(filename);
 }
 
 void test_dawg_packed(void) {
@@ -140,6 +164,7 @@ void test_dawg_packed(void) {
 
   check_packed_mode(reorder_kwg, words, false);
   check_packed_mode(reorder_kwg, words, true);
+  assert_rejects_bad_header();
 
   dictionary_word_list_destroy(words);
   kwg_destroy(reorder_kwg);

--- a/test/dawg_packed_test.c
+++ b/test/dawg_packed_test.c
@@ -1,0 +1,148 @@
+#include "../src/def/kwg_defs.h"
+#include "../src/ent/dawg_packed.h"
+#include "../src/ent/dictionary_word.h"
+#include "../src/ent/game.h"
+#include "../src/ent/kwg.h"
+#include "../src/ent/player.h"
+#include "../src/impl/config.h"
+#include "../src/impl/kwg_maker.h"
+#include "../src/util/io_util.h"
+#include "test_util.h"
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+enum {
+  // NWL23 capped at 8 letters: small enough that the byte-aligned strategy
+  // lands on sub-32-bit nodes (the retro target), and a realistic word list
+  // for fitting onto constrained hardware.
+  MAX_TEST_WORD_LENGTH = 8,
+};
+
+static void assert_same_word_set(DictionaryWordList *expected,
+                                 DictionaryWordList *actual) {
+  dictionary_word_list_sort(expected);
+  dictionary_word_list_sort(actual);
+  assert(dictionary_word_list_get_count(expected) ==
+         dictionary_word_list_get_count(actual));
+  for (int word_idx = 0; word_idx < dictionary_word_list_get_count(expected);
+       word_idx++) {
+    const DictionaryWord *expected_word =
+        dictionary_word_list_get_word(expected, word_idx);
+    const DictionaryWord *actual_word =
+        dictionary_word_list_get_word(actual, word_idx);
+    assert(dictionary_word_get_length(expected_word) ==
+           dictionary_word_get_length(actual_word));
+    assert(memcmp(dictionary_word_get_word(expected_word),
+                  dictionary_word_get_word(actual_word),
+                  dictionary_word_get_length(expected_word)) == 0);
+  }
+}
+
+// Verifies that a packed DAWG built in `prefer_byte_alignment` mode encodes the
+// reorder DAWG losslessly: every decoded node matches the source KWG, the
+// blob survives a file round-trip, and the word set is preserved.
+static void check_packed_mode(const KWG *reorder_kwg,
+                              const DictionaryWordList *words,
+                              bool prefer_byte_alignment) {
+  const int node_count = kwg_get_number_of_nodes(reorder_kwg);
+  DawgPacked *dp =
+      dawg_packed_create_from_kwg(reorder_kwg, prefer_byte_alignment);
+
+  printf("packed dawg (%s): %d nodes, tile_bits=%u arc_bits=%u stored_width=%u "
+         "-> %zu bytes (vs %d bytes at 32 bits, %.2f%%)\n",
+         prefer_byte_alignment ? "byte-aligned" : "bit-packed", node_count,
+         dp->tile_bits, dp->arc_bits, dp->stored_width,
+         dawg_packed_get_node_bytes(dp), node_count * 4,
+         100.0 * (double)dawg_packed_get_node_bytes(dp) / (node_count * 4));
+
+  // Decoded nodes must be identical to the source 32-bit KWG nodes.
+  for (int node_idx = 0; node_idx < node_count; node_idx++) {
+    assert(dawg_packed_get_node(dp, (uint32_t)node_idx) ==
+           kwg_node(reorder_kwg, (uint32_t)node_idx));
+  }
+
+  // File round-trip.
+  const char *filename = "dawg_packed_round_trip_test.pdwg";
+  ErrorStack *error_stack = error_stack_create();
+  dawg_packed_write_to_file(dp, filename, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  DawgPacked *loaded = dawg_packed_read_from_file(filename, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(loaded != NULL);
+  assert(loaded->node_count == dp->node_count);
+  assert(loaded->root_index == dp->root_index);
+  assert(loaded->tile_bits == dp->tile_bits);
+  assert(loaded->arc_bits == dp->arc_bits);
+  assert(loaded->stored_width == dp->stored_width);
+  assert(loaded->byte_aligned == dp->byte_aligned);
+  assert(dawg_packed_get_node_bytes(loaded) == dawg_packed_get_node_bytes(dp));
+  assert(memcmp(loaded->node_bits, dp->node_bits, dp->node_bytes) == 0);
+
+  // Word set must round-trip through the loaded packed DAWG.
+  DictionaryWordList *decoded = dictionary_word_list_create();
+  dawg_packed_write_words(loaded, decoded);
+  DictionaryWordList *expected = dictionary_word_list_create();
+  for (int word_idx = 0; word_idx < dictionary_word_list_get_count(words);
+       word_idx++) {
+    const DictionaryWord *word = dictionary_word_list_get_word(words, word_idx);
+    dictionary_word_list_add_word(expected, dictionary_word_get_word(word),
+                                  dictionary_word_get_length(word));
+  }
+  assert_same_word_set(expected, decoded);
+
+  (void)remove(filename);
+  dictionary_word_list_destroy(expected);
+  dictionary_word_list_destroy(decoded);
+  dawg_packed_destroy(loaded);
+  error_stack_destroy(error_stack);
+  dawg_packed_destroy(dp);
+}
+
+void test_dawg_packed(void) {
+  Config *config = config_create_or_die("set -lex NWL23");
+  Game *game = config_game_create(config);
+  const KWG *nwl_kwg = player_get_kwg(game_get_player(game, 0));
+  DictionaryWordList *all_words = dictionary_word_list_create();
+  kwg_write_words(nwl_kwg, kwg_get_dawg_root_node_index(nwl_kwg), all_words,
+                  NULL);
+
+  // Cap word length to emulate a constrained-hardware word list.
+  DictionaryWordList *words = dictionary_word_list_create();
+  for (int word_idx = 0; word_idx < dictionary_word_list_get_count(all_words);
+       word_idx++) {
+    const DictionaryWord *word =
+        dictionary_word_list_get_word(all_words, word_idx);
+    if (dictionary_word_get_length(word) <= MAX_TEST_WORD_LENGTH) {
+      dictionary_word_list_add_word(words, dictionary_word_get_word(word),
+                                    dictionary_word_get_length(word));
+    }
+  }
+  dictionary_word_list_destroy(all_words);
+
+  KWG *reorder_kwg = make_kwg_from_words(words, KWG_MAKER_OUTPUT_DAWG,
+                                         KWG_MAKER_MERGE_TAIL_REORDER);
+
+  // Both strategies must beat the 32-bit-per-node baseline for this corpus,
+  // and the byte-aligned strategy must produce whole-byte nodes.
+  const int node_count = kwg_get_number_of_nodes(reorder_kwg);
+  DawgPacked *bit_packed = dawg_packed_create_from_kwg(reorder_kwg, false);
+  assert(dawg_packed_get_node_bytes(bit_packed) < (size_t)node_count * 4);
+  dawg_packed_destroy(bit_packed);
+  DawgPacked *byte_aligned = dawg_packed_create_from_kwg(reorder_kwg, true);
+  assert(byte_aligned->byte_aligned);
+  assert((byte_aligned->stored_width % 8U) == 0U);
+  assert(dawg_packed_get_node_bytes(byte_aligned) < (size_t)node_count * 4);
+  dawg_packed_destroy(byte_aligned);
+
+  check_packed_mode(reorder_kwg, words, false);
+  check_packed_mode(reorder_kwg, words, true);
+
+  dictionary_word_list_destroy(words);
+  kwg_destroy(reorder_kwg);
+  game_destroy(game);
+  config_destroy(config);
+}

--- a/test/dawg_packed_test.h
+++ b/test/dawg_packed_test.h
@@ -1,0 +1,6 @@
+#ifndef DAWG_PACKED_TEST_H
+#define DAWG_PACKED_TEST_H
+
+void test_dawg_packed(void);
+
+#endif

--- a/test/test.c
+++ b/test/test.c
@@ -21,6 +21,7 @@
 #include "convert_test.h"
 #include "create_data_test.h"
 #include "cross_set_test.h"
+#include "dawg_packed_test.h"
 #include "endgame_test.h"
 #include "equity_adjustment_test.h"
 #include "equity_test.h"
@@ -160,6 +161,7 @@ static TestEntry on_demand_test_table[] = {
     {"multipv", test_multi_pv},
     {"kwgtailmerge", test_kwg_tail_merge},
     {"kwgtailreorder", test_kwg_tail_reorder},
+    {"dawgpacked", test_dawg_packed},
     {"kwgmergebench", test_kwg_merge_build_bench},
     {"kue", test_kue},
     {"monsterq", test_monster_q},


### PR DESCRIPTION
A niche, opt-in serialization that re-encodes a reorder DAWG's 32-bit nodes into the minimum bits each needs — the arc index widened only to the real node count, the tile only to the lexicon's largest machine letter. Intended for fitting a word list onto constrained/retro hardware. **Mainline KWG stays the 32-bit default and its output is byte-for-byte unchanged** (no edits to any KWG build/serialize code).

## What's here
- **`src/ent/dawg_packed.{h,c}`** — encoder from a DAWG-only KWG, native-endian writer/reader, and a decoder that reconstructs standard 32-bit node values so the existing `kwg_node_*` accessors apply unchanged.
  - **Configurable width**: bit-packed (smallest) or byte-aligned (whole-byte nodes, cheap to decode on 8-bit CPUs — no cross-byte shifting). The header records the choice so the reader stays trivial.
  - The node array is an LSB-first bit-stream (identical on any CPU); only the header `u32`s are native-endian. No cross-endian interop is needed or claimed.
- **`convert.c`** — `CONVERT_TEXT2DAWG_PACKED` (`text2dawgpacked`), writing a `.pdawg` file.
- **`test/dawg_packed_test.c`** (key `dawgpacked`) — NWL23 capped at 8 letters; **full round trip through a file** (write → read → traverse → word-set compare), per-node equality against the source KWG, and byte-identical reload — in both bit-packed and byte-aligned modes.

## Results
NWL23 ≤ 8 letters (59,562 nodes): bit-packed 23-bit nodes = **71.9%** of the 32-bit baseline; byte-aligned lands on clean **3-byte nodes** = 75.0%. The full NWL23 reorder DAWG (124,265 nodes) packs to 3-byte nodes as well (75%).

## Performance
Strictly neutral for production KWGs *by construction*: the only `src/` use is `convert.c`'s cold conversion path; the bit-stream decoder is called only by the packed format's own reader and the test. Zero new code in movegen/lookup/endgame. (The packed format is a size-optimized *storage* format, not a fast runtime format — production should keep using the 32-bit KWG.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)