### PR TITLE
Disable BitRack-keyed caches for BitRack-incompatible letter distributions

### DIFF
--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -2721,6 +2721,7 @@ void gen_load_position(MoveGen *gen, const MoveGenArgs *args) {
   const Player *opponent = game_get_player(game, 1 - gen->player_index);
 
   memcpy(&gen->ld, game_get_ld(game), sizeof(LetterDistribution));
+  gen->bit_rack_compatible = bit_rack_is_compatible_with_ld(&gen->ld);
   gen->kwg = player_get_kwg(player);
   gen->kwg = (override_kwg == NULL) ? player_get_kwg(player) : override_kwg;
   const KLV *new_klv = player_get_klv(player);
@@ -2751,7 +2752,10 @@ void gen_load_position(MoveGen *gen, const MoveGenArgs *args) {
   gen->klv = new_klv;
   gen->klv_mutation_counter_at_load = new_klv_mutation_counter;
   gen->klv_instance_fp_at_load = new_klv_instance_fp;
-  const RackInfoTable *new_rit = player_get_rack_info_table(player);
+  // The RIT keys on a BitRack, so it is unusable for a BitRack-incompatible
+  // alphabet; treat it as absent (the WMP is gated the same way below).
+  const RackInfoTable *new_rit =
+      gen->bit_rack_compatible ? player_get_rack_info_table(player) : NULL;
   if (new_rit != gen->rack_info_table) {
     memset(gen->rit_cache_valid, 0, sizeof(gen->rit_cache_valid));
     // Leave values are stored in the subrack cache; they depend on the
@@ -2767,8 +2771,10 @@ void gen_load_position(MoveGen *gen, const MoveGenArgs *args) {
   move_list_set_rack(move_list, &gen->player_rack);
   rack_set_dist_size(&gen->leave, ld_get_size(&gen->ld));
   const WMP *previous_wmp = gen->wmp_move_gen.wmp;
+  // The WMP keys on a BitRack, so it is unusable for a BitRack-incompatible
+  // alphabet; pass NULL so wmp_move_gen stays inactive (no BitRack is built).
   wmp_move_gen_init(&gen->wmp_move_gen, &gen->ld, &gen->player_rack,
-                    player_get_wmp(player));
+                    gen->bit_rack_compatible ? player_get_wmp(player) : NULL);
 
   if (gen->move_record_type == MOVE_RECORD_ALL_SMALL ||
       gen->move_record_type == MOVE_RECORD_TILES_PLAYED ||
@@ -2876,6 +2882,8 @@ void gen_look_up_leaves_and_record_exchanges(MoveGen *gen) {
   const RackInfoTable *rit = gen->rack_info_table;
   gen->rit_entry = NULL;
 
+  // rit is NULL for BitRack-incompatible alphabets (gated in
+  // gen_load_position), so this RIT-cache path is already skipped for them.
   if (has_full_rack && rit != NULL) {
     const BitRack player_bit_rack =
         bit_rack_create_from_rack(&gen->ld, &gen->player_rack);
@@ -2933,7 +2941,10 @@ void gen_look_up_leaves_and_record_exchanges(MoveGen *gen) {
     // requires recording the actual exchange moves (which goes through
     // the RIT-alike generate_exchange_moves_from_table, skipping the
     // KLV descent either way).
-    const bool kle_eligible = has_full_rack;
+    // Unlike the RIT/WMP caches (gated by being NULL), this KLV-leaves cache is
+    // always available, so it must consult bit_rack_compatible directly: its
+    // key is a BitRack, unrepresentable for a too-large alphabet.
+    const bool kle_eligible = has_full_rack && gen->bit_rack_compatible;
     const BitRack kle_bit_rack =
         kle_eligible ? bit_rack_create_from_rack(&gen->ld, &gen->player_rack)
                      : bit_rack_create_empty();

--- a/src/impl/move_gen.h
+++ b/src/impl/move_gen.h
@@ -221,6 +221,12 @@ typedef struct MoveGen {
   KlvLeavesCacheEntry klv_leaves_cache[MOVEGEN_KLV_LEAVES_CACHE_SIZE];
   const Board *board;
   LetterDistribution ld;
+  // Whether ld fits a BitRack: <= BIT_RACK_MAX_ALPHABET_SIZE machine letters
+  // (4-bit letter index) and <= 15 of any one letter, blanks included (4-bit
+  // per-letter count) -- see bit_rack_is_compatible_with_ld. The RIT cache,
+  // KLV-leaves cache, and WMP all key on a BitRack, so all three are disabled
+  // when this is false. Set in gen_load_position.
+  bool bit_rack_compatible;
   MoveList *move_list;
   AnchorHeap anchor_heap;
   Equity tile_scores[MACHINE_LETTER_MAX_VALUE];

--- a/test/move_gen_test.c
+++ b/test/move_gen_test.c
@@ -1620,6 +1620,45 @@ void test_move_gen_instance_fingerprint(void) {
   error_stack_destroy(error_stack);
 }
 
+// Regression: an alphabet too large for a BitRack (Polish has more than
+// BIT_RACK_MAX_ALPHABET_SIZE letters) must not build a BitRack cache key during
+// move generation -- doing so shifts a uint64_t by >= 64 (undefined behavior).
+// With a full rack and equity sort the generator takes its RIT / KLV-leaves
+// cache path, which is where the BitRack key was built; this drives that path
+// for such an alphabet and asserts it completes and produces moves (under the
+// sanitizer build, a reintroduced shift would be caught here).
+void large_alphabet_movegen_test(void) {
+  Config *config = config_create_or_die(
+      "set -lex OSPS49 -s1 equity -s2 equity -r1 all -r2 all -numplays 1 "
+      "-wmp false");
+  Game *game = config_game_create(config);
+  // Precondition for the path under test: this alphabet does not fit a BitRack.
+  assert(!bit_rack_is_compatible_with_ld(game_get_ld(game)));
+  game_seed(game, 42);
+  draw_to_full_rack(game, 0);
+  MoveList *move_list = move_list_create(1000);
+  const MoveGenArgs move_gen_args = {
+      .game = game,
+      .move_list = move_list,
+      .move_record_type = MOVE_RECORD_ALL,
+      .move_sort_type = MOVE_SORT_EQUITY,
+      .override_kwg = NULL,
+      .eq_margin_movegen = 0,
+      .target_equity = EQUITY_MAX_VALUE,
+      .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+  };
+  generate_moves_for_game(&move_gen_args);
+  // The point of this test is that the leave/exchange path ran without
+  // tripping the BitRack shift; the move list is a bounded top-equity heap, so
+  // assert only that generation produced moves (not that a specific
+  // non-scoring play survived eviction).
+  assert(count_scoring_plays(move_list) + count_nonscoring_plays(move_list) >
+         0);
+  move_list_destroy(move_list);
+  game_destroy(game);
+  config_destroy(config);
+}
+
 void test_move_gen(void) {
   test_move_gen_instance_fingerprint();
   leave_lookup_test();
@@ -1651,4 +1690,5 @@ void test_move_gen(void) {
   wmp_blank_possibilities_bananas_3();
   wmp_blank_possibilities_bananas_4();
   wmp_blank_possibilities_bananas_5();
+  large_alphabet_movegen_test();
 }


### PR DESCRIPTION
## What this changes

A `BitRack` is a 128-bit multiset key that packs `BIT_RACK_BITS_PER_LETTER` (4) bits × `BIT_RACK_MAX_ALPHABET_SIZE` (32) letters. It can therefore only represent a letter distribution with **≤ 32 machine letters and ≤ 15 of any single letter** (blanks included) — precisely the `bit_rack_is_compatible_with_ld()` predicate.

Three move-generation subsystems use a BitRack as a key — the **RIT cache**, the **KLV-leaves cache**, and the **WMP**. The invariant should be: *for a BitRack-incompatible distribution, none of them engage.* Nothing enforced it. `bit_rack_is_compatible_with_ld()` was referenced only in a unit test; WMP and RIT stayed inert for large alphabets purely because such lexicons ship no `.wmp` / rack-info-table files.

This PR makes the invariant explicit and enforced centrally in `gen_load_position`:

- Cache `gen->bit_rack_compatible = bit_rack_is_compatible_with_ld(&gen->ld)` once per position.
- When false, treat the **RIT** and **WMP** as absent (`NULL`), so neither builds a BitRack (`wmp_move_gen_init(NULL)` is the existing inactive path).
- The **KLV-leaves cache** is always available (not gated by a nullable resource), so it consults the flag directly.

For a compatible distribution (every common lexicon — English, French, Catalan, …) this is a **no-op**: the gates resolve to the prior values.

## The bug it fixes

The KLV-leaves cache (`gen->klv_leaves_cache`) is on for any equity-sorted generation with a full rack and built its BitRack key **unconditionally**. For an incompatible alphabet (e.g. **Polish `OSPS49`, 33 letters**), the `ml = 32` iteration of `bit_rack_create_from_rack` runs `bit_rack.high |= x << (shift - 64)` with `shift = 128` — a shift of 64 on a `uint64_t`, undefined behavior:

```
src/ent/bit_rack.h: runtime error: shift exponent 64 is too large for 64-bit type 'uint64_t'
```

It is reached on the ordinary best-move path, **independent of the WordMap**:

```
#0 bit_rack_create_from_rack             bit_rack.h
#1 gen_look_up_leaves_and_record_exchanges  move_gen.c   ← KLV-leaves cache
#2 generate_moves
#3 get_top_equity_move                   gameplay.c       (set -lex OSPS49 -wmp false)
```

On arm64 `x << 64` wraps the shift count mod 64 rather than dropping the bits, so beyond the UB the key can also *collide* — two distinct racks comparing equal and returning a wrong cached leave value.

## Validation

- **Before/after** under dev ASAN/UBSAN with `UBSAN_OPTIONS=halt_on_error=1`: the shift error fires without the fix and is gone with the central gate alone. Polish (`OSPS49`) and English (`CSW24`, which exercises the RIT/KLV cache) autoplay both run clean.
- New regression test `large_alphabet_movegen_test` generates `OSPS49` moves with a full rack + equity sort (the cache path). The full `movegen` and `bitrack` suites pass (`BUILD=release`).
- `format.py`, `cppcheck` (no errors), and circular-deps all clean.

Only distributions with **more than 32 letters** (or more than 15 of a letter) are affected — Polish qualifies; the common lexicons fit — which is why it had not surfaced.

(Supersedes #570, which auto-closed when its branch was renamed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LvFYMgVajp5e5U4m2rtaB