### PR TITLE
Small-lexicon toolkit: acdawg, compact leaves, playability metrics, subset selection

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -100,6 +100,11 @@ jobs:
             tests: "config movegen gameplay players string alpha ld l leavemap kwg bag rack bitrack board layout cs move game vm shadow eq eqadj stats infer rv am"
           - shard: rest
             tests: "hm math bai command gcg words wordprune kwgmaker cgp rl ch cv cd wmp wmpmaker wmg winpct zobrist tt load"
+          - shard: retro
+            # Small/retro-target formats (arc-compressed + packed DAWG, compact
+            # leaves) and playability metrics. acdawg, clv and playability also
+            # run Polish (OSPS49) internally to flex the large-alphabet paths.
+            tests: "dawgarccompressed dawgpacked clv playability"
           - shard: ap_rit
             tests: "ap_rit"
     steps:

--- a/src/def/convert_defs.h
+++ b/src/def/convert_defs.h
@@ -30,6 +30,10 @@ typedef enum {
   CONVERT_GADDAG2TEXT,
   CONVERT_CSV2KLV,
   CONVERT_KLV2CSV,
+  // Fits a small parametric "compact leaves" (.clv) model approximating the
+  // input KLV's leave values under a target byte budget (see 'clvsize'). For
+  // small/retro targets that cannot carry a full ~3.7 MB KLV.
+  CONVERT_KLV2CLV,
   CONVERT_TEXT2WORDMAP,
   CONVERT_DAWG2WORDMAP,
   CONVERT_KLVWMP2RIT,

--- a/src/def/convert_defs.h
+++ b/src/def/convert_defs.h
@@ -17,6 +17,15 @@ typedef enum {
   // (minimal arc width + minimal tile width) rather than a full 32-bit word.
   // Niche, opt-in output for fitting a word list onto small/retro hardware.
   CONVERT_TEXT2DAWG_PACKED,
+  // Like CONVERT_TEXT2DAWG_PACKED, but arc-compresses the reorder DAWG: the
+  // first-child arc is encoded as a popular-table index, a local signed gap, or
+  // a rank-located escape, shrinking the resident footprint further than the
+  // packed DAWG. Same niche, opt-in retro-hardware use; same Alpha caveat.
+  CONVERT_TEXT2DAWG_ARC_COMPRESSED,
+  // Same arc-compressed format, but built in BALANCED mode: a lower escape rate
+  // (a little more RAM, still smaller than the packed DAWG) for materially
+  // faster traversal. See dawg_arc_compressed_mode_t.
+  CONVERT_TEXT2DAWG_ARC_COMPRESSED_BALANCED,
   CONVERT_DAWG2TEXT,
   CONVERT_GADDAG2TEXT,
   CONVERT_CSV2KLV,

--- a/src/ent/compact_leaves.c
+++ b/src/ent/compact_leaves.c
@@ -1,0 +1,545 @@
+#include "compact_leaves.h"
+
+#include "../def/equity_defs.h"
+#include "../def/letter_distribution_defs.h"
+#include "../ent/rack.h"
+#include "../util/fileproxy.h"
+#include "../util/io_util.h"
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Explicit little-endian byte (de)serialization so a .clv is byte-identical on
+// any CPU (it is meant to be transported to constrained systems).
+static inline void put_u16(uint8_t *b, size_t *p, uint16_t v) {
+  b[(*p)++] = (uint8_t)(v & 0xFF);
+  b[(*p)++] = (uint8_t)((v >> 8) & 0xFF);
+}
+static inline void put_u32(uint8_t *b, size_t *p, uint32_t v) {
+  for (int byte_idx = 0; byte_idx < 4; byte_idx++) {
+    b[(*p)++] = (uint8_t)((v >> (8 * byte_idx)) & 0xFF);
+  }
+}
+static inline void put_u64(uint8_t *b, size_t *p, uint64_t v) {
+  for (int byte_idx = 0; byte_idx < 8; byte_idx++) {
+    b[(*p)++] = (uint8_t)((v >> (8 * byte_idx)) & 0xFF);
+  }
+}
+static inline uint16_t get_u16(const uint8_t *b, size_t *p) {
+  const uint16_t v = (uint16_t)(b[*p] | ((uint16_t)b[*p + 1] << 8));
+  *p += 2;
+  return v;
+}
+static inline uint32_t get_u32(const uint8_t *b, size_t *p) {
+  uint32_t v = 0;
+  for (int byte_idx = 0; byte_idx < 4; byte_idx++) {
+    v |= (uint32_t)b[*p + byte_idx] << (8 * byte_idx);
+  }
+  *p += 4;
+  return v;
+}
+static inline uint64_t get_u64(const uint8_t *b, size_t *p) {
+  uint64_t v = 0;
+  for (int byte_idx = 0; byte_idx < 8; byte_idx++) {
+    v |= (uint64_t)b[*p + byte_idx] << (8 * byte_idx);
+  }
+  *p += 8;
+  return v;
+}
+
+// ---- sub-byte bit packing (LSB-first) for the optional bit-packed body ----
+// Self-contained (does not depend on the DAWG modules) so .clv stays
+// orthogonal.
+static int compact_leaves_bits_needed(uint32_t max_value) {
+  int bits = 0;
+  while (max_value > 0) {
+    bits++;
+    max_value >>= 1;
+  }
+  return bits < 1 ? 1 : bits;
+}
+// Map signed <-> unsigned so small-magnitude coefficients pack into few bits.
+static inline uint32_t compact_leaves_zigzag(int32_t value) {
+  const uint32_t sign = value < 0 ? 0xFFFFFFFFU : 0U;
+  return ((uint32_t)value << 1) ^ sign;
+}
+static inline int32_t compact_leaves_unzigzag(uint32_t encoded) {
+  return (int32_t)(encoded >> 1) ^ -(int32_t)(encoded & 1U);
+}
+// buf must be zero-initialized over the bit range (writes via OR).
+static void put_bits(uint8_t *buf, size_t *bit_pos, uint32_t value, int nbits) {
+  for (int i = 0; i < nbits; i++) {
+    if ((value >> i) & 1U) {
+      buf[(*bit_pos + (size_t)i) >> 3] |=
+          (uint8_t)(1U << ((*bit_pos + (size_t)i) & 7U));
+    }
+  }
+  *bit_pos += (size_t)nbits;
+}
+static uint32_t get_bits(const uint8_t *buf, size_t *bit_pos, int nbits) {
+  uint32_t value = 0;
+  for (int i = 0; i < nbits; i++) {
+    if ((buf[(*bit_pos + (size_t)i) >> 3] >> ((*bit_pos + (size_t)i) & 7U)) &
+        1U) {
+      value |= (1U << i);
+    }
+  }
+  *bit_pos += (size_t)nbits;
+  return value;
+}
+// Bit widths derived identically by writer and reader from dist_size / the
+// max-synergy-tiles constant (so they need not be stored).
+static int compact_leaves_tile_bits(const CompactLeaves *cl) {
+  return compact_leaves_bits_needed((uint32_t)cl->dist_size - 1);
+}
+static int compact_leaves_num_tiles_bits(void) {
+  return compact_leaves_bits_needed(COMPACT_LEAVES_MAX_SYNERGY_TILES);
+}
+
+static inline int compact_leaves_vc_count(const CompactLeaves *cl) {
+  return (cl->flags & COMPACT_LEAVES_FLAG_VC_TABLE)
+             ? COMPACT_LEAVES_VC_TABLE_SIZE
+             : COMPACT_LEAVES_VC_POLY_SIZE;
+}
+
+// Number of coefficients in the base block (intercept + per-tile + optional
+// duplicate + vowel/consonant cells).
+static size_t compact_leaves_base_coef_count(const CompactLeaves *cl) {
+  size_t count =
+      1 + (size_t)cl->dist_size + (size_t)compact_leaves_vc_count(cl);
+  if (cl->flags & COMPACT_LEAVES_FLAG_HAS_DUP) {
+    count += (size_t)cl->dist_size;
+  }
+  return count;
+}
+
+// Serialized byte length of cl.
+static size_t compact_leaves_serialized_size(const CompactLeaves *cl) {
+  if (cl->flags & COMPACT_LEAVES_FLAG_BITPACKED) {
+    const int tile_bits = compact_leaves_tile_bits(cl);
+    const int nt_bits = compact_leaves_num_tiles_bits();
+    size_t body_bits =
+        compact_leaves_base_coef_count(cl) * (size_t)cl->coef_bits;
+    for (uint32_t syn_idx = 0; syn_idx < cl->num_synergies; syn_idx++) {
+      body_bits +=
+          (size_t)nt_bits +
+          (size_t)cl->synergies[syn_idx].num_tiles * (size_t)tile_bits +
+          (size_t)cl->coef_bits;
+    }
+    // header + vowel_bits(8) + coef_bits(1) + ceil(body_bits / 8)
+    return COMPACT_LEAVES_HEADER_BYTES + 8 + 1 + (body_bits + 7) / 8;
+  }
+  size_t size = COMPACT_LEAVES_HEADER_BYTES;
+  size += 8;                         // vowel_bits
+  size += 2;                         // base_ticks
+  size += (size_t)cl->dist_size * 2; // tile_ticks
+  if (cl->flags & COMPACT_LEAVES_FLAG_HAS_DUP) {
+    size += (size_t)cl->dist_size * 2; // dup_ticks
+  }
+  size += (size_t)compact_leaves_vc_count(cl) * 2; // vc_ticks
+  for (uint32_t syn_idx = 0; syn_idx < cl->num_synergies; syn_idx++) {
+    size += 1 + cl->synergies[syn_idx].num_tiles + 2; // k + tiles + coef
+  }
+  return size;
+}
+
+void compact_leaves_destroy(CompactLeaves *cl) {
+  if (cl == NULL) {
+    return;
+  }
+  free(cl->tile_ticks);
+  free(cl->dup_ticks);
+  free(cl->synergies);
+  free(cl);
+}
+
+void compact_leaves_write_to_file(const CompactLeaves *cl, const char *filename,
+                                  ErrorStack *error_stack) {
+  const size_t num_bytes = compact_leaves_serialized_size(cl);
+  uint8_t *bytes = (uint8_t *)calloc_or_die(num_bytes, 1);
+  size_t pos = 0;
+  for (int magic_idx = 0; magic_idx < 4; magic_idx++) {
+    bytes[pos++] = (uint8_t)COMPACT_LEAVES_MAGIC[magic_idx];
+  }
+  bytes[pos++] = COMPACT_LEAVES_VERSION;
+  bytes[pos++] = cl->radix_code;
+  bytes[pos++] = cl->dist_size;
+  bytes[pos++] = cl->flags;
+  put_u32(bytes, &pos, cl->num_synergies);
+  put_u64(bytes, &pos, cl->vowel_bits);
+  const int vc_count = compact_leaves_vc_count(cl);
+  if (cl->flags & COMPACT_LEAVES_FLAG_BITPACKED) {
+    bytes[pos++] = cl->coef_bits;
+    const int cb = cl->coef_bits;
+    const int tile_bits = compact_leaves_tile_bits(cl);
+    const int nt_bits = compact_leaves_num_tiles_bits();
+    size_t bit_pos = pos * 8; // body begins byte-aligned, packed LSB-first
+    put_bits(bytes, &bit_pos, compact_leaves_zigzag(cl->base_ticks), cb);
+    for (uint8_t ml = 0; ml < cl->dist_size; ml++) {
+      put_bits(bytes, &bit_pos, compact_leaves_zigzag(cl->tile_ticks[ml]), cb);
+    }
+    if (cl->flags & COMPACT_LEAVES_FLAG_HAS_DUP) {
+      for (uint8_t ml = 0; ml < cl->dist_size; ml++) {
+        put_bits(bytes, &bit_pos, compact_leaves_zigzag(cl->dup_ticks[ml]), cb);
+      }
+    }
+    for (int vc_idx = 0; vc_idx < vc_count; vc_idx++) {
+      put_bits(bytes, &bit_pos, compact_leaves_zigzag(cl->vc_ticks[vc_idx]),
+               cb);
+    }
+    for (uint32_t syn_idx = 0; syn_idx < cl->num_synergies; syn_idx++) {
+      const CompactLeavesSynergy *syn = &cl->synergies[syn_idx];
+      put_bits(bytes, &bit_pos, syn->num_tiles, nt_bits);
+      for (uint8_t tile_idx = 0; tile_idx < syn->num_tiles; tile_idx++) {
+        put_bits(bytes, &bit_pos, syn->tiles[tile_idx], tile_bits);
+      }
+      put_bits(bytes, &bit_pos, compact_leaves_zigzag(syn->value_ticks), cb);
+    }
+  } else {
+    put_u16(bytes, &pos, (uint16_t)cl->base_ticks);
+    for (uint8_t ml = 0; ml < cl->dist_size; ml++) {
+      put_u16(bytes, &pos, (uint16_t)cl->tile_ticks[ml]);
+    }
+    if (cl->flags & COMPACT_LEAVES_FLAG_HAS_DUP) {
+      for (uint8_t ml = 0; ml < cl->dist_size; ml++) {
+        put_u16(bytes, &pos, (uint16_t)cl->dup_ticks[ml]);
+      }
+    }
+    for (int vc_idx = 0; vc_idx < vc_count; vc_idx++) {
+      put_u16(bytes, &pos, (uint16_t)cl->vc_ticks[vc_idx]);
+    }
+    for (uint32_t syn_idx = 0; syn_idx < cl->num_synergies; syn_idx++) {
+      const CompactLeavesSynergy *syn = &cl->synergies[syn_idx];
+      bytes[pos++] = syn->num_tiles;
+      for (uint8_t tile_idx = 0; tile_idx < syn->num_tiles; tile_idx++) {
+        bytes[pos++] = syn->tiles[tile_idx];
+      }
+      put_u16(bytes, &pos, (uint16_t)syn->value_ticks);
+    }
+  }
+
+  FILE *stream = fopen_safe(filename, "wb", error_stack);
+  if (!error_stack_is_empty(error_stack)) {
+    free(bytes);
+    return;
+  }
+  fwrite_or_die(bytes, 1, num_bytes, stream, "compact leaves");
+  fclose_or_die(stream);
+  free(bytes);
+}
+
+CompactLeaves *compact_leaves_read_from_file(const char *filename,
+                                             ErrorStack *error_stack) {
+  FILE *stream = stream_from_filename(filename, error_stack);
+  if (!error_stack_is_empty(error_stack)) {
+    return NULL;
+  }
+  fseek(stream, 0, SEEK_END);
+  const long file_len = ftell(stream);
+  fseek(stream, 0, SEEK_SET);
+  if (file_len < COMPACT_LEAVES_HEADER_BYTES + 10) {
+    fclose_or_die(stream);
+    error_stack_push(
+        error_stack, ERROR_STATUS_CONVERT_MALFORMED_KWG,
+        get_formatted_string("compact leaves file too small: %s", filename));
+    return NULL;
+  }
+  uint8_t *bytes = (uint8_t *)malloc_or_die((size_t)file_len);
+  if (fread(bytes, 1, (size_t)file_len, stream) != (size_t)file_len) {
+    fclose_or_die(stream);
+    free(bytes);
+    error_stack_push(
+        error_stack, ERROR_STATUS_CONVERT_MALFORMED_KWG,
+        get_formatted_string("truncated compact leaves file: %s", filename));
+    return NULL;
+  }
+  fclose_or_die(stream);
+
+  if (memcmp(bytes, COMPACT_LEAVES_MAGIC, 4) != 0 ||
+      bytes[4] != COMPACT_LEAVES_VERSION) {
+    free(bytes);
+    error_stack_push(error_stack, ERROR_STATUS_CONVERT_MALFORMED_KWG,
+                     get_formatted_string(
+                         "bad compact leaves header in file: %s", filename));
+    return NULL;
+  }
+  CompactLeaves *cl = (CompactLeaves *)calloc_or_die(1, sizeof(CompactLeaves));
+  size_t pos = 4;
+  pos++; // version (validated)
+  cl->radix_code = bytes[pos++];
+  cl->radix_millipoints = compact_leaves_radix_millipoints(cl->radix_code);
+  cl->dist_size = bytes[pos++];
+  cl->flags = bytes[pos++];
+  cl->num_synergies = get_u32(bytes, &pos);
+  // Validate sizes before allocating, then bound every read against file_len.
+  if (cl->dist_size == 0 || cl->dist_size > MAX_ALPHABET_SIZE) {
+    free(bytes);
+    free(cl);
+    error_stack_push(
+        error_stack, ERROR_STATUS_CONVERT_MALFORMED_KWG,
+        get_formatted_string("invalid compact leaves dist_size in file: %s",
+                             filename));
+    return NULL;
+  }
+  cl->vowel_bits = get_u64(bytes, &pos);
+  const int vc_count = compact_leaves_vc_count(cl);
+  if (cl->flags & COMPACT_LEAVES_FLAG_BITPACKED) {
+    // --- bit-packed body: coef_bits byte, then a LSB-first bit stream ---
+    if (pos + 1 > (size_t)file_len) {
+      compact_leaves_destroy(cl);
+      free(bytes);
+      error_stack_push(error_stack, ERROR_STATUS_CONVERT_MALFORMED_KWG,
+                       get_formatted_string(
+                           "truncated compact leaves header: %s", filename));
+      return NULL;
+    }
+    cl->coef_bits = bytes[pos++];
+    if (cl->coef_bits < 1 || cl->coef_bits > 16) {
+      compact_leaves_destroy(cl);
+      free(bytes);
+      error_stack_push(
+          error_stack, ERROR_STATUS_CONVERT_MALFORMED_KWG,
+          get_formatted_string("invalid compact leaves coef_bits in file: %s",
+                               filename));
+      return NULL;
+    }
+    const int cb = cl->coef_bits;
+    const int tile_bits = compact_leaves_tile_bits(cl);
+    const int nt_bits = compact_leaves_num_tiles_bits();
+    const size_t total_bits = (size_t)file_len * 8;
+    size_t bit_pos = pos * 8;
+    const size_t base_bits = compact_leaves_base_coef_count(cl) * (size_t)cb;
+    if (bit_pos + base_bits > total_bits) {
+      compact_leaves_destroy(cl);
+      free(bytes);
+      error_stack_push(
+          error_stack, ERROR_STATUS_CONVERT_MALFORMED_KWG,
+          get_formatted_string("truncated compact leaves body: %s", filename));
+      return NULL;
+    }
+    cl->base_ticks =
+        (int16_t)compact_leaves_unzigzag(get_bits(bytes, &bit_pos, cb));
+    cl->tile_ticks = (int16_t *)malloc_or_die(sizeof(int16_t) * cl->dist_size);
+    for (uint8_t ml = 0; ml < cl->dist_size; ml++) {
+      cl->tile_ticks[ml] =
+          (int16_t)compact_leaves_unzigzag(get_bits(bytes, &bit_pos, cb));
+    }
+    if (cl->flags & COMPACT_LEAVES_FLAG_HAS_DUP) {
+      cl->dup_ticks = (int16_t *)malloc_or_die(sizeof(int16_t) * cl->dist_size);
+      for (uint8_t ml = 0; ml < cl->dist_size; ml++) {
+        cl->dup_ticks[ml] =
+            (int16_t)compact_leaves_unzigzag(get_bits(bytes, &bit_pos, cb));
+      }
+    }
+    for (int vc_idx = 0; vc_idx < vc_count; vc_idx++) {
+      cl->vc_ticks[vc_idx] =
+          (int16_t)compact_leaves_unzigzag(get_bits(bytes, &bit_pos, cb));
+    }
+    // Reject a num_synergies that cannot possibly fit the remaining bits, so a
+    // crafted file cannot trigger a huge allocation (calloc_or_die aborts).
+    // Each synergy needs at least nt_bits + one tile + cb bits.
+    const size_t min_syn_bits =
+        (size_t)nt_bits + (size_t)tile_bits + (size_t)cb;
+    if ((size_t)cl->num_synergies > (total_bits - bit_pos) / min_syn_bits) {
+      compact_leaves_destroy(cl);
+      free(bytes);
+      error_stack_push(
+          error_stack, ERROR_STATUS_CONVERT_MALFORMED_KWG,
+          get_formatted_string("invalid compact leaves num_synergies: %s",
+                               filename));
+      return NULL;
+    }
+    if (cl->num_synergies > 0) {
+      cl->synergies = (CompactLeavesSynergy *)calloc_or_die(
+          cl->num_synergies, sizeof(CompactLeavesSynergy));
+      for (uint32_t syn_idx = 0; syn_idx < cl->num_synergies; syn_idx++) {
+        if (bit_pos + (size_t)nt_bits > total_bits) {
+          compact_leaves_destroy(cl);
+          free(bytes);
+          error_stack_push(
+              error_stack, ERROR_STATUS_CONVERT_MALFORMED_KWG,
+              get_formatted_string("truncated compact leaves synergies: %s",
+                                   filename));
+          return NULL;
+        }
+        CompactLeavesSynergy *syn = &cl->synergies[syn_idx];
+        syn->num_tiles = (uint8_t)get_bits(bytes, &bit_pos, nt_bits);
+        if (syn->num_tiles == 0 ||
+            syn->num_tiles > COMPACT_LEAVES_MAX_SYNERGY_TILES ||
+            bit_pos + (size_t)syn->num_tiles * (size_t)tile_bits + (size_t)cb >
+                total_bits) {
+          compact_leaves_destroy(cl);
+          free(bytes);
+          error_stack_push(
+              error_stack, ERROR_STATUS_CONVERT_MALFORMED_KWG,
+              get_formatted_string("invalid compact leaves synergy in file: %s",
+                                   filename));
+          return NULL;
+        }
+        for (uint8_t tile_idx = 0; tile_idx < syn->num_tiles; tile_idx++) {
+          const uint32_t ml = get_bits(bytes, &bit_pos, tile_bits);
+          if (ml >= cl->dist_size) {
+            compact_leaves_destroy(cl);
+            free(bytes);
+            error_stack_push(
+                error_stack, ERROR_STATUS_CONVERT_MALFORMED_KWG,
+                get_formatted_string("invalid compact leaves synergy tile: %s",
+                                     filename));
+            return NULL;
+          }
+          syn->tiles[tile_idx] = (MachineLetter)ml;
+        }
+        syn->value_ticks =
+            (int16_t)compact_leaves_unzigzag(get_bits(bytes, &bit_pos, cb));
+      }
+    }
+    free(bytes);
+    return cl;
+  }
+  // Bound the fixed base block before reading it.
+  size_t base_block_bytes =
+      2 + (size_t)cl->dist_size * 2 + (size_t)vc_count * 2;
+  if (cl->flags & COMPACT_LEAVES_FLAG_HAS_DUP) {
+    base_block_bytes += (size_t)cl->dist_size * 2;
+  }
+  if (pos + base_block_bytes > (size_t)file_len) {
+    compact_leaves_destroy(cl);
+    free(bytes);
+    error_stack_push(
+        error_stack, ERROR_STATUS_CONVERT_MALFORMED_KWG,
+        get_formatted_string("truncated compact leaves body: %s", filename));
+    return NULL;
+  }
+  cl->base_ticks = (int16_t)get_u16(bytes, &pos);
+  cl->tile_ticks = (int16_t *)malloc_or_die(sizeof(int16_t) * cl->dist_size);
+  for (uint8_t ml = 0; ml < cl->dist_size; ml++) {
+    cl->tile_ticks[ml] = (int16_t)get_u16(bytes, &pos);
+  }
+  if (cl->flags & COMPACT_LEAVES_FLAG_HAS_DUP) {
+    cl->dup_ticks = (int16_t *)malloc_or_die(sizeof(int16_t) * cl->dist_size);
+    for (uint8_t ml = 0; ml < cl->dist_size; ml++) {
+      cl->dup_ticks[ml] = (int16_t)get_u16(bytes, &pos);
+    }
+  }
+  for (int vc_idx = 0; vc_idx < vc_count; vc_idx++) {
+    cl->vc_ticks[vc_idx] = (int16_t)get_u16(bytes, &pos);
+  }
+  // Reject a num_synergies that cannot possibly fit (each synergy is >= 1 byte
+  // num_tiles + 1 tile + 2 value), so a crafted file cannot force a huge
+  // calloc.
+  if ((size_t)cl->num_synergies > ((size_t)file_len - pos) / 4) {
+    compact_leaves_destroy(cl);
+    free(bytes);
+    error_stack_push(error_stack, ERROR_STATUS_CONVERT_MALFORMED_KWG,
+                     get_formatted_string(
+                         "invalid compact leaves num_synergies: %s", filename));
+    return NULL;
+  }
+  // Bound-check the synergy section before trusting num_synergies.
+  if (cl->num_synergies > 0) {
+    cl->synergies = (CompactLeavesSynergy *)calloc_or_die(
+        cl->num_synergies, sizeof(CompactLeavesSynergy));
+    for (uint32_t syn_idx = 0; syn_idx < cl->num_synergies; syn_idx++) {
+      if (pos + 1 > (size_t)file_len) {
+        compact_leaves_destroy(cl);
+        free(bytes);
+        error_stack_push(
+            error_stack, ERROR_STATUS_CONVERT_MALFORMED_KWG,
+            get_formatted_string("truncated compact leaves synergies: %s",
+                                 filename));
+        return NULL;
+      }
+      CompactLeavesSynergy *syn = &cl->synergies[syn_idx];
+      syn->num_tiles = bytes[pos++];
+      if (syn->num_tiles == 0 ||
+          syn->num_tiles > COMPACT_LEAVES_MAX_SYNERGY_TILES ||
+          pos + syn->num_tiles + 2 > (size_t)file_len) {
+        compact_leaves_destroy(cl);
+        free(bytes);
+        error_stack_push(
+            error_stack, ERROR_STATUS_CONVERT_MALFORMED_KWG,
+            get_formatted_string("invalid compact leaves synergy in file: %s",
+                                 filename));
+        return NULL;
+      }
+      for (uint8_t tile_idx = 0; tile_idx < syn->num_tiles; tile_idx++) {
+        syn->tiles[tile_idx] = bytes[pos++];
+      }
+      syn->value_ticks = (int16_t)get_u16(bytes, &pos);
+    }
+  }
+  free(bytes);
+  return cl;
+}
+
+Equity compact_leaves_get_leave_value(const CompactLeaves *cl,
+                                      const Rack *leave) {
+  if (leave == NULL || rack_get_total_letters(leave) == 0) {
+    return 0;
+  }
+  int64_t ticks = cl->base_ticks;
+  int num_vowels = 0;
+  int num_consonants = 0;
+  for (uint8_t ml = 0; ml < cl->dist_size; ml++) {
+    const int count = rack_get_letter(leave, ml);
+    if (count == 0) {
+      continue;
+    }
+    ticks += (int64_t)cl->tile_ticks[ml] * count;
+    if (cl->dup_ticks != NULL && count > 1) {
+      ticks += (int64_t)cl->dup_ticks[ml] * (count - 1);
+    }
+    if (ml != 0) { // blank (ml 0) is neither vowel nor consonant
+      if ((cl->vowel_bits >> ml) & 1U) {
+        num_vowels += count;
+      } else {
+        num_consonants += count;
+      }
+    }
+  }
+  if (cl->flags & COMPACT_LEAVES_FLAG_VC_TABLE) {
+    const int vowel_idx = num_vowels > COMPACT_LEAVES_VC_CLAMP
+                              ? COMPACT_LEAVES_VC_CLAMP
+                              : num_vowels;
+    const int cons_idx = num_consonants > COMPACT_LEAVES_VC_CLAMP
+                             ? COMPACT_LEAVES_VC_CLAMP
+                             : num_consonants;
+    ticks += cl->vc_ticks[vowel_idx * COMPACT_LEAVES_VC_DIM + cons_idx];
+  } else {
+    const int imbalance = num_vowels - num_consonants;
+    ticks += (int64_t)cl->vc_ticks[0] * imbalance +
+             (int64_t)cl->vc_ticks[1] * imbalance * imbalance;
+  }
+  for (uint32_t syn_idx = 0; syn_idx < cl->num_synergies; syn_idx++) {
+    const CompactLeavesSynergy *syn = &cl->synergies[syn_idx];
+    int occurrences = INT_MAX;
+    uint8_t tile_idx = 0;
+    while (tile_idx < syn->num_tiles) {
+      const MachineLetter ml = syn->tiles[tile_idx];
+      int needed = 1;
+      tile_idx++;
+      while (tile_idx < syn->num_tiles && syn->tiles[tile_idx] == ml) {
+        needed++;
+        tile_idx++;
+      }
+      const int can = rack_get_letter(leave, ml) / needed;
+      if (can < occurrences) {
+        occurrences = can;
+      }
+    }
+    // Indicator: the combo's value is added once if it is present in the leave
+    // (matches how the fitter scores synergy terms).
+    if (occurrences > 0) {
+      ticks += syn->value_ticks;
+    }
+  }
+  int64_t millipoints = ticks * cl->radix_millipoints;
+  if (millipoints > EQUITY_MAX_VALUE) {
+    millipoints = EQUITY_MAX_VALUE;
+  } else if (millipoints < EQUITY_MIN_VALUE) {
+    millipoints = EQUITY_MIN_VALUE;
+  }
+  return (Equity)millipoints;
+}

--- a/src/ent/compact_leaves.c
+++ b/src/ent/compact_leaves.c
@@ -17,21 +17,25 @@ static inline void put_u16(uint8_t *b, size_t *p, uint16_t v) {
   b[(*p)++] = (uint8_t)(v & 0xFF);
   b[(*p)++] = (uint8_t)((v >> 8) & 0xFF);
 }
+
 static inline void put_u32(uint8_t *b, size_t *p, uint32_t v) {
   for (int byte_idx = 0; byte_idx < 4; byte_idx++) {
     b[(*p)++] = (uint8_t)((v >> (8 * byte_idx)) & 0xFF);
   }
 }
+
 static inline void put_u64(uint8_t *b, size_t *p, uint64_t v) {
   for (int byte_idx = 0; byte_idx < 8; byte_idx++) {
     b[(*p)++] = (uint8_t)((v >> (8 * byte_idx)) & 0xFF);
   }
 }
+
 static inline uint16_t get_u16(const uint8_t *b, size_t *p) {
   const uint16_t v = (uint16_t)(b[*p] | ((uint16_t)b[*p + 1] << 8));
   *p += 2;
   return v;
 }
+
 static inline uint32_t get_u32(const uint8_t *b, size_t *p) {
   uint32_t v = 0;
   for (int byte_idx = 0; byte_idx < 4; byte_idx++) {
@@ -40,6 +44,7 @@ static inline uint32_t get_u32(const uint8_t *b, size_t *p) {
   *p += 4;
   return v;
 }
+
 static inline uint64_t get_u64(const uint8_t *b, size_t *p) {
   uint64_t v = 0;
   for (int byte_idx = 0; byte_idx < 8; byte_idx++) {
@@ -60,14 +65,17 @@ static int compact_leaves_bits_needed(uint32_t max_value) {
   }
   return bits < 1 ? 1 : bits;
 }
+
 // Map signed <-> unsigned so small-magnitude coefficients pack into few bits.
 static inline uint32_t compact_leaves_zigzag(int32_t value) {
   const uint32_t sign = value < 0 ? 0xFFFFFFFFU : 0U;
   return ((uint32_t)value << 1) ^ sign;
 }
+
 static inline int32_t compact_leaves_unzigzag(uint32_t encoded) {
   return (int32_t)(encoded >> 1) ^ -(int32_t)(encoded & 1U);
 }
+
 // buf must be zero-initialized over the bit range (writes via OR).
 static void put_bits(uint8_t *buf, size_t *bit_pos, uint32_t value, int nbits) {
   for (int i = 0; i < nbits; i++) {
@@ -78,6 +86,7 @@ static void put_bits(uint8_t *buf, size_t *bit_pos, uint32_t value, int nbits) {
   }
   *bit_pos += (size_t)nbits;
 }
+
 static uint32_t get_bits(const uint8_t *buf, size_t *bit_pos, int nbits) {
   uint32_t value = 0;
   for (int i = 0; i < nbits; i++) {
@@ -89,11 +98,13 @@ static uint32_t get_bits(const uint8_t *buf, size_t *bit_pos, int nbits) {
   *bit_pos += (size_t)nbits;
   return value;
 }
+
 // Bit widths derived identically by writer and reader from dist_size / the
 // max-synergy-tiles constant (so they need not be stored).
 static int compact_leaves_tile_bits(const CompactLeaves *cl) {
   return compact_leaves_bits_needed((uint32_t)cl->dist_size - 1);
 }
+
 static int compact_leaves_num_tiles_bits(void) {
   return compact_leaves_bits_needed(COMPACT_LEAVES_MAX_SYNERGY_TILES);
 }

--- a/src/ent/compact_leaves.h
+++ b/src/ent/compact_leaves.h
@@ -1,0 +1,119 @@
+#ifndef COMPACT_LEAVES_H
+#define COMPACT_LEAVES_H
+
+#include "../def/board_defs.h"
+#include "../ent/equity.h"
+#include "../ent/rack.h"
+#include "../util/io_util.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// A "compact leaves" file (.clv) is a small parametric APPROXIMATION of a KLV,
+// for systems that cannot store the exhaustive leave table (CSW21's .klv2 is
+// ~3.67 MB / 914,624 leaves; a .clv targets a few KB). It is opt-in and
+// orthogonal to mainline MAGPIE; the regular KLV remains the default.
+//
+// The value of a leave L (tile multiset, counts n[ml], ml 0 = blank) is
+//   f(L) = base
+//        + sum_ml v[ml] * n[ml]                 (per-tile linear)
+//        + sum_ml d[ml] * max(n[ml]-1, 0)        (duplicate penalty; optional)
+//        + g(nv, nc)                             (vowel/consonant adjustment)
+//        + sum_{t in synergies} s_t * count(t in L)
+// where nv/nc are the leave's vowel/consonant counts (the vowel set is stored
+// in the file, so lookup needs no LetterDistribution). Everything is
+// FIXED-POINT: each coefficient is a signed integer of "ticks", and value =
+// (sum ticks) * radix_millipoints. Default radix = EQUITY_RESOLUTION/8 = 125 mp
+// = 1/8 point (divides 1000 evenly -> lossless), configurable in the header.
+// See COMPACT_LEAVES.md for the model, the frequency-weighted fit, and the
+// format.
+
+enum {
+  COMPACT_LEAVES_VERSION = 1,
+  // 4 magic + 1 version + 1 radix_code + 1 dist_size + 1 flags + 4 num_synergy.
+  COMPACT_LEAVES_HEADER_BYTES = 12,
+  // flags bits.
+  COMPACT_LEAVES_FLAG_HAS_DUP = 0x1,  // dup_ticks[] present
+  COMPACT_LEAVES_FLAG_VC_TABLE = 0x2, // V/C is the full 2-D table (else poly)
+  // All coefficients ("ticks") and synergy fields are sub-byte bit-packed
+  // (zigzag fixed-width). Lets more synergies fit a byte budget. When unset the
+  // body is byte-granular (the simpler, more portable default).
+  COMPACT_LEAVES_FLAG_BITPACKED = 0x4,
+  // Vowel/consonant adjustment: clamped 2-D table over (min(nv,K), min(nc,K)).
+  COMPACT_LEAVES_VC_CLAMP = 4,       // counts clamped to 0..4
+  COMPACT_LEAVES_VC_DIM = 5,         // (CLAMP + 1)
+  COMPACT_LEAVES_VC_TABLE_SIZE = 25, // DIM * DIM
+  COMPACT_LEAVES_VC_POLY_SIZE = 2,   // a1*i + a2*i^2 fallback (i = nv-nc)
+  // A synergy term is a small tile multiset; a leave holds <= RACK_SIZE-1
+  // tiles.
+  COMPACT_LEAVES_MAX_SYNERGY_TILES = 6,
+};
+
+#define COMPACT_LEAVES_MAGIC "CLV1"
+
+// radix_code -> millipoints per tick (kept small/enumerable; all divide
+// EQUITY_RESOLUTION evenly so decode is lossless).
+typedef enum {
+  COMPACT_LEAVES_RADIX_EIGHTH = 0,  // 125 mp = 1/8 point (default)
+  COMPACT_LEAVES_RADIX_QUARTER = 1, // 250 mp = 1/4 point
+  COMPACT_LEAVES_RADIX_HALF = 2,    // 500 mp = 1/2 point
+  COMPACT_LEAVES_RADIX_WHOLE = 3,   // 1000 mp = 1 point
+} compact_leaves_radix_t;
+
+// One selected interaction term: a sorted tile multiset and its coefficient.
+typedef struct CompactLeavesSynergy {
+  uint8_t num_tiles; // 2..COMPACT_LEAVES_MAX_SYNERGY_TILES
+  MachineLetter tiles[COMPACT_LEAVES_MAX_SYNERGY_TILES]; // sorted, ml order
+  int16_t value_ticks;
+} CompactLeavesSynergy;
+
+typedef struct CompactLeaves {
+  uint8_t dist_size;         // machine letters incl blank (~27 for English)
+  uint8_t radix_code;        // compact_leaves_radix_t (stored in the header)
+  int32_t radix_millipoints; // derived: millipoints per tick (125 = 1/8 point)
+  uint8_t flags;
+  // Bit width of each zigzag-encoded coefficient when FLAG_BITPACKED is set
+  // (stored in the file just after vowel_bits). Unused in byte mode.
+  uint8_t coef_bits;
+  // Which machine letters are vowels (bit ml set). Stored so a lookup is
+  // self-contained -- no LetterDistribution needed at query time.
+  uint64_t vowel_bits;
+  int16_t base_ticks;
+  int16_t *tile_ticks; // [dist_size] per-tile v[ml]
+  int16_t *dup_ticks;  // [dist_size] d[ml], or NULL if !HAS_DUP
+  int16_t vc_ticks[COMPACT_LEAVES_VC_TABLE_SIZE]; // table or [0..1] for poly
+  CompactLeavesSynergy *synergies;                // [num_synergies]
+  uint32_t num_synergies;
+} CompactLeaves;
+
+// Radix code <-> millipoints.
+static inline int32_t compact_leaves_radix_millipoints(uint8_t radix_code) {
+  switch ((compact_leaves_radix_t)radix_code) {
+  case COMPACT_LEAVES_RADIX_QUARTER:
+    return EQUITY_RESOLUTION / 4;
+  case COMPACT_LEAVES_RADIX_HALF:
+    return EQUITY_RESOLUTION / 2;
+  case COMPACT_LEAVES_RADIX_WHOLE:
+    return EQUITY_RESOLUTION;
+  case COMPACT_LEAVES_RADIX_EIGHTH:
+  default:
+    return EQUITY_RESOLUTION / 8;
+  }
+}
+
+void compact_leaves_destroy(CompactLeaves *cl);
+
+void compact_leaves_write_to_file(const CompactLeaves *cl, const char *filename,
+                                  ErrorStack *error_stack);
+
+CompactLeaves *compact_leaves_read_from_file(const char *filename,
+                                             ErrorStack *error_stack);
+
+// Approximate leave value as an Equity (millipoints), accumulated in tick space
+// and scaled by the radix once. Drops into the existing additive use site
+// (static_eval) with the same contract as klv_get_leave_value. Empty leave ->
+// 0.
+Equity compact_leaves_get_leave_value(const CompactLeaves *cl,
+                                      const Rack *leave);
+
+#endif

--- a/src/ent/data_filepaths.c
+++ b/src/ent/data_filepaths.c
@@ -17,7 +17,8 @@ static const char *const filepath_type_names[] = {"kwg",
                                                   "lexicon",
                                                   "wordmap",
                                                   "rack info table",
-                                                  "packed dawg"};
+                                                  "packed dawg",
+                                                  "arc-compressed dawg"};
 
 void string_builder_add_directory_for_data_type(StringBuilder *sb,
                                                 const char *data_path,
@@ -30,6 +31,7 @@ void string_builder_add_directory_for_data_type(StringBuilder *sb,
   case DATA_FILEPATH_TYPE_LEAVES:
   case DATA_FILEPATH_TYPE_RACK_INFO_TABLE:
   case DATA_FILEPATH_TYPE_DAWG_PACKED:
+  case DATA_FILEPATH_TYPE_DAWG_ARC_COMPRESSED:
     string_builder_add_formatted_string(sb, "%s/lexica/", data_path);
     break;
   case DATA_FILEPATH_TYPE_LAYOUT:
@@ -69,6 +71,9 @@ char *get_filepath(const char *data_path, const char *data_name,
     break;
   case DATA_FILEPATH_TYPE_DAWG_PACKED:
     file_ext = DAWG_PACKED_EXTENSION;
+    break;
+  case DATA_FILEPATH_TYPE_DAWG_ARC_COMPRESSED:
+    file_ext = DAWG_ARC_COMPRESSED_EXTENSION;
     break;
   case DATA_FILEPATH_TYPE_LAYOUT:
     file_ext = TXT_EXTENSION;

--- a/src/ent/data_filepaths.c
+++ b/src/ent/data_filepaths.c
@@ -18,7 +18,8 @@ static const char *const filepath_type_names[] = {"kwg",
                                                   "wordmap",
                                                   "rack info table",
                                                   "packed dawg",
-                                                  "arc-compressed dawg"};
+                                                  "arc-compressed dawg",
+                                                  "compact leaves"};
 
 void string_builder_add_directory_for_data_type(StringBuilder *sb,
                                                 const char *data_path,
@@ -32,6 +33,7 @@ void string_builder_add_directory_for_data_type(StringBuilder *sb,
   case DATA_FILEPATH_TYPE_RACK_INFO_TABLE:
   case DATA_FILEPATH_TYPE_DAWG_PACKED:
   case DATA_FILEPATH_TYPE_DAWG_ARC_COMPRESSED:
+  case DATA_FILEPATH_TYPE_COMPACT_LEAVES:
     string_builder_add_formatted_string(sb, "%s/lexica/", data_path);
     break;
   case DATA_FILEPATH_TYPE_LAYOUT:
@@ -74,6 +76,9 @@ char *get_filepath(const char *data_path, const char *data_name,
     break;
   case DATA_FILEPATH_TYPE_DAWG_ARC_COMPRESSED:
     file_ext = DAWG_ARC_COMPRESSED_EXTENSION;
+    break;
+  case DATA_FILEPATH_TYPE_COMPACT_LEAVES:
+    file_ext = COMPACT_LEAVES_EXTENSION;
     break;
   case DATA_FILEPATH_TYPE_LAYOUT:
     file_ext = TXT_EXTENSION;

--- a/src/ent/data_filepaths.h
+++ b/src/ent/data_filepaths.h
@@ -9,6 +9,7 @@
 #define DAWG_ARC_COMPRESSED_EXTENSION ".acdawg"
 #define WORDMAP_EXTENSION ".wmp"
 #define KLV_EXTENSION ".klv2"
+#define COMPACT_LEAVES_EXTENSION ".clv"
 #define RACK_INFO_TABLE_EXTENSION ".rit"
 #define TXT_EXTENSION ".txt"
 #define CSV_EXTENSION ".csv"
@@ -28,6 +29,7 @@ typedef enum {
   DATA_FILEPATH_TYPE_RACK_INFO_TABLE,
   DATA_FILEPATH_TYPE_DAWG_PACKED,
   DATA_FILEPATH_TYPE_DAWG_ARC_COMPRESSED,
+  DATA_FILEPATH_TYPE_COMPACT_LEAVES,
 } data_filepath_t;
 
 char *data_filepaths_get_readable_filename(const char *data_paths,

--- a/src/ent/data_filepaths.h
+++ b/src/ent/data_filepaths.h
@@ -6,6 +6,7 @@
 
 #define KWG_EXTENSION ".kwg"
 #define DAWG_PACKED_EXTENSION ".pdawg"
+#define DAWG_ARC_COMPRESSED_EXTENSION ".acdawg"
 #define WORDMAP_EXTENSION ".wmp"
 #define KLV_EXTENSION ".klv2"
 #define RACK_INFO_TABLE_EXTENSION ".rit"
@@ -26,6 +27,7 @@ typedef enum {
   DATA_FILEPATH_TYPE_WORDMAP,
   DATA_FILEPATH_TYPE_RACK_INFO_TABLE,
   DATA_FILEPATH_TYPE_DAWG_PACKED,
+  DATA_FILEPATH_TYPE_DAWG_ARC_COMPRESSED,
 } data_filepath_t;
 
 char *data_filepaths_get_readable_filename(const char *data_paths,

--- a/src/ent/dawg_arc_compressed.c
+++ b/src/ent/dawg_arc_compressed.c
@@ -1,0 +1,557 @@
+#include "dawg_arc_compressed.h"
+
+#include "../def/board_defs.h"
+#include "../util/fileproxy.h"
+#include "../util/io_util.h"
+#include "dawg_packed.h"
+#include "dictionary_word.h"
+#include "kwg.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+enum {
+  // Smallest subfield width considered by the config search; below this the
+  // popular table cannot index a useful number of targets.
+  DAWG_ARC_COMPRESSED_MIN_FIELD = 4,
+  DAWG_ARC_COMPRESSED_MAX_TILE_BITS = 8,
+  DAWG_ARC_COMPRESSED_MAX_ARC_BITS = 22,
+  // The config-search directory-size estimate charges one 32-bit counter per
+  // this many nodes (a rough proxy; the real directory keys on RANK_BLOCK).
+  DAWG_ARC_COMPRESSED_CONFIG_DIRECTORY_STRIDE = 256,
+  // BALANCED mode picks the smallest config whose escape rate is at or below
+  // this percent of nodes (a knee on the size/speed curve, still smaller than
+  // the fixed-width DAWG); MIN_RAM ignores it and just minimizes total bytes.
+  DAWG_ARC_COMPRESSED_BALANCED_ESCAPE_PCT = 15,
+};
+
+// Candidate popular-table sizes; a candidate is usable only when it is both
+// indexable by the subfield (K <= 2^field) and backed by enough targets.
+static const uint32_t popular_candidates[] = {64,   128,  256,  512,  1024,
+                                              2048, 4096, 8192, 16384};
+enum { DAWG_ARC_COMPRESSED_NUM_POPULAR_CANDIDATES = 9 };
+
+// A DAWG node after state-DFS renumbering: arc is the renumbered first-child
+// index (0 = no child).
+typedef struct DawgArcCompressedNode {
+  MachineLetter tile;
+  bool accepts;
+  bool is_end;
+  uint32_t arc;
+} DawgArcCompressedNode;
+
+// (in-degree, index) pair used to rank targets for the popular table.
+typedef struct DawgArcCompressedRankEntry {
+  uint32_t in_degree;
+  uint32_t index;
+} DawgArcCompressedRankEntry;
+
+// Sorts by descending in-degree, breaking ties by ascending node index so the
+// ranking is deterministic.
+static int dawg_arc_compressed_rank_compare(const void *left,
+                                            const void *right) {
+  const DawgArcCompressedRankEntry *left_entry =
+      (const DawgArcCompressedRankEntry *)left;
+  const DawgArcCompressedRankEntry *right_entry =
+      (const DawgArcCompressedRankEntry *)right;
+  if (left_entry->in_degree != right_entry->in_degree) {
+    return (left_entry->in_degree < right_entry->in_degree) ? 1 : -1;
+  }
+  if (left_entry->index != right_entry->index) {
+    return (left_entry->index < right_entry->index) ? -1 : 1;
+  }
+  return 0;
+}
+
+// Number of bits needed to represent every value in [0, max_value].
+static inline uint8_t bits_needed(uint32_t max_value) {
+  uint8_t bits = 1;
+  while ((max_value >> bits) != 0) {
+    bits++;
+  }
+  return bits;
+}
+
+// zig-zag signed->unsigned gap map (WebGraph's int2nat; Boldi & Vigna 2004).
+static inline uint64_t zigzag(int64_t value) {
+  return (value >= 0) ? ((uint64_t)value << 1)
+                      : (((uint64_t)(-value) << 1) - 1U);
+}
+
+// Renumbers the DAWG reachable from the KWG's dawg root into state-DFS order
+// (sibling runs kept contiguous so most gaps are small), reserving renumbered
+// index 0 as a no-child sentinel. Returns a freshly allocated node array of
+// length *out_count with the root at *out_root. The KWG is read only.
+static DawgArcCompressedNode *dawg_arc_compressed_renumber(const KWG *kwg,
+                                                           uint32_t *out_count,
+                                                           uint32_t *out_root) {
+  const uint32_t old_count = (uint32_t)kwg_get_number_of_nodes(kwg);
+  const uint32_t root = kwg_get_dawg_root_node_index(kwg);
+
+  // run_start[old_idx] = first index of the sibling run containing old_idx.
+  uint32_t *run_start = (uint32_t *)malloc_or_die(sizeof(uint32_t) * old_count);
+  uint32_t current_run = 0;
+  for (uint32_t old_idx = 0; old_idx < old_count; old_idx++) {
+    if (old_idx == 0 || kwg_node_is_end(kwg_node(kwg, old_idx - 1))) {
+      current_run = old_idx;
+    }
+    run_start[old_idx] = current_run;
+  }
+
+  uint32_t *new_of = (uint32_t *)calloc_or_die(old_count, sizeof(uint32_t));
+  uint32_t *order = (uint32_t *)malloc_or_die(sizeof(uint32_t) * old_count);
+  uint32_t order_count = 0;
+  uint8_t *visited = (uint8_t *)calloc_or_die((old_count + 7) / 8, 1);
+  // Total pushes over the whole DFS are bounded by the arc count (<=
+  // old_count).
+  uint32_t *stack =
+      (uint32_t *)malloc_or_die(sizeof(uint32_t) * (old_count + 1));
+  uint32_t stack_top = 0;
+  uint32_t *kids = (uint32_t *)malloc_or_die(sizeof(uint32_t) * old_count);
+
+  stack[stack_top++] = run_start[root];
+  while (stack_top > 0) {
+    const uint32_t run = stack[--stack_top];
+    if (((visited[run >> 3] >> (run & 7)) & 1U) != 0) {
+      continue;
+    }
+    visited[run >> 3] |= (uint8_t)(1U << (run & 7));
+    uint32_t kids_count = 0;
+    uint32_t node_idx = run;
+    for (;;) {
+      new_of[node_idx] = order_count + 1;
+      order[order_count++] = node_idx;
+      const uint32_t node = kwg_node(kwg, node_idx);
+      const uint32_t arc = kwg_node_arc_index(node);
+      if (arc != 0) {
+        const uint32_t child_run = run_start[arc];
+        if (((visited[child_run >> 3] >> (child_run & 7)) & 1U) == 0) {
+          kids[kids_count++] = child_run;
+        }
+      }
+      if (kwg_node_is_end(node)) {
+        break;
+      }
+      node_idx++;
+    }
+    // Push in reverse so the first child's run is processed first (DFS order).
+    for (uint32_t kid_idx = kids_count; kid_idx-- > 0;) {
+      stack[stack_top++] = kids[kid_idx];
+    }
+  }
+
+  const uint32_t new_count = order_count + 1;
+  DawgArcCompressedNode *nodes = (DawgArcCompressedNode *)malloc_or_die(
+      sizeof(DawgArcCompressedNode) * new_count);
+  nodes[0].tile = 0;
+  nodes[0].accepts = false;
+  nodes[0].is_end = true;
+  nodes[0].arc = 0;
+  for (uint32_t new_idx = 1; new_idx < new_count; new_idx++) {
+    const uint32_t old_idx = order[new_idx - 1];
+    const uint32_t node = kwg_node(kwg, old_idx);
+    const uint32_t arc = kwg_node_arc_index(node);
+    nodes[new_idx].tile = (MachineLetter)kwg_node_tile(node);
+    nodes[new_idx].accepts = kwg_node_accepts(node);
+    nodes[new_idx].is_end = kwg_node_is_end(node);
+    nodes[new_idx].arc = (arc != 0) ? new_of[arc] : 0;
+  }
+  *out_root = new_of[root];
+  *out_count = new_count;
+
+  free(run_start);
+  free(new_of);
+  free(order);
+  free(visited);
+  free(stack);
+  free(kids);
+  return nodes;
+}
+
+// Chooses the (field, popular_count) pair that minimizes the total resident
+// size: fixed-width records + popular table + escape side array + an estimate
+// of the rank directory. rank_pos[node] is the node's position in the
+// in-degree ranking (UINT32_MAX if it is never a target).
+static void dawg_arc_compressed_best_config(
+    const DawgArcCompressedNode *nodes, uint32_t node_count,
+    const uint32_t *rank_pos, uint32_t ranked_count, uint8_t tile_bits,
+    uint8_t arc_bits, dawg_arc_compressed_mode_t mode, uint8_t *out_field,
+    uint32_t *out_popular_count) {
+  const uint32_t directory_estimate =
+      ((node_count + DAWG_ARC_COMPRESSED_CONFIG_DIRECTORY_STRIDE - 1) /
+       DAWG_ARC_COMPRESSED_CONFIG_DIRECTORY_STRIDE) *
+      32;
+  const bool balanced = mode == DAWG_ARC_COMPRESSED_MODE_BALANCED;
+  uint64_t best_total = UINT64_MAX;
+  uint8_t best_field = DAWG_ARC_COMPRESSED_MIN_FIELD;
+  uint32_t best_popular_count = 0;
+  // BALANCED tracks the smallest config whose escape rate is within the
+  // ceiling.
+  uint64_t best_balanced_total = UINT64_MAX;
+  uint8_t balanced_field = DAWG_ARC_COMPRESSED_MIN_FIELD;
+  uint32_t balanced_popular_count = 0;
+  for (uint8_t field = DAWG_ARC_COMPRESSED_MIN_FIELD; field <= arc_bits;
+       field++) {
+    const uint32_t sentinel = (1U << field) - 1U;
+    for (int cand_idx = 0;
+         cand_idx < DAWG_ARC_COMPRESSED_NUM_POPULAR_CANDIDATES; cand_idx++) {
+      const uint32_t popular_count = popular_candidates[cand_idx];
+      if (popular_count > (1U << field) || popular_count > ranked_count) {
+        continue;
+      }
+      uint32_t escape_count = 0;
+      for (uint32_t node_idx = 0; node_idx < node_count; node_idx++) {
+        const uint32_t arc = nodes[node_idx].arc;
+        if (arc == 0 || rank_pos[arc] < popular_count) {
+          continue;
+        }
+        const uint64_t zigzagged = zigzag((int64_t)arc - (int64_t)node_idx);
+        if (zigzagged < 1 || zigzagged > sentinel - 1) {
+          escape_count++;
+        }
+      }
+      const uint64_t record_bits =
+          (uint64_t)node_count * (tile_bits + 3 + field);
+      const uint64_t total = record_bits + (uint64_t)popular_count * arc_bits +
+                             (uint64_t)escape_count * arc_bits +
+                             directory_estimate;
+      if (total < best_total) {
+        best_total = total;
+        best_field = field;
+        best_popular_count = popular_count;
+      }
+      if ((uint64_t)escape_count * 100 <=
+              (uint64_t)node_count * DAWG_ARC_COMPRESSED_BALANCED_ESCAPE_PCT &&
+          total < best_balanced_total) {
+        best_balanced_total = total;
+        balanced_field = field;
+        balanced_popular_count = popular_count;
+      }
+    }
+  }
+  // BALANCED uses the within-ceiling minimum when one exists; otherwise (e.g. a
+  // tiny lexicon where even the widest config escapes a lot) falls back to the
+  // overall MIN_RAM minimum.
+  if (balanced && best_balanced_total != UINT64_MAX) {
+    *out_field = balanced_field;
+    *out_popular_count = balanced_popular_count;
+  } else {
+    *out_field = best_field;
+    *out_popular_count = best_popular_count;
+  }
+}
+
+// Fills the cached section offsets and num_bytes from the header fields, which
+// must already be set on dp. Shared by create and read so the layout has a
+// single source of truth.
+static void dawg_arc_compressed_compute_offsets(DawgArcCompressed *dp) {
+  const size_t header_bits = (size_t)DAWG_ARC_COMPRESSED_HEADER_BYTES * 8;
+  dp->popular_bit_off = header_bits;
+  size_t pos = header_bits + (size_t)dp->popular_count * dp->arc_bits;
+  pos = (pos + 7) & ~(size_t)7;
+  dp->escape_bit_off = pos;
+  pos += (size_t)dp->escape_count * dp->arc_bits;
+  pos = (pos + 7) & ~(size_t)7;
+  dp->bitmap_byte_off = pos >> 3;
+  const size_t bitmap_bytes = ((size_t)dp->node_count + 7) / 8;
+  pos += bitmap_bytes * 8;
+  dp->directory_bit_off = pos;
+  const size_t num_blocks =
+      ((size_t)dp->node_count + DAWG_ARC_COMPRESSED_RANK_BLOCK - 1) /
+      DAWG_ARC_COMPRESSED_RANK_BLOCK;
+  pos += (num_blocks + 1) * 32;
+  dp->record_bit_off = pos;
+  pos += (size_t)dp->node_count * dp->rec_width;
+  dp->num_bytes = (pos + 7) / 8;
+}
+
+DawgArcCompressed *
+dawg_arc_compressed_create_from_kwg(const KWG *kwg,
+                                    dawg_arc_compressed_mode_t mode) {
+  uint32_t node_count = 0;
+  uint32_t root = 0;
+  DawgArcCompressedNode *nodes =
+      dawg_arc_compressed_renumber(kwg, &node_count, &root);
+
+  uint32_t max_tile = 0;
+  for (uint32_t node_idx = 0; node_idx < node_count; node_idx++) {
+    if (nodes[node_idx].tile > max_tile) {
+      max_tile = nodes[node_idx].tile;
+    }
+  }
+  const uint8_t tile_bits = bits_needed(max_tile);
+  const uint8_t arc_bits = bits_needed(node_count - 1);
+
+  // Rank targets by in-degree; rank_pos[node] is its position in that ranking.
+  uint32_t *in_degree = (uint32_t *)calloc_or_die(node_count, sizeof(uint32_t));
+  for (uint32_t node_idx = 0; node_idx < node_count; node_idx++) {
+    const uint32_t arc = nodes[node_idx].arc;
+    if (arc != 0) {
+      in_degree[arc]++;
+    }
+  }
+  DawgArcCompressedRankEntry *ranked =
+      (DawgArcCompressedRankEntry *)malloc_or_die(
+          sizeof(DawgArcCompressedRankEntry) * node_count);
+  uint32_t ranked_count = 0;
+  for (uint32_t node_idx = 0; node_idx < node_count; node_idx++) {
+    if (in_degree[node_idx] > 0) {
+      ranked[ranked_count].in_degree = in_degree[node_idx];
+      ranked[ranked_count].index = node_idx;
+      ranked_count++;
+    }
+  }
+  qsort(ranked, ranked_count, sizeof(DawgArcCompressedRankEntry),
+        dawg_arc_compressed_rank_compare);
+  uint32_t *rank_pos = (uint32_t *)malloc_or_die(sizeof(uint32_t) * node_count);
+  for (uint32_t node_idx = 0; node_idx < node_count; node_idx++) {
+    rank_pos[node_idx] = UINT32_MAX;
+  }
+  for (uint32_t rank_idx = 0; rank_idx < ranked_count; rank_idx++) {
+    rank_pos[ranked[rank_idx].index] = rank_idx;
+  }
+
+  uint8_t field = DAWG_ARC_COMPRESSED_MIN_FIELD;
+  uint32_t popular_count = 0;
+  dawg_arc_compressed_best_config(nodes, node_count, rank_pos, ranked_count,
+                                  tile_bits, arc_bits, mode, &field,
+                                  &popular_count);
+  const uint32_t sentinel = (1U << field) - 1U;
+  const uint8_t rec_width = (uint8_t)(tile_bits + 3 + field);
+
+  // Classify every arc into the four encodings, collecting the escape targets
+  // (in node order) and the escape bit-map.
+  uint32_t *subfield = (uint32_t *)malloc_or_die(sizeof(uint32_t) * node_count);
+  uint8_t *flag = (uint8_t *)calloc_or_die(node_count, 1);
+  uint8_t *escape_bitmap = (uint8_t *)calloc_or_die((node_count + 7) / 8, 1);
+  uint32_t *escapes = (uint32_t *)malloc_or_die(sizeof(uint32_t) * node_count);
+  uint32_t escape_count = 0;
+  for (uint32_t node_idx = 0; node_idx < node_count; node_idx++) {
+    const uint32_t arc = nodes[node_idx].arc;
+    if (arc == 0) {
+      subfield[node_idx] = 0;
+    } else if (rank_pos[arc] < popular_count) {
+      subfield[node_idx] = rank_pos[arc];
+      flag[node_idx] = 1;
+    } else {
+      const uint64_t zigzagged = zigzag((int64_t)arc - (int64_t)node_idx);
+      if (zigzagged >= 1 && zigzagged <= sentinel - 1) {
+        subfield[node_idx] = (uint32_t)zigzagged;
+      } else {
+        subfield[node_idx] = sentinel;
+        escape_bitmap[node_idx >> 3] |= (uint8_t)(1U << (node_idx & 7));
+        escapes[escape_count++] = arc;
+      }
+    }
+  }
+
+  DawgArcCompressed *dp =
+      (DawgArcCompressed *)malloc_or_die(sizeof(DawgArcCompressed));
+  dp->node_count = node_count;
+  dp->root_index = root;
+  dp->popular_count = popular_count;
+  dp->escape_count = escape_count;
+  dp->tile_bits = tile_bits;
+  dp->arc_bits = arc_bits;
+  dp->rec_width = rec_width;
+  dp->field = field;
+  dawg_arc_compressed_compute_offsets(dp);
+
+  uint8_t *bytes = (uint8_t *)calloc_or_die(dp->num_bytes, 1);
+  // Header. Write the magic byte-by-byte (memcpy from a string literal trips
+  // bugprone-not-null-terminated-result on this binary tag).
+  for (int magic_idx = 0; magic_idx < 4; magic_idx++) {
+    bytes[magic_idx] = (uint8_t)DAWG_ARC_COMPRESSED_MAGIC[magic_idx];
+  }
+  bytes[4] = DAWG_ARC_COMPRESSED_VERSION;
+  bytes[5] = tile_bits;
+  bytes[6] = arc_bits;
+  bytes[7] = rec_width;
+  bytes[8] = field;
+  // bytes[9..11] reserved padding (already zero). Multi-byte fields use native
+  // byte order: an arc-compressed DAWG is read back on the same machine.
+  memcpy(bytes + 12, &node_count, sizeof(uint32_t));
+  memcpy(bytes + 16, &root, sizeof(uint32_t));
+  memcpy(bytes + 20, &popular_count, sizeof(uint32_t));
+  memcpy(bytes + 24, &escape_count, sizeof(uint32_t));
+
+  // Popular table.
+  for (uint32_t pop_idx = 0; pop_idx < popular_count; pop_idx++) {
+    dawg_packed_bits_write(bytes,
+                           dp->popular_bit_off + (size_t)pop_idx * arc_bits,
+                           arc_bits, ranked[pop_idx].index);
+  }
+  // Escape side array.
+  for (uint32_t escape_idx = 0; escape_idx < escape_count; escape_idx++) {
+    dawg_packed_bits_write(bytes,
+                           dp->escape_bit_off + (size_t)escape_idx * arc_bits,
+                           arc_bits, escapes[escape_idx]);
+  }
+  // Escape bit-map.
+  memcpy(bytes + dp->bitmap_byte_off, escape_bitmap, (node_count + 7) / 8);
+  // Rank directory: directory[block] = cumulative escape count before the
+  // block; directory[num_blocks] = total.
+  const uint32_t num_blocks =
+      (node_count + DAWG_ARC_COMPRESSED_RANK_BLOCK - 1) /
+      DAWG_ARC_COMPRESSED_RANK_BLOCK;
+  uint32_t cumulative = 0;
+  for (uint32_t block_idx = 0; block_idx < num_blocks; block_idx++) {
+    dawg_packed_bits_write(
+        bytes, dp->directory_bit_off + (size_t)block_idx * 32, 32, cumulative);
+    uint32_t block_end = (block_idx + 1) * DAWG_ARC_COMPRESSED_RANK_BLOCK;
+    if (block_end > node_count) {
+      block_end = node_count;
+    }
+    for (uint32_t node_idx = block_idx * DAWG_ARC_COMPRESSED_RANK_BLOCK;
+         node_idx < block_end; node_idx++) {
+      if (((escape_bitmap[node_idx >> 3] >> (node_idx & 7)) & 1U) != 0) {
+        cumulative++;
+      }
+    }
+  }
+  dawg_packed_bits_write(bytes, dp->directory_bit_off + (size_t)num_blocks * 32,
+                         32, cumulative);
+  // Records.
+  for (uint32_t node_idx = 0; node_idx < node_count; node_idx++) {
+    const uint32_t value =
+        subfield[node_idx] | ((uint32_t)flag[node_idx] << field) |
+        ((uint32_t)(nodes[node_idx].is_end ? 1U : 0U) << (field + 1)) |
+        ((uint32_t)(nodes[node_idx].accepts ? 1U : 0U) << (field + 2)) |
+        ((uint32_t)nodes[node_idx].tile << (field + 3));
+    dawg_packed_bits_write(bytes,
+                           dp->record_bit_off + (size_t)node_idx * rec_width,
+                           rec_width, value);
+  }
+  dp->bytes = bytes;
+
+  free(nodes);
+  free(in_degree);
+  free(ranked);
+  free(rank_pos);
+  free(subfield);
+  free(flag);
+  free(escape_bitmap);
+  free(escapes);
+  return dp;
+}
+
+void dawg_arc_compressed_destroy(DawgArcCompressed *dp) {
+  if (dp == NULL) {
+    return;
+  }
+  free(dp->bytes);
+  free(dp);
+}
+
+void dawg_arc_compressed_write_to_file(const DawgArcCompressed *dp,
+                                       const char *filename,
+                                       ErrorStack *error_stack) {
+  FILE *stream = fopen_safe(filename, "wb", error_stack);
+  if (!error_stack_is_empty(error_stack)) {
+    return;
+  }
+  fwrite_or_die(dp->bytes, 1, dp->num_bytes, stream, "arc-compressed dawg");
+  fclose_or_die(stream);
+}
+
+DawgArcCompressed *dawg_arc_compressed_read_from_file(const char *filename,
+                                                      ErrorStack *error_stack) {
+  FILE *stream = stream_from_filename(filename, error_stack);
+  if (!error_stack_is_empty(error_stack)) {
+    return NULL;
+  }
+  uint8_t header[DAWG_ARC_COMPRESSED_HEADER_BYTES];
+  if (fread(header, 1, sizeof(header), stream) != sizeof(header) ||
+      memcmp(header, DAWG_ARC_COMPRESSED_MAGIC, 4) != 0 ||
+      header[4] != DAWG_ARC_COMPRESSED_VERSION) {
+    fclose_or_die(stream);
+    error_stack_push(
+        error_stack, ERROR_STATUS_CONVERT_MALFORMED_KWG,
+        get_formatted_string("malformed arc-compressed dawg header in file: %s",
+                             filename));
+    return NULL;
+  }
+  DawgArcCompressed *dp =
+      (DawgArcCompressed *)malloc_or_die(sizeof(DawgArcCompressed));
+  dp->tile_bits = header[5];
+  dp->arc_bits = header[6];
+  dp->rec_width = header[7];
+  dp->field = header[8];
+  memcpy(&dp->node_count, header + 12, sizeof(uint32_t));
+  memcpy(&dp->root_index, header + 16, sizeof(uint32_t));
+  memcpy(&dp->popular_count, header + 20, sizeof(uint32_t));
+  memcpy(&dp->escape_count, header + 24, sizeof(uint32_t));
+
+  // Reject corrupt/malicious headers before trusting the fields for sizing,
+  // allocation, and bit-shift widths.
+  const uint8_t expected_rec_width = (uint8_t)(dp->tile_bits + 3 + dp->field);
+  if (dp->tile_bits < 1 || dp->tile_bits > DAWG_ARC_COMPRESSED_MAX_TILE_BITS ||
+      dp->arc_bits < 1 || dp->arc_bits > DAWG_ARC_COMPRESSED_MAX_ARC_BITS ||
+      dp->field < 1 || dp->field >= dp->arc_bits ||
+      dp->rec_width != expected_rec_width || dp->node_count == 0 ||
+      dp->node_count > (1U << dp->arc_bits) ||
+      dp->root_index >= dp->node_count ||
+      dp->popular_count > (1U << dp->field) ||
+      dp->escape_count > dp->node_count) {
+    fclose_or_die(stream);
+    free(dp);
+    error_stack_push(
+        error_stack, ERROR_STATUS_CONVERT_MALFORMED_KWG,
+        get_formatted_string(
+            "invalid arc-compressed dawg header fields in file: %s", filename));
+    return NULL;
+  }
+
+  dawg_arc_compressed_compute_offsets(dp);
+  dp->bytes = (uint8_t *)malloc_or_die(dp->num_bytes);
+  memcpy(dp->bytes, header, sizeof(header));
+  const size_t body_bytes = dp->num_bytes - sizeof(header);
+  if (fread(dp->bytes + sizeof(header), 1, body_bytes, stream) != body_bytes) {
+    fclose_or_die(stream);
+    dawg_arc_compressed_destroy(dp);
+    error_stack_push(
+        error_stack, ERROR_STATUS_CONVERT_MALFORMED_KWG,
+        get_formatted_string("truncated arc-compressed dawg data in file: %s",
+                             filename));
+    return NULL;
+  }
+  fclose_or_die(stream);
+  return dp;
+}
+
+static void dawg_arc_compressed_write_words_aux(const DawgArcCompressed *dp,
+                                                uint32_t node_index,
+                                                MachineLetter *prefix,
+                                                int prefix_length, bool accepts,
+                                                DictionaryWordList *words) {
+  if (accepts) {
+    dictionary_word_list_add_word(words, prefix, prefix_length);
+  }
+  if (node_index == 0) {
+    return;
+  }
+  for (uint32_t node_idx = node_index;; node_idx++) {
+    const uint32_t node = dawg_arc_compressed_get_node(dp, node_idx);
+    const MachineLetter ml = (MachineLetter)kwg_node_tile(node);
+    const uint32_t arc = kwg_node_arc_index(node);
+    const bool node_accepts = kwg_node_accepts(node);
+    if (prefix_length < BOARD_DIM) {
+      prefix[prefix_length] = ml;
+    }
+    dawg_arc_compressed_write_words_aux(dp, arc, prefix, prefix_length + 1,
+                                        node_accepts, words);
+    if (kwg_node_is_end(node)) {
+      break;
+    }
+  }
+}
+
+void dawg_arc_compressed_write_words(const DawgArcCompressed *dp,
+                                     DictionaryWordList *words) {
+  MachineLetter prefix[BOARD_DIM];
+  dawg_arc_compressed_write_words_aux(dp, dp->root_index, prefix, 0, false,
+                                      words);
+}

--- a/src/ent/dawg_arc_compressed.h
+++ b/src/ent/dawg_arc_compressed.h
@@ -1,0 +1,198 @@
+#ifndef DAWG_ARC_COMPRESSED_H
+#define DAWG_ARC_COMPRESSED_H
+
+#include "../def/kwg_defs.h"
+#include "../util/io_util.h"
+#include "dawg_packed.h"
+#include "dictionary_word.h"
+#include "kwg.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// An "arc-compressed DAWG" is a niche, opt-in serialization of a DAWG-only KWG
+// that shrinks the in-RAM footprint further than the packed DAWG (.pdawg) by
+// compressing the one field with real slack: the first-child arc. Like the
+// packed DAWG it is intended for fitting a full word list onto retro hardware,
+// NOT for mainline MAGPIE; the regular 32-bit KWG remains the default
+// everywhere and is produced unchanged, and nothing here touches kwg_maker or
+// the gaddag path that wordprune depends on.
+//
+// Records stay FIXED-WIDTH (node j lives at a known bit offset), so the graph
+// is still randomly addressable and traversable in place. Each record carries
+// the same tile / accepts / is_end fields as a KWG node, plus a 1-bit flag and
+// a field-bit subfield that together encode the arc four ways:
+//   * flag = 1                  -> subfield indexes a "popular" table of the K
+//                                  highest in-degree target nodes;
+//   * flag = 0, subfield = 0    -> no child (leaf);
+//   * flag = 0, subfield = max  -> escape: the full target lives in a side
+//                                  array, located by rank over an escape
+//                                  bit-map (a one-level rank directory,
+//                                  Jacobson 1989 sec 5.1);
+//   * flag = 0, otherwise       -> target = j + unzigzag(subfield), a local
+//                                  signed gap to a nearby node.
+// Nodes are renumbered in state-DFS order (sibling runs kept contiguous) so
+// most arcs point near their source and the gap stays small. See
+// tools/RETRO_DAWG.md for the full study and the prior-art attribution.
+//
+// Layout (all bit fields are LSB-first within bytes, identical on any CPU; the
+// few multi-byte header fields use the writer's native byte order, so an
+// arc-compressed DAWG reads back on a machine of the same endianness):
+//   header | popular | escapes | escape bit-map | rank directory | records
+//
+// Like the packed DAWG, child order within a node's list is preserved, so an
+// arc-compressed DAWG built from a KWG_MAKER_MERGE_TAIL_REORDER DAWG inherits
+// that DAWG's caveat: valid for linear-scan readers and word lookup, NOT for
+// the Alpha cross-set path.
+
+enum {
+  // On-disk format version (started at 2; version 1 was never shipped).
+  DAWG_ARC_COMPRESSED_VERSION = 2,
+  // 4 magic + 1 version + 1 tile_bits + 1 arc_bits + 1 rec_width + 1 field +
+  // 3 pad + 4 node_count + 4 root_index + 4 popular_count + 4 escape_count.
+  DAWG_ARC_COMPRESSED_HEADER_BYTES = 32,
+  // The escape rank directory stores one cumulative escape count per block of
+  // this many nodes; the in-block remainder is finished with a population
+  // count.
+  DAWG_ARC_COMPRESSED_RANK_BLOCK = 64,
+};
+
+#define DAWG_ARC_COMPRESSED_MAGIC "ACDW"
+
+// Build mode: which point on the size/speed curve to target. Both modes produce
+// the identical on-disk format and the identical decoder; they differ only in
+// the chosen (field, popular-table size K), and therefore in the escape rate.
+// Escapes cost a popcount-rank + a side-array read on every *descended* node,
+// so a lower escape rate traverses faster, not just larger -- the rate is both
+// a RAM lever and a speed lever. Measured on CSW24, lazy/inlined traversal, vs
+// the fixed-width packed DAWG:
+//   MIN_RAM  -- 472.7 KB, ~33% escapes -> ~1.47x word-lookup, ~1.23x rack-gen.
+//               Smallest possible footprint (the retro goal); the slow end.
+//   BALANCED -- ~488 KB (still smaller than the packed DAWG), ~14% escapes ->
+//               ~1.32x word-lookup, ~1.14x rack-gen. A little more RAM for
+//               materially faster traversal; for lookup/move-gen-heavy use.
+typedef enum {
+  DAWG_ARC_COMPRESSED_MODE_MIN_RAM,
+  DAWG_ARC_COMPRESSED_MODE_BALANCED,
+} dawg_arc_compressed_mode_t;
+
+typedef struct DawgArcCompressed {
+  // The entire serialized blob (header through records), so writing the file is
+  // a single fwrite and the decoder reads its tables straight out of memory
+  // with zero load-time reconstruction.
+  uint8_t *bytes;
+  size_t num_bytes;
+  uint32_t node_count;    // includes the reserved index-0 no-child sentinel
+  uint32_t root_index;    // renumbered index of the DAWG root
+  uint32_t popular_count; // K: entries in the popular table
+  uint32_t escape_count;  // entries in the escape side array
+  uint8_t tile_bits;
+  uint8_t arc_bits;  // bits to hold any node index (popular/escape targets)
+  uint8_t rec_width; // tile_bits + 3 + field
+  uint8_t field;     // subfield width in bits
+  // Cached section bit/byte offsets into bytes, derived from the header fields.
+  size_t popular_bit_off;
+  size_t escape_bit_off;
+  size_t bitmap_byte_off;
+  size_t directory_bit_off;
+  size_t record_bit_off;
+} DawgArcCompressed;
+
+// rank over the escape bit-map: directory[block] + population count of the
+// set escape bits in this node's block below node_index.
+static inline uint32_t
+dawg_arc_compressed_escape_rank(const DawgArcCompressed *dp,
+                                uint32_t node_index) {
+  const uint32_t block = node_index / DAWG_ARC_COMPRESSED_RANK_BLOCK;
+  uint32_t rank = dawg_packed_bits_read(
+      dp->bytes, dp->directory_bit_off + (size_t)block * 32, 32);
+  const uint8_t *bitmap = dp->bytes + dp->bitmap_byte_off;
+  const uint32_t block_start_byte =
+      block * (DAWG_ARC_COMPRESSED_RANK_BLOCK / 8);
+  const uint32_t end_byte = node_index >> 3;
+  for (uint32_t byte_idx = block_start_byte; byte_idx < end_byte; byte_idx++) {
+    rank += (uint32_t)__builtin_popcount(bitmap[byte_idx]);
+  }
+  rank += (uint32_t)__builtin_popcount(
+      bitmap[end_byte] & (uint8_t)((1U << (node_index & 7)) - 1U));
+  return rank;
+}
+
+// Decodes record node_index back into a 32-bit value using the standard KWG
+// node layout, so kwg_node_is_end / kwg_node_accepts / kwg_node_arc_index /
+// kwg_node_tile all apply.
+static inline uint32_t dawg_arc_compressed_get_node(const DawgArcCompressed *dp,
+                                                    uint32_t node_index) {
+  const uint32_t record = dawg_packed_bits_read(
+      dp->bytes, dp->record_bit_off + (size_t)node_index * dp->rec_width,
+      dp->rec_width);
+  const uint32_t sentinel = (1U << dp->field) - 1U;
+  const uint32_t subfield = record & sentinel;
+  const uint32_t flag = (record >> dp->field) & 1U;
+  const uint32_t is_end = (record >> (dp->field + 1)) & 1U;
+  const uint32_t accepts = (record >> (dp->field + 2)) & 1U;
+  const uint32_t tile = record >> (dp->field + 3);
+  uint32_t arc;
+  if (flag != 0) {
+    arc = dawg_packed_bits_read(
+        dp->bytes, dp->popular_bit_off + (size_t)subfield * dp->arc_bits,
+        dp->arc_bits);
+  } else if (subfield == 0) {
+    arc = 0;
+  } else if (subfield == sentinel) {
+    const uint32_t slot = dawg_arc_compressed_escape_rank(dp, node_index);
+    arc = dawg_packed_bits_read(
+        dp->bytes, dp->escape_bit_off + (size_t)slot * dp->arc_bits,
+        dp->arc_bits);
+  } else {
+    // unzigzag: even -> +n/2, odd -> -(n+1)/2.
+    const int64_t gap = (subfield & 1U) ? -(int64_t)((subfield + 1U) >> 1)
+                                        : (int64_t)(subfield >> 1);
+    arc = (uint32_t)((int64_t)node_index + gap);
+  }
+  uint32_t node = arc;
+  if (is_end != 0) {
+    node |= KWG_NODE_IS_END_FLAG;
+  }
+  if (accepts != 0) {
+    node |= KWG_NODE_ACCEPTS_FLAG;
+  }
+  node |= tile << KWG_TILE_BIT_OFFSET;
+  return node;
+}
+
+static inline uint32_t
+dawg_arc_compressed_get_node_count(const DawgArcCompressed *dp) {
+  return dp->node_count;
+}
+
+static inline uint32_t
+dawg_arc_compressed_get_root_index(const DawgArcCompressed *dp) {
+  return dp->root_index;
+}
+
+static inline size_t
+dawg_arc_compressed_get_num_bytes(const DawgArcCompressed *dp) {
+  return dp->num_bytes;
+}
+
+void dawg_arc_compressed_destroy(DawgArcCompressed *dp);
+
+// Builds an arc-compressed DAWG from a DAWG-only KWG (read only; not modified).
+// mode selects the size/speed operating point (see dawg_arc_compressed_mode_t).
+DawgArcCompressed *
+dawg_arc_compressed_create_from_kwg(const KWG *kwg,
+                                    dawg_arc_compressed_mode_t mode);
+
+void dawg_arc_compressed_write_to_file(const DawgArcCompressed *dp,
+                                       const char *filename,
+                                       ErrorStack *error_stack);
+
+DawgArcCompressed *dawg_arc_compressed_read_from_file(const char *filename,
+                                                      ErrorStack *error_stack);
+
+// Appends every word reachable from the arc-compressed DAWG's root to words.
+void dawg_arc_compressed_write_words(const DawgArcCompressed *dp,
+                                     DictionaryWordList *words);
+
+#endif

--- a/src/impl/autoplay.c
+++ b/src/impl/autoplay.c
@@ -37,6 +37,7 @@
 #include "gameplay.h"
 #include "rack_list.h"
 #include "simmer.h"
+#include "word_playability.h"
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -297,6 +298,9 @@ typedef struct AutoplayWorker {
   Rack nontarget_known_rack;
   Rack target_known_rack;
   MoveList *move_lists[2];
+  // Per-thread word-playability accumulator; NULL unless args.playability is
+  // set.
+  WordPlayabilityCounts *playability_counts;
 } AutoplayWorker;
 
 AutoplayWorker *autoplay_worker_create(const AutoplayArgs *args,
@@ -334,6 +338,10 @@ AutoplayWorker *autoplay_worker_create(const AutoplayArgs *args,
   autoplay_worker->sim_results = NULL;
   autoplay_worker->inference_results = NULL;
   autoplay_worker->error_stack = NULL;
+  autoplay_worker->playability_counts =
+      ap_args->playability
+          ? word_playability_counts_create(ap_args->playability)
+          : NULL;
 
   // Only allocate sim structs if at least one of the players running a sim.
   if (ap_args->p1_sim_args.num_plies > 0 ||
@@ -364,6 +372,7 @@ void autoplay_worker_destroy(AutoplayWorker *autoplay_worker) {
   error_stack_destroy(autoplay_worker->error_stack);
   move_list_destroy(autoplay_worker->move_lists[0]);
   move_list_destroy(autoplay_worker->move_lists[1]);
+  word_playability_counts_destroy(autoplay_worker->playability_counts);
   free(autoplay_worker);
 }
 
@@ -666,6 +675,14 @@ const Move *game_runner_play_move(AutoplayWorker *autoplay_worker,
   get_leave_for_move(move, game, &rare_rack_or_move_leave);
   autoplay_results_add_move(autoplay_worker->autoplay_results,
                             game_runner->game, move, &rare_rack_or_move_leave);
+
+  // Word-playability analyzes the position the player on turn faces, using its
+  // own full move list (the engine's list is best-only under static equity).
+  if (autoplay_worker->playability_counts) {
+    word_playability_counts_add_position(autoplay_worker->playability_counts,
+                                         autoplay_worker->args.playability,
+                                         game);
+  }
 
   // Print board with move about to be played if requested
   if (autoplay_worker->args.print_boards) {
@@ -1045,6 +1062,26 @@ void autoplay(const AutoplayArgs *args, AutoplayResults *autoplay_results,
   if (!is_leavegen_mode) {
     autoplay_results_consolidate(autoplay_results_list, autoplay_num_threads,
                                  autoplay_results);
+  }
+
+  // Reduce the per-thread word-playability tables into the first worker's and
+  // write the sorted CSV. Done before the workers are destroyed.
+  if (args->playability && autoplay_num_threads > 0) {
+    WordPlayabilityCounts *totals = autoplay_workers[0]->playability_counts;
+    for (int thread_index = 1; thread_index < autoplay_num_threads;
+         thread_index++) {
+      word_playability_counts_merge(
+          totals, autoplay_workers[thread_index]->playability_counts);
+    }
+    word_playability_write_csv(args->playability, totals, error_stack);
+    const uint64_t positions = word_playability_counts_get_positions(totals);
+    const uint64_t bingos = word_playability_counts_get_bingos(totals);
+    char *pb_status = get_formatted_string(
+        "playability: %llu bingos in %llu best-play turns (%.4f bingos/turn)\n",
+        (unsigned long long)bingos, (unsigned long long)positions,
+        positions > 0 ? (double)bingos / (double)positions : 0.0);
+    thread_control_print(thread_control, pb_status);
+    free(pb_status);
   }
 
   autoplay_results_set_status_data(autoplay_results, NULL, 0, true,

--- a/src/impl/autoplay.h
+++ b/src/impl/autoplay.h
@@ -7,6 +7,7 @@
 #include "../ent/sim_args.h"
 #include "../ent/thread_control.h"
 #include "../util/io_util.h"
+#include "word_playability.h"
 #include <stdbool.h>
 
 typedef struct GameStringOptions GameStringOptions;
@@ -29,6 +30,10 @@ typedef struct AutoplayArgs {
   double cutoff;
   SimArgs p1_sim_args;
   SimArgs p2_sim_args;
+  // When non-NULL, every position the player on turn faces is analyzed for the
+  // word-playability metrics and a CSV is written at the end. Owned by the
+  // caller (config), borrowed here. NULL for ordinary autoplay/leavegen.
+  const WordPlayabilityContext *playability;
 } AutoplayArgs;
 
 void autoplay(const AutoplayArgs *args, AutoplayResults *autoplay_results,

--- a/src/impl/compact_leaves_maker.c
+++ b/src/impl/compact_leaves_maker.c
@@ -1,0 +1,958 @@
+#include "compact_leaves_maker.h"
+
+#include "../ent/equity.h"
+#include "../ent/klv.h"
+#include "../ent/letter_distribution.h"
+#include "../ent/rack.h"
+#include "../util/io_util.h"
+#include "../util/string_util.h"
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+enum {
+  CLM_VC_DIM = COMPACT_LEAVES_VC_DIM,          // 5
+  CLM_VC_CLAMP = COMPACT_LEAVES_VC_CLAMP,      // 4
+  CLM_VC_CELLS = COMPACT_LEAVES_VC_TABLE_SIZE, // 25
+  CLM_MAX_LEAVE = (RACK_SIZE)-1,               // 6
+  // Open-addressing table for distinct sub-multiset candidates. 2^22 covers the
+  // largest shipped distribution (Polish ~2.64M distinct size-2..6 combos) at a
+  // safe load factor; cand_hash_add aborts rather than spin if ever full.
+  CLM_HASH_BITS = 22,
+  CLM_HASH_SIZE = 1 << CLM_HASH_BITS,
+  // Most synergy sub-multisets a single leave (<= 6 tiles) can contain is
+  // C(6,2)+...+C(6,6) = 57; round up for headroom.
+  CLM_MAX_ACTIVE = 64,
+  // Cap on conjugate-gradient iterations when jointly fitting synergy coefs.
+  // Large synergy sets (tens of thousands, e.g. bit-packed 256 KB) are
+  // ill-conditioned and need many iterations; matvecs are cheap (CSR) and the
+  // relative-residual tolerance stops early once converged.
+  CLM_CG_MAX_ITERS = 1000,
+};
+
+// Conjugate-gradient convergence: stop when the residual norm drops to this
+// fraction of the initial right-hand-side norm.
+static const double CLM_CG_TOL = 1e-4;
+
+// ---- open-addressing hash: packed-multiset key -> candidate index ----
+typedef struct CandHash {
+  uint64_t *keys; // 0 = empty
+  double *s1;     // sum_L w_L * residual_L over leaves containing the combo
+  double *s2;     // sum_L w_L
+  uint8_t *ntiles;
+  uint32_t count;
+} CandHash;
+
+static void cand_hash_create(CandHash *h) {
+  h->keys = (uint64_t *)calloc_or_die(CLM_HASH_SIZE, sizeof(uint64_t));
+  h->s1 = (double *)calloc_or_die(CLM_HASH_SIZE, sizeof(double));
+  h->s2 = (double *)calloc_or_die(CLM_HASH_SIZE, sizeof(double));
+  h->ntiles = (uint8_t *)calloc_or_die(CLM_HASH_SIZE, 1);
+  h->count = 0;
+}
+static void cand_hash_destroy(CandHash *h) {
+  free(h->keys);
+  free(h->s1);
+  free(h->s2);
+  free(h->ntiles);
+}
+static void cand_hash_add(CandHash *h, uint64_t key, uint8_t ntiles, double w,
+                          double residual) {
+  uint64_t slot = (key * 0x9E3779B97F4A7C15ULL) >> (64 - CLM_HASH_BITS);
+  uint32_t probes = 0;
+  for (;;) {
+    if (h->keys[slot] == 0) {
+      h->keys[slot] = key;
+      h->ntiles[slot] = ntiles;
+      h->count++;
+      break;
+    }
+    if (h->keys[slot] == key) {
+      break;
+    }
+    slot = (slot + 1) & (CLM_HASH_SIZE - 1);
+    if (++probes >= CLM_HASH_SIZE) {
+      log_fatal(
+          "compact leaves candidate hash is full; increase CLM_HASH_BITS");
+    }
+  }
+  h->s1[slot] += w * residual;
+  h->s2[slot] += w;
+}
+
+// ---- dense SPD solve via Cholesky (G is p x p, row-major) ----
+static void cholesky_solve(double *g, const double *r, double *x, int p) {
+  // In-place Cholesky factor of g (lower), then forward/back substitution.
+  for (int i = 0; i < p; i++) {
+    for (int j = 0; j <= i; j++) {
+      double sum = g[i * p + j];
+      for (int k = 0; k < j; k++) {
+        sum -= g[i * p + k] * g[j * p + k];
+      }
+      if (i == j) {
+        g[i * p + j] = sqrt(sum > 1e-12 ? sum : 1e-12);
+      } else {
+        g[i * p + j] = sum / g[j * p + j];
+      }
+    }
+  }
+  for (int i = 0; i < p; i++) {
+    double sum = r[i];
+    for (int k = 0; k < i; k++) {
+      sum -= g[i * p + k] * x[k];
+    }
+    x[i] = sum / g[i * p + i];
+  }
+  for (int i = p - 1; i >= 0; i--) {
+    double sum = x[i];
+    for (int k = i + 1; k < p; k++) {
+      sum -= g[k * p + i] * x[k];
+    }
+    x[i] = sum / g[i * p + i];
+  }
+}
+
+// ---- vowel/consonant cell (0..24), with (0,0) pinned (returns -1) ----
+static int vc_cell(int num_vowels, int num_consonants) {
+  const int v = num_vowels > CLM_VC_CLAMP ? CLM_VC_CLAMP : num_vowels;
+  const int c = num_consonants > CLM_VC_CLAMP ? CLM_VC_CLAMP : num_consonants;
+  const int cell = v * CLM_VC_DIM + c;
+  return cell; // caller treats cell 0 as the pinned/absorbed reference
+}
+
+// Per-leave fixed-point quantizer: points -> ticks at the given radix.
+static int16_t quantize_ticks(double coef_points, int32_t radix_millipoints) {
+  long t = lround(coef_points * 1000.0 / (double)radix_millipoints);
+  if (t > 32767) {
+    t = 32767;
+  } else if (t < -32768) {
+    t = -32768;
+  }
+  return (int16_t)t;
+}
+
+// Context threaded through the leave enumeration.
+typedef struct FitState {
+  const KLV *klv;
+  const LetterDistribution *ld;
+  const uint64_t *weights; // by KLV word index; NULL => uniform
+  uint8_t dist_size;
+  uint64_t vowel_bits;
+  Rack *leave;
+  int base_p;
+} FitState;
+
+static inline double leave_weight(const FitState *st, uint32_t word_index) {
+  if (st->weights == NULL) {
+    return 1.0;
+  }
+  return (double)st->weights[word_index];
+}
+
+// Builds the sparse base feature row (col,val pairs) for the current leave and
+// returns its length; also returns nv/nc. cols/vals must hold >= 2 + dist_size.
+static int base_row(const FitState *st, const Rack *leave, int *cols,
+                    double *vals, int *out_nv, int *out_nc) {
+  const int A = st->dist_size;
+  int len = 0;
+  cols[len] = 0;
+  vals[len] = 1.0; // intercept
+  len++;
+  int nv = 0;
+  int nc = 0;
+  for (int ml = 0; ml < A; ml++) {
+    const int n = rack_get_letter(leave, ml);
+    if (n == 0) {
+      continue;
+    }
+    cols[len] = 1 + ml;
+    vals[len] = n;
+    len++;
+    if (n > 1) {
+      cols[len] = 1 + A + ml;
+      vals[len] = n - 1;
+      len++;
+    }
+    if (ml != 0) {
+      if ((st->vowel_bits >> ml) & 1U) {
+        nv += n;
+      } else {
+        nc += n;
+      }
+    }
+  }
+  const int cell = vc_cell(nv, nc);
+  if (cell != 0) {
+    cols[len] = 1 + 2 * A + (cell - 1);
+    vals[len] = 1.0;
+    len++;
+  }
+  *out_nv = nv;
+  *out_nc = nc;
+  return len;
+}
+
+// Recursively enumerate every leave (multiset of size 1..CLM_MAX_LEAVE)
+// drawable from bag, invoking cb for each. cb reads st->leave.
+typedef void (*leave_cb_t)(FitState *, void *);
+static void enum_leaves(FitState *st, const Rack *bag, int ml, int size,
+                        leave_cb_t cb, void *cb_data) {
+  if (ml >= st->dist_size) {
+    if (size >= 1) {
+      cb(st, cb_data);
+    }
+    return;
+  }
+  int max_here = rack_get_letter(bag, ml);
+  if (max_here > CLM_MAX_LEAVE - size) {
+    max_here = CLM_MAX_LEAVE - size;
+  }
+  for (int c = 0; c <= max_here; c++) {
+    if (c > 0) {
+      rack_add_letter(st->leave, ml);
+    }
+    enum_leaves(st, bag, ml + 1, size + c, cb, cb_data);
+  }
+  // Restore: remove the copies of ml we added in this frame.
+  while (rack_get_letter(st->leave, ml) > 0) {
+    rack_take_letter(st->leave, ml);
+  }
+}
+
+// ---- pass 1: accumulate base Gram + r ----
+typedef struct GramAcc {
+  double *gram;
+  double *rvec;
+  int p;
+} GramAcc;
+static void cb_gram(FitState *st, void *data) {
+  GramAcc *acc = (GramAcc *)data;
+  int cols[2 + MAX_ALPHABET_SIZE];
+  double vals[2 + MAX_ALPHABET_SIZE];
+  int nv;
+  int nc;
+  const int len = base_row(st, st->leave, cols, vals, &nv, &nc);
+  const uint32_t idx = klv_get_word_index(st->klv, st->leave);
+  const double w = leave_weight(st, idx);
+  if (w == 0.0) {
+    return;
+  }
+  const double y = equity_to_double(klv_get_indexed_leave_value(st->klv, idx));
+  const int p = acc->p;
+  for (int a = 0; a < len; a++) {
+    acc->rvec[cols[a]] += w * vals[a] * y;
+    for (int b = 0; b < len; b++) {
+      acc->gram[cols[a] * p + cols[b]] += w * vals[a] * vals[b];
+    }
+  }
+}
+
+// Collects the (machine-letter, count) pairs of the present tiles in a leave
+// into pml/pcnt and returns how many distinct tiles are present.
+static int present_tiles(const Rack *leave, int dist_size, int *pml,
+                         int *pcnt) {
+  int num_present = 0;
+  for (int ml = 0; ml < dist_size; ml++) {
+    const int n = rack_get_letter(leave, ml);
+    if (n > 0) {
+      pml[num_present] = ml;
+      pcnt[num_present] = n;
+      num_present++;
+    }
+  }
+  return num_present;
+}
+
+// Generic enumeration of every sub-multiset (size 2..CLM_MAX_LEAVE) of the
+// present tiles, invoking cb(packed_key, ntiles, ctx) for each.
+typedef void (*submultiset_cb)(uint64_t key, uint8_t ntiles, void *ctx);
+static void walk_submultisets(const int *pml, const int *pcnt, int num_present,
+                              int idx, int subsize, uint64_t key,
+                              submultiset_cb cb, void *ctx) {
+  if (idx == num_present) {
+    if (subsize >= 2) {
+      cb(key, (uint8_t)subsize, ctx);
+    }
+    return;
+  }
+  // choose how many of present tile idx to include (0..pcnt[idx]), capped so
+  // total stays <= CLM_MAX_LEAVE.
+  int maxc = pcnt[idx];
+  if (maxc > CLM_MAX_LEAVE - subsize) {
+    maxc = CLM_MAX_LEAVE - subsize;
+  }
+  for (int count = 0; count <= maxc; count++) {
+    uint64_t new_key = key;
+    for (int copy = 0; copy < count; copy++) {
+      new_key = (new_key << 6) | (uint64_t)(pml[idx] + 1);
+    }
+    walk_submultisets(pml, pcnt, num_present, idx + 1, subsize + count, new_key,
+                      cb, ctx);
+  }
+}
+
+// ---- pass 2: residual (vs quantized base) + candidate synergy accumulation --
+typedef struct ResAcc {
+  const CompactLeaves *cl; // base-only model (num_synergies == 0)
+  CandHash *hash;
+} ResAcc;
+typedef struct HashSink {
+  CandHash *hash;
+  double w;
+  double e;
+} HashSink;
+static void hash_sink_cb(uint64_t key, uint8_t ntiles, void *ctx) {
+  HashSink *sink = (HashSink *)ctx;
+  cand_hash_add(sink->hash, key, ntiles, sink->w, sink->e);
+}
+static void cb_residual(FitState *st, void *data) {
+  const ResAcc *acc = (const ResAcc *)data;
+  const uint32_t idx = klv_get_word_index(st->klv, st->leave);
+  const double w = leave_weight(st, idx);
+  if (w == 0.0) {
+    return;
+  }
+  const double y = equity_to_double(klv_get_indexed_leave_value(st->klv, idx));
+  const double base =
+      equity_to_double(compact_leaves_get_leave_value(acc->cl, st->leave));
+  const double e = y - base;
+  int pml[MAX_ALPHABET_SIZE];
+  int pcnt[MAX_ALPHABET_SIZE];
+  const int num_present = present_tiles(st->leave, st->dist_size, pml, pcnt);
+  HashSink sink = {.hash = acc->hash, .w = w, .e = e};
+  walk_submultisets(pml, pcnt, num_present, 0, 0, 0, hash_sink_cb, &sink);
+}
+
+// ---- selected-synergy hash: packed key -> index in the selected array ----
+typedef struct SelHash {
+  uint64_t *keys; // 0 = empty (a real synergy key is always nonzero)
+  int32_t *idx;
+  uint32_t cap;
+  int shift;
+} SelHash;
+static void sel_hash_create(SelHash *h, uint32_t num_selected) {
+  uint32_t cap = 16;
+  while (cap < num_selected * 2 + 1) {
+    cap <<= 1;
+  }
+  h->keys = (uint64_t *)calloc_or_die(cap, sizeof(uint64_t));
+  h->idx = (int32_t *)malloc_or_die((size_t)cap * sizeof(int32_t));
+  h->cap = cap;
+  int bits = 0;
+  while ((1u << bits) < cap) {
+    bits++;
+  }
+  h->shift = 64 - bits;
+}
+static void sel_hash_destroy(SelHash *h) {
+  free(h->keys);
+  free(h->idx);
+}
+static void sel_hash_put(SelHash *h, uint64_t key, int32_t value) {
+  uint64_t slot = (key * 0x9E3779B97F4A7C15ULL) >> h->shift;
+  while (h->keys[slot] != 0) {
+    slot = (slot + 1) & (h->cap - 1);
+  }
+  h->keys[slot] = key;
+  h->idx[slot] = value;
+}
+static int32_t sel_hash_get(const SelHash *h, uint64_t key) {
+  uint64_t slot = (key * 0x9E3779B97F4A7C15ULL) >> h->shift;
+  while (h->keys[slot] != 0) {
+    if (h->keys[slot] == key) {
+      return h->idx[slot];
+    }
+    slot = (slot + 1) & (h->cap - 1);
+  }
+  return -1;
+}
+
+// ---- backfitting: collect the selected synergies present in a leave ----
+typedef struct CollectSink {
+  const SelHash *sel;
+  int *active;
+  int num_active;
+} CollectSink;
+static void collect_sink_cb(uint64_t key, uint8_t ntiles, void *ctx) {
+  (void)ntiles;
+  CollectSink *sink = (CollectSink *)ctx;
+  const int32_t s = sel_hash_get(sink->sel, key);
+  if (s >= 0 && sink->num_active < CLM_MAX_ACTIVE) {
+    sink->active[sink->num_active++] = s;
+  }
+}
+
+// Returns the selected synergies present in the current leave (indices into the
+// selected array) via sink, and the leave's weight (0 => skip).
+static double leave_active(const FitState *st, const SelHash *sel,
+                           CollectSink *sink) {
+  const uint32_t idx = klv_get_word_index(st->klv, st->leave);
+  const double w = leave_weight(st, idx);
+  if (w == 0.0) {
+    return 0.0;
+  }
+  int pml[MAX_ALPHABET_SIZE];
+  int pcnt[MAX_ALPHABET_SIZE];
+  const int num_present = present_tiles(st->leave, st->dist_size, pml, pcnt);
+  sink->sel = sel;
+  sink->num_active = 0;
+  walk_submultisets(pml, pcnt, num_present, 0, 0, 0, collect_sink_cb, sink);
+  return w;
+}
+
+// We jointly fit the selected synergies by conjugate gradient on the ridge
+// normal equations (Phi^T W Phi + ridge I) x = Phi^T W r, where r = y - base.
+// CG is robust for this SPD system regardless of conditioning (plain Jacobi
+// backfitting diverges because nested combos are far from diagonally dominant,
+// and a dense Gram is infeasible at tens of thousands of synergies). The leaf x
+// synergy indicator matrix is applied implicitly via a CSR of each leaf's
+// active synergies, built once so CG iterations are pure arithmetic.
+
+// ---- pass A: count contributing rows (w > 0 and >= 1 active synergy) + nnz --
+typedef struct CsrCountAcc {
+  const SelHash *sel;
+  uint32_t num_rows;
+  size_t nnz;
+} CsrCountAcc;
+static void cb_csr_count(FitState *st, void *data) {
+  CsrCountAcc *acc = (CsrCountAcc *)data;
+  int active[CLM_MAX_ACTIVE] = {0};
+  CollectSink sink = {.sel = acc->sel, .active = active, .num_active = 0};
+  const double w = leave_active(st, acc->sel, &sink);
+  if (w == 0.0 || sink.num_active == 0) {
+    return;
+  }
+  acc->num_rows++;
+  acc->nnz += (size_t)sink.num_active;
+}
+
+// ---- pass B: fill the CSR (row weight, residual r = y - base, active set)
+// ----
+typedef struct CsrFillAcc {
+  const CompactLeaves *cl; // base-only model
+  const SelHash *sel;
+  double *row_w;
+  double *row_rhs;
+  size_t *row_off;
+  int *act;
+  uint32_t nr;
+  size_t cur;
+} CsrFillAcc;
+static void cb_csr_fill(FitState *st, void *data) {
+  CsrFillAcc *acc = (CsrFillAcc *)data;
+  int active[CLM_MAX_ACTIVE] = {0};
+  CollectSink sink = {.sel = acc->sel, .active = active, .num_active = 0};
+  const double w = leave_active(st, acc->sel, &sink);
+  if (w == 0.0 || sink.num_active == 0) {
+    return;
+  }
+  const uint32_t idx = klv_get_word_index(st->klv, st->leave);
+  const double y = equity_to_double(klv_get_indexed_leave_value(st->klv, idx));
+  const double base =
+      equity_to_double(compact_leaves_get_leave_value(acc->cl, st->leave));
+  acc->row_w[acc->nr] = w;
+  acc->row_rhs[acc->nr] = y - base;
+  acc->row_off[acc->nr] = acc->cur;
+  for (int a = 0; a < sink.num_active; a++) {
+    acc->act[acc->cur++] = active[a];
+  }
+  acc->nr++;
+}
+
+// Jointly fits the selected synergy coefficients (coef in/out: warm-started
+// from the marginal estimates, overwritten with the CG solution).
+static void solve_synergies_cg(FitState *st, const Rack *bag,
+                               const CompactLeaves *cl, const SelHash *sel,
+                               uint32_t num_synergies, double ridge,
+                               double *coef) {
+  CsrCountAcc count_acc = {.sel = sel, .num_rows = 0, .nnz = 0};
+  enum_leaves(st, bag, 0, 0, cb_csr_count, &count_acc);
+  const uint32_t num_rows = count_acc.num_rows;
+  const size_t nnz = count_acc.nnz;
+  if (num_rows == 0 || nnz == 0) {
+    for (uint32_t s = 0; s < num_synergies; s++) {
+      coef[s] = 0.0;
+    }
+    return;
+  }
+  double *row_w = (double *)malloc_or_die((size_t)num_rows * sizeof(double));
+  double *row_rhs = (double *)malloc_or_die((size_t)num_rows * sizeof(double));
+  size_t *row_off =
+      (size_t *)malloc_or_die(((size_t)num_rows + 1) * sizeof(size_t));
+  int *act = (int *)malloc_or_die(nnz * sizeof(int));
+  CsrFillAcc fill_acc = {.cl = cl,
+                         .sel = sel,
+                         .row_w = row_w,
+                         .row_rhs = row_rhs,
+                         .row_off = row_off,
+                         .act = act,
+                         .nr = 0,
+                         .cur = 0};
+  enum_leaves(st, bag, 0, 0, cb_csr_fill, &fill_acc);
+  row_off[fill_acc.nr] = fill_acc.cur;
+
+  double *rhs = (double *)calloc_or_die(num_synergies, sizeof(double));
+  for (uint32_t r = 0; r < num_rows; r++) {
+    const double wr = row_w[r] * row_rhs[r];
+    for (size_t k = row_off[r]; k < row_off[r + 1]; k++) {
+      rhs[act[k]] += wr;
+    }
+  }
+  double *res = (double *)malloc_or_die(num_synergies * sizeof(double));
+  double *pvec = (double *)malloc_or_die(num_synergies * sizeof(double));
+  double *avec = (double *)malloc_or_die(num_synergies * sizeof(double));
+  // avec = A * coef (warm-start matvec), then res = rhs - avec.
+  for (uint32_t s = 0; s < num_synergies; s++) {
+    avec[s] = ridge * coef[s];
+  }
+  for (uint32_t r = 0; r < num_rows; r++) {
+    double sp = 0.0;
+    for (size_t k = row_off[r]; k < row_off[r + 1]; k++) {
+      sp += coef[act[k]];
+    }
+    const double wsp = row_w[r] * sp;
+    for (size_t k = row_off[r]; k < row_off[r + 1]; k++) {
+      avec[act[k]] += wsp;
+    }
+  }
+  double rs_old = 0.0;
+  double rhs_norm2 = 0.0;
+  for (uint32_t s = 0; s < num_synergies; s++) {
+    res[s] = rhs[s] - avec[s];
+    pvec[s] = res[s];
+    rs_old += res[s] * res[s];
+    rhs_norm2 += rhs[s] * rhs[s];
+  }
+  const double tol2 =
+      CLM_CG_TOL * CLM_CG_TOL * (rhs_norm2 > 0.0 ? rhs_norm2 : 1.0);
+  const uint32_t max_iters =
+      num_synergies < CLM_CG_MAX_ITERS ? num_synergies : CLM_CG_MAX_ITERS;
+  for (uint32_t it = 0; it < max_iters && rs_old > tol2; it++) {
+    // avec = (Phi^T W Phi + ridge I) pvec
+    for (uint32_t s = 0; s < num_synergies; s++) {
+      avec[s] = ridge * pvec[s];
+    }
+    for (uint32_t r = 0; r < num_rows; r++) {
+      double sp = 0.0;
+      for (size_t k = row_off[r]; k < row_off[r + 1]; k++) {
+        sp += pvec[act[k]];
+      }
+      const double wsp = row_w[r] * sp;
+      for (size_t k = row_off[r]; k < row_off[r + 1]; k++) {
+        avec[act[k]] += wsp;
+      }
+    }
+    double pap = 0.0;
+    for (uint32_t s = 0; s < num_synergies; s++) {
+      pap += pvec[s] * avec[s];
+    }
+    if (pap <= 0.0) {
+      break;
+    }
+    const double alpha = rs_old / pap;
+    double rs_new = 0.0;
+    for (uint32_t s = 0; s < num_synergies; s++) {
+      coef[s] += alpha * pvec[s];
+      res[s] -= alpha * avec[s];
+      rs_new += res[s] * res[s];
+    }
+    const double beta_cg = rs_new / rs_old;
+    for (uint32_t s = 0; s < num_synergies; s++) {
+      pvec[s] = res[s] + beta_cg * pvec[s];
+    }
+    rs_old = rs_new;
+  }
+  free(rhs);
+  free(res);
+  free(pvec);
+  free(avec);
+  free(row_w);
+  free(row_rhs);
+  free(row_off);
+  free(act);
+}
+
+// Decode a packed synergy key back into sorted machine letters.
+static uint8_t unpack_key(uint64_t key, MachineLetter *tiles) {
+  MachineLetter tmp[COMPACT_LEAVES_MAX_SYNERGY_TILES];
+  uint8_t n = 0;
+  while (key != 0 && n < COMPACT_LEAVES_MAX_SYNERGY_TILES) {
+    tmp[n++] = (MachineLetter)((key & 0x3F) - 1);
+    key >>= 6;
+  }
+  // tmp is high-to-low; the key was built ascending so reverse to sorted order.
+  for (uint8_t i = 0; i < n; i++) {
+    tiles[i] = tmp[n - 1 - i];
+  }
+  return n;
+}
+
+typedef struct ScoredCand {
+  uint64_t key;
+  double score; // weighted-error-reduction per byte
+  double coef;  // points
+  uint8_t ntiles;
+} ScoredCand;
+
+static int scored_cand_cmp(const void *a, const void *b) {
+  const ScoredCand *x = (const ScoredCand *)a;
+  const ScoredCand *y = (const ScoredCand *)b;
+  if (x->score < y->score) {
+    return 1;
+  }
+  if (x->score > y->score) {
+    return -1;
+  }
+  return 0;
+}
+
+// Bit-width helpers for the optional bit-packed format (mirror the codec's
+// zigzag + bits_needed so the maker can size the body in bits).
+static int clm_bits_needed(uint32_t max_value) {
+  int bits = 0;
+  while (max_value > 0) {
+    bits++;
+    max_value >>= 1;
+  }
+  return bits < 1 ? 1 : bits;
+}
+static int clm_coef_bits(int32_t ticks) {
+  const uint32_t sign = ticks < 0 ? 0xFFFFFFFFU : 0U;
+  const uint32_t zigzag = ((uint32_t)ticks << 1) ^ sign;
+  return clm_bits_needed(zigzag);
+}
+
+CompactLeaves *
+compact_leaves_create_from_klv(const KLV *klv, const LetterDistribution *ld,
+                               const uint64_t *weights, size_t target_bytes,
+                               uint8_t radix_code, bool bit_packed) {
+  const int A = ld_get_size(ld);
+  const int radix_mp = compact_leaves_radix_millipoints(radix_code);
+  const double synergy_ridge = 1.0;
+
+  FitState st = {.klv = klv,
+                 .ld = ld,
+                 .weights = weights,
+                 .dist_size = (uint8_t)A,
+                 .vowel_bits = 0,
+                 .leave = rack_create((uint16_t)A),
+                 .base_p = 1 + 2 * A + (CLM_VC_CELLS - 1)};
+  for (int ml = 1; ml < A; ml++) {
+    if (ld_get_is_vowel(ld, ml)) {
+      st.vowel_bits |= (uint64_t)1 << ml;
+    }
+  }
+  const int p = st.base_p;
+  Rack *bag = get_new_bag_as_rack(ld);
+
+  // Pass 1: base Gram + r, then ridge + Cholesky solve.
+  GramAcc gram_acc = {
+      .gram = (double *)calloc_or_die((size_t)p * p, sizeof(double)),
+      .rvec = (double *)calloc_or_die(p, sizeof(double)),
+      .p = p};
+  enum_leaves(&st, bag, 0, 0, cb_gram, &gram_acc);
+  double diag_mean = 0.0;
+  for (int i = 0; i < p; i++) {
+    diag_mean += gram_acc.gram[i * p + i];
+  }
+  diag_mean /= p;
+  const double ridge = diag_mean * 1e-4 + 1e-9;
+  for (int i = 0; i < p; i++) {
+    gram_acc.gram[i * p + i] += ridge;
+  }
+  double *beta = (double *)calloc_or_die(p, sizeof(double));
+  cholesky_solve(gram_acc.gram, gram_acc.rvec, beta, p);
+
+  // Quantize the base model into cl now, with no synergies yet, so that pass 2
+  // and backfitting both fit synergies against the *quantized* base that eval
+  // will actually use (keeps fit and eval consistent).
+  CompactLeaves *cl = (CompactLeaves *)calloc_or_die(1, sizeof(CompactLeaves));
+  cl->dist_size = (uint8_t)A;
+  cl->radix_code = radix_code;
+  cl->radix_millipoints = radix_mp;
+  cl->flags = COMPACT_LEAVES_FLAG_HAS_DUP | COMPACT_LEAVES_FLAG_VC_TABLE;
+  if (bit_packed) {
+    cl->flags |= COMPACT_LEAVES_FLAG_BITPACKED;
+  }
+  cl->vowel_bits = st.vowel_bits;
+  cl->base_ticks = quantize_ticks(beta[0], radix_mp);
+  cl->tile_ticks = (int16_t *)calloc_or_die((size_t)A, sizeof(int16_t));
+  cl->dup_ticks = (int16_t *)calloc_or_die((size_t)A, sizeof(int16_t));
+  for (int ml = 0; ml < A; ml++) {
+    cl->tile_ticks[ml] = quantize_ticks(beta[1 + ml], radix_mp);
+    cl->dup_ticks[ml] = quantize_ticks(beta[1 + A + ml], radix_mp);
+  }
+  cl->vc_ticks[0] = 0; // pinned reference cell
+  for (int cell = 1; cell < CLM_VC_CELLS; cell++) {
+    cl->vc_ticks[cell] = quantize_ticks(beta[1 + 2 * A + (cell - 1)], radix_mp);
+  }
+  cl->num_synergies = 0;
+  cl->synergies = NULL;
+
+  // Pass 2: residuals vs the quantized base + candidate synergy stats.
+  CandHash hash;
+  cand_hash_create(&hash);
+  ResAcc res_acc = {.cl = cl, .hash = &hash};
+  enum_leaves(&st, bag, 0, 0, cb_residual, &res_acc);
+
+  // Score candidates by marginal weighted-error reduction per byte.
+  ScoredCand *scored =
+      (ScoredCand *)malloc_or_die((size_t)hash.count * sizeof(ScoredCand));
+  uint32_t num_scored = 0;
+  for (uint32_t slot = 0; slot < CLM_HASH_SIZE; slot++) {
+    if (hash.keys[slot] == 0 || hash.s2[slot] <= 0.0) {
+      continue;
+    }
+    const double denom = hash.s2[slot] + synergy_ridge;
+    const double coef = hash.s1[slot] / denom;
+    const double gain = (hash.s1[slot] * hash.s1[slot]) / denom;
+    const uint8_t nt = hash.ntiles[slot];
+    const double bytes = 1.0 + nt + 2.0;
+    scored[num_scored].key = hash.keys[slot];
+    scored[num_scored].score = gain / bytes;
+    scored[num_scored].coef = coef;
+    scored[num_scored].ntiles = nt;
+    num_scored++;
+  }
+  qsort(scored, num_scored, sizeof(ScoredCand), scored_cand_cmp);
+
+  // Size accounting for synergy selection. Byte mode: a synergy costs
+  // 1 (num_tiles) + ntiles + 2 (value) bytes against target_bytes, starting
+  // from the fixed base block. Bit mode: synergies and coefficients are
+  // sub-byte packed, so cost is in bits against a bit budget -- more fit.
+  const size_t base_bytes = (size_t)COMPACT_LEAVES_HEADER_BYTES + 8 + 2 +
+                            (size_t)A * 2 + (size_t)A * 2 + CLM_VC_CELLS * 2;
+  int coef_bits = 0;
+  int tile_bits = 0;
+  int nt_bits = 0;
+  if (bit_packed) {
+    // coef_bits: fixed zigzag width holding every coefficient. Derive a bound
+    // from the base coefficients and all candidate marginals so the jointly-fit
+    // values (clamped to this width on emit) round-trip.
+    coef_bits = clm_coef_bits(cl->base_ticks);
+    for (int ml = 0; ml < A; ml++) {
+      const int tb = clm_coef_bits(cl->tile_ticks[ml]);
+      const int db = clm_coef_bits(cl->dup_ticks[ml]);
+      coef_bits = tb > coef_bits ? tb : coef_bits;
+      coef_bits = db > coef_bits ? db : coef_bits;
+    }
+    for (int cell = 0; cell < CLM_VC_CELLS; cell++) {
+      const int vcb = clm_coef_bits(cl->vc_ticks[cell]);
+      coef_bits = vcb > coef_bits ? vcb : coef_bits;
+    }
+    for (uint32_t i = 0; i < num_scored; i++) {
+      const int scb = clm_coef_bits(quantize_ticks(scored[i].coef, radix_mp));
+      coef_bits = scb > coef_bits ? scb : coef_bits;
+    }
+    tile_bits = clm_bits_needed((uint32_t)A - 1);
+    nt_bits = clm_bits_needed(COMPACT_LEAVES_MAX_SYNERGY_TILES);
+    cl->coef_bits = (uint8_t)coef_bits;
+  }
+  const size_t base_coef_count = 1 + (size_t)A + (size_t)A + CLM_VC_CELLS;
+  const size_t prefix_bytes = (size_t)COMPACT_LEAVES_HEADER_BYTES + 8 + 1;
+  const size_t used0 =
+      bit_packed ? base_coef_count * (size_t)coef_bits : base_bytes;
+  const size_t budget = bit_packed ? (target_bytes > prefix_bytes
+                                          ? (target_bytes - prefix_bytes) * 8
+                                          : 0)
+                                   : target_bytes;
+
+  // Greedy by score (already sorted desc); a smaller later term can still fit
+  // after a larger earlier one was skipped. First count how many fit.
+  size_t used = used0;
+  uint32_t num_synergies = 0;
+  for (uint32_t i = 0; i < num_scored; i++) {
+    const size_t cost = bit_packed
+                            ? (size_t)nt_bits +
+                                  (size_t)scored[i].ntiles * (size_t)tile_bits +
+                                  (size_t)coef_bits
+                            : 1 + (size_t)scored[i].ntiles + 2;
+    if (used + cost <= budget) {
+      used += cost;
+      num_synergies++;
+    }
+  }
+
+  // Materialize the selected set: keys, warm-start coefs (marginal estimate),
+  // and a key -> selected-index hash for the joint refit.
+  const uint32_t sel_alloc = num_synergies > 0 ? num_synergies : 1;
+  uint64_t *sel_key = (uint64_t *)malloc_or_die(sel_alloc * sizeof(uint64_t));
+  double *sel_coef = (double *)calloc_or_die(sel_alloc, sizeof(double));
+  SelHash sel;
+  sel_hash_create(&sel, num_synergies);
+  used = used0;
+  uint32_t selected = 0;
+  for (uint32_t i = 0; i < num_scored && selected < num_synergies; i++) {
+    const size_t cost = bit_packed
+                            ? (size_t)nt_bits +
+                                  (size_t)scored[i].ntiles * (size_t)tile_bits +
+                                  (size_t)coef_bits
+                            : 1 + (size_t)scored[i].ntiles + 2;
+    if (used + cost > budget) {
+      continue;
+    }
+    used += cost;
+    sel_key[selected] = scored[i].key;
+    sel_coef[selected] = scored[i].coef;
+    sel_hash_put(&sel, scored[i].key, (int32_t)selected);
+    selected++;
+  }
+  num_synergies = selected;
+
+  // Jointly refit the selected synergy coefficients so overlapping / nested
+  // combos share the residual instead of each independently claiming it (the
+  // marginal estimates above systematically overshoot when applied additively).
+  if (num_synergies > 0) {
+    solve_synergies_cg(&st, bag, cl, &sel, num_synergies, synergy_ridge,
+                       sel_coef);
+  }
+
+  // Emit the jointly fit synergies into cl. In bit mode the value is clamped to
+  // coef_bits so the serialized size matches the selection budget exactly.
+  cl->synergies = (CompactLeavesSynergy *)calloc_or_die(
+      sel_alloc, sizeof(CompactLeavesSynergy));
+  const int32_t value_max = bit_packed ? (1 << (coef_bits - 1)) - 1 : 0;
+  const int32_t value_min = bit_packed ? -(1 << (coef_bits - 1)) : 0;
+  for (uint32_t s = 0; s < num_synergies; s++) {
+    CompactLeavesSynergy *syn = &cl->synergies[s];
+    syn->num_tiles = unpack_key(sel_key[s], syn->tiles);
+    int32_t value = quantize_ticks(sel_coef[s], radix_mp);
+    if (bit_packed) {
+      value = value > value_max ? value_max
+                                : (value < value_min ? value_min : value);
+    }
+    syn->value_ticks = (int16_t)value;
+  }
+  cl->num_synergies = num_synergies;
+
+  free(sel_key);
+  free(sel_coef);
+  sel_hash_destroy(&sel);
+  free(scored);
+  cand_hash_destroy(&hash);
+  free(beta);
+  free(gram_acc.gram);
+  free(gram_acc.rvec);
+  rack_destroy(bag);
+  rack_destroy(st.leave);
+  return cl;
+}
+
+// ---- expand the model into a KLV (lossy) ----
+typedef struct OverwriteAcc {
+  const CompactLeaves *cl;
+  KLV *klv;
+} OverwriteAcc;
+static void cb_overwrite(FitState *st, void *data) {
+  const OverwriteAcc *acc = (const OverwriteAcc *)data;
+  const uint32_t idx = klv_get_word_index(st->klv, st->leave);
+  klv_set_indexed_leave_value(
+      acc->klv, idx, compact_leaves_get_leave_value(acc->cl, st->leave));
+}
+void compact_leaves_overwrite_klv(const CompactLeaves *cl, KLV *klv,
+                                  const LetterDistribution *ld) {
+  const int A = ld_get_size(ld);
+  FitState st = {.klv = klv,
+                 .ld = ld,
+                 .weights = NULL,
+                 .dist_size = (uint8_t)A,
+                 .vowel_bits = cl->vowel_bits,
+                 .leave = rack_create((uint16_t)A),
+                 .base_p = 0};
+  Rack *bag = get_new_bag_as_rack(ld);
+  OverwriteAcc acc = {.cl = cl, .klv = klv};
+  enum_leaves(&st, bag, 0, 0, cb_overwrite, &acc);
+  rack_destroy(bag);
+  rack_destroy(st.leave);
+}
+
+// ---- RMS ----
+typedef struct RmsAcc {
+  const CompactLeaves *cl;
+  const uint64_t *weights;
+  double wsse;
+  double wsum;
+  double usse;
+  double ucount;
+} RmsAcc;
+static void cb_rms(FitState *st, void *data) {
+  RmsAcc *acc = (RmsAcc *)data;
+  const uint32_t idx = klv_get_word_index(st->klv, st->leave);
+  const double y = equity_to_double(klv_get_indexed_leave_value(st->klv, idx));
+  const double f =
+      equity_to_double(compact_leaves_get_leave_value(acc->cl, st->leave));
+  const double d = f - y;
+  acc->usse += d * d;
+  acc->ucount += 1.0;
+  if (acc->weights != NULL) {
+    const double w = (double)acc->weights[idx];
+    acc->wsse += w * d * d;
+    acc->wsum += w;
+  }
+}
+void compact_leaves_rms(const CompactLeaves *cl, const KLV *klv,
+                        const LetterDistribution *ld, const uint64_t *weights,
+                        double *weighted_rms_out, double *unweighted_rms_out) {
+  const int A = ld_get_size(ld);
+  FitState st = {.klv = klv,
+                 .ld = ld,
+                 .weights = weights,
+                 .dist_size = (uint8_t)A,
+                 .vowel_bits = cl->vowel_bits,
+                 .leave = rack_create((uint16_t)A),
+                 .base_p = 0};
+  Rack *bag = get_new_bag_as_rack(ld);
+  RmsAcc acc = {.cl = cl, .weights = weights, 0, 0, 0, 0};
+  enum_leaves(&st, bag, 0, 0, cb_rms, &acc);
+  rack_destroy(bag);
+  rack_destroy(st.leave);
+  if (unweighted_rms_out != NULL) {
+    *unweighted_rms_out = acc.ucount > 0 ? sqrt(acc.usse / acc.ucount) : 0.0;
+  }
+  if (weighted_rms_out != NULL) {
+    *weighted_rms_out = acc.wsum > 0 ? sqrt(acc.wsse / acc.wsum) : 0.0;
+  }
+}
+
+uint64_t *compact_leaves_read_weights_csv(const KLV *klv,
+                                          const LetterDistribution *ld,
+                                          const char *csv_path,
+                                          ErrorStack *error_stack) {
+  FILE *file = fopen(csv_path, "r");
+  if (file == NULL) {
+    error_stack_push(error_stack, ERROR_STATUS_CONVERT_INPUT_FILE_ERROR,
+                     get_formatted_string(
+                         "could not open leave-frequency csv: %s", csv_path));
+    return NULL;
+  }
+  const uint32_t num_leaves = klv_get_number_of_leaves(klv);
+  uint64_t *weights = (uint64_t *)calloc_or_die(num_leaves, sizeof(uint64_t));
+  Rack rack;
+  rack_set_dist_size(&rack, ld_get_size(ld));
+  ErrorStack *scratch = error_stack_create();
+  char line[256];
+  while (fgets(line, sizeof(line), file)) {
+    const char *leave_str = strtok(line, ",");
+    const char *count_str = strtok(NULL, "\n");
+    if (leave_str == NULL || count_str == NULL) {
+      continue;
+    }
+    const uint64_t count = string_to_uint64(count_str, scratch);
+    if (!error_stack_is_empty(scratch) || count == 0) {
+      error_stack_reset(scratch);
+      continue;
+    }
+    if (rack_set_to_string(ld, &rack, leave_str) < 0) {
+      continue;
+    }
+    const uint32_t idx = klv_get_word_index(klv, &rack);
+    if (idx != KLV_UNFOUND_INDEX && idx < num_leaves) {
+      weights[idx] = count;
+    }
+  }
+  fclose(file);
+  error_stack_destroy(scratch);
+  return weights;
+}

--- a/src/impl/compact_leaves_maker.c
+++ b/src/impl/compact_leaves_maker.c
@@ -52,12 +52,14 @@ static void cand_hash_create(CandHash *h) {
   h->ntiles = (uint8_t *)calloc_or_die(CLM_HASH_SIZE, 1);
   h->count = 0;
 }
+
 static void cand_hash_destroy(CandHash *h) {
   free(h->keys);
   free(h->s1);
   free(h->s2);
   free(h->ntiles);
 }
+
 static void cand_hash_add(CandHash *h, uint64_t key, uint8_t ntiles, double w,
                           double residual) {
   uint64_t slot = (key * 0x9E3779B97F4A7C15ULL) >> (64 - CLM_HASH_BITS);
@@ -307,6 +309,7 @@ static void hash_sink_cb(uint64_t key, uint8_t ntiles, void *ctx) {
   HashSink *sink = (HashSink *)ctx;
   cand_hash_add(sink->hash, key, ntiles, sink->w, sink->e);
 }
+
 static void cb_residual(FitState *st, void *data) {
   const ResAcc *acc = (const ResAcc *)data;
   const uint32_t idx = klv_get_word_index(st->klv, st->leave);
@@ -346,10 +349,12 @@ static void sel_hash_create(SelHash *h, uint32_t num_selected) {
   }
   h->shift = 64 - bits;
 }
+
 static void sel_hash_destroy(SelHash *h) {
   free(h->keys);
   free(h->idx);
 }
+
 static void sel_hash_put(SelHash *h, uint64_t key, int32_t value) {
   uint64_t slot = (key * 0x9E3779B97F4A7C15ULL) >> h->shift;
   while (h->keys[slot] != 0) {
@@ -358,6 +363,7 @@ static void sel_hash_put(SelHash *h, uint64_t key, int32_t value) {
   h->keys[slot] = key;
   h->idx[slot] = value;
 }
+
 static int32_t sel_hash_get(const SelHash *h, uint64_t key) {
   uint64_t slot = (key * 0x9E3779B97F4A7C15ULL) >> h->shift;
   while (h->keys[slot] != 0) {
@@ -618,6 +624,7 @@ static int clm_bits_needed(uint32_t max_value) {
   }
   return bits < 1 ? 1 : bits;
 }
+
 static int clm_coef_bits(int32_t ticks) {
   const uint32_t sign = ticks < 0 ? 0xFFFFFFFFU : 0U;
   const uint32_t zigzag = ((uint32_t)ticks << 1) ^ sign;
@@ -851,6 +858,7 @@ static void cb_overwrite(FitState *st, void *data) {
   klv_set_indexed_leave_value(
       acc->klv, idx, compact_leaves_get_leave_value(acc->cl, st->leave));
 }
+
 void compact_leaves_overwrite_klv(const CompactLeaves *cl, KLV *klv,
                                   const LetterDistribution *ld) {
   const int A = ld_get_size(ld);
@@ -892,6 +900,7 @@ static void cb_rms(FitState *st, void *data) {
     acc->wsum += w;
   }
 }
+
 void compact_leaves_rms(const CompactLeaves *cl, const KLV *klv,
                         const LetterDistribution *ld, const uint64_t *weights,
                         double *weighted_rms_out, double *unweighted_rms_out) {

--- a/src/impl/compact_leaves_maker.h
+++ b/src/impl/compact_leaves_maker.h
@@ -1,0 +1,52 @@
+#ifndef COMPACT_LEAVES_MAKER_H
+#define COMPACT_LEAVES_MAKER_H
+
+#include "../ent/compact_leaves.h"
+#include "../ent/klv.h"
+#include "../ent/letter_distribution.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// Fits a CompactLeaves model approximating klv's leave values, minimizing
+// frequency-weighted squared error under target_bytes. weights is a per-leave
+// frequency array indexed by the KLV word index (NULL => uniform). radix_code
+// selects the fixed-point quantum (default COMPACT_LEAVES_RADIX_EIGHTH).
+//
+// v1 model: intercept + per-tile + duplicate penalty + 5x5 vowel/consonant
+// table + greedily selected synergies (scored by weighted-error-reduction per
+// byte), jointly refit. The size budget is spent on synergies. When bit_packed
+// is true the body is sub-byte bit-packed (FLAG_BITPACKED), so the selection
+// uses the packed cost and fits more synergies into target_bytes.
+//
+// target_bytes has an effective floor: the base block (header + per-tile + dup
+// + V/C coefficients, no synergies) is always emitted, so a target below that
+// floor (~111 B bit-packed / ~180 B byte for English) yields a base-only file
+// AT the floor size, not smaller. Above the floor the file is always
+// <= target_bytes.
+CompactLeaves *
+compact_leaves_create_from_klv(const KLV *klv, const LetterDistribution *ld,
+                               const uint64_t *weights, size_t target_bytes,
+                               uint8_t radix_code, bool bit_packed);
+
+// Reads a leave-frequency CSV ("leave_str,count" per line, blank tile = '?', as
+// written by `autoplay topkleaves`) into a per-leave weight array indexed by
+// KLV word index (caller frees). Lines that don't parse or name an unknown
+// leave are skipped. On open failure, pushes an error and returns NULL.
+uint64_t *compact_leaves_read_weights_csv(const KLV *klv,
+                                          const LetterDistribution *ld,
+                                          const char *csv_path,
+                                          ErrorStack *error_stack);
+
+// Overwrites every leave value in klv with the compact model's prediction, so
+// the result can be written out as a .klv2 (lossy expansion) for evaluation.
+void compact_leaves_overwrite_klv(const CompactLeaves *cl, KLV *klv,
+                                  const LetterDistribution *ld);
+
+// Frequency-weighted and unweighted RMS (in points) of the QUANTIZED model vs
+// the KLV's values, over all leaves. weights NULL => unweighted only.
+void compact_leaves_rms(const CompactLeaves *cl, const KLV *klv,
+                        const LetterDistribution *ld, const uint64_t *weights,
+                        double *weighted_rms_out, double *unweighted_rms_out);
+
+#endif

--- a/src/impl/config.c
+++ b/src/impl/config.c
@@ -31,6 +31,7 @@
 #include "../ent/inference_results.h"
 #include "../ent/klv.h"
 #include "../ent/klv_csv.h"
+#include "../ent/kwg.h"
 #include "../ent/letter_distribution.h"
 #include "../ent/move.h"
 #include "../ent/player.h"
@@ -64,6 +65,7 @@
 #include "move_gen.h"
 #include "peg.h"
 #include "simmer.h"
+#include "word_playability.h"
 #include <assert.h>
 #include <ctype.h>
 #include <float.h>
@@ -103,6 +105,11 @@ typedef enum {
   ARG_TOKEN_P1_NAME,
   ARG_TOKEN_P2_NAME,
   ARG_TOKEN_LEAVE_GEN,
+  ARG_TOKEN_PLAYABILITY,
+  ARG_TOKEN_PLAYABILITY_SMALL_KWG,
+  ARG_TOKEN_PLAYABILITY_OUT,
+  ARG_TOKEN_PLAYABILITY_SORT,
+  ARG_TOKEN_PLAYABILITY_DUMP,
   ARG_TOKEN_CREATE_DATA,
   ARG_TOKEN_DATA_PATH,
   ARG_TOKEN_BINGO_BONUS,
@@ -1150,6 +1157,47 @@ void add_help_arg_to_string_builder(const Config *config, int token,
           "with game pairs to evaluate the resulting leaves. Depending on your "
           "hardware, this command could take days or weeks.";
       break;
+    case ARG_TOKEN_PLAYABILITY:
+      usages[0] = "<num_games>";
+      examples[0] = "1000";
+      text =
+          "Plays <num_games> autoplay games and writes a CSV of per-word "
+          "playability metrics for the current lexicon: a uniform play count "
+          "(main word and every hook), the equity loss if the word were the "
+          "only one removed from the lexicon, and (when a small word set is "
+          "given via 'smallkwg') the equity gained by adding the word to that "
+          "small set. Use 'pbout' for the output path and 'pbsort' for the "
+          "sort key. Equity totals are summed in integer millipoints.";
+      break;
+    case ARG_TOKEN_PLAYABILITY_SMALL_KWG:
+      usages[0] = "<lexicon_name>";
+      examples[0] = "CSW24_2to4";
+      text = "Specifies a small word set (a KWG lexicon name) for the "
+             "playability bonus metric. When omitted, the bonus is not "
+             "computed.";
+      break;
+    case ARG_TOKEN_PLAYABILITY_OUT:
+      usages[0] = "<output_path>";
+      examples[0] = "playability.csv";
+      text = "Specifies the output CSV path for the playability command "
+             "(default: playability.csv).";
+      break;
+    case ARG_TOKEN_PLAYABILITY_SORT:
+      usages[0] = "<count_or_penalty_or_bonus>";
+      examples[0] = "count";
+      examples[1] = "penalty";
+      text = "Specifies the playability CSV sort key (descending, ties "
+             "alphabetical); one of count, penalty, or bonus (default: count).";
+      break;
+    case ARG_TOKEN_PLAYABILITY_DUMP:
+      usages[0] = "<dump_path_prefix>";
+      examples[0] = "cache/pb";
+      text =
+          "Dumps each analyzed position (seed baseline + above-baseline moves "
+          "with formed-word ids) to <prefix>.<n> per worker, plus "
+          "<prefix>.words, for offline dictionary-subset selection. Requires "
+          "a small word set (smallkwg) used as the seed.";
+      break;
     case ARG_TOKEN_CREATE_DATA:
       usages[0] = "<type> <output_name> [<letter_distribution>]";
       examples[0] = "klv CSW50";
@@ -2084,6 +2132,7 @@ char *impl_help(Config *config, ErrorStack *error_stack) {
         ARG_TOKEN_INFER,                /* infer */
         ARG_TOKEN_LEAVE_GEN,            /* leavegen */
         ARG_TOKEN_PEG,                  /* peg */
+        ARG_TOKEN_PLAYABILITY,          /* playability */
         ARG_TOKEN_RACK_AND_GEN_AND_SIM, /* rgsimulate */
         ARG_TOKEN_SHOW_ENDGAME,         /* shendgame */
         ARG_TOKEN_SHOW_GAME,            /* shgame */
@@ -2148,6 +2197,9 @@ char *impl_help(Config *config, ErrorStack *error_stack) {
         ARG_TOKEN_NUMBER_OF_SMALL_PLAYS,   /* numsmallplays */
         ARG_TOKEN_P1_NUM_PLAYS,            /* np1 */
         ARG_TOKEN_P2_NUM_PLAYS,            /* np2 */
+        ARG_TOKEN_PLAYABILITY_DUMP,        /* pbdump */
+        ARG_TOKEN_PLAYABILITY_OUT,         /* pbout */
+        ARG_TOKEN_PLAYABILITY_SORT,        /* pbsort */
         ARG_TOKEN_PEG_ONLY,                /* pegonly */
         ARG_TOKEN_PEG_PESSIMISTIC,         /* pegpess */
         ARG_TOKEN_PEG_STRIDE,              /* pegstride */
@@ -2157,6 +2209,7 @@ char *impl_help(Config *config, ErrorStack *error_stack) {
         ARG_TOKEN_PLIES,                   /* plies */
         ARG_TOKEN_PEG_NOPRUNE,             /* pnoprune */
         ARG_TOKEN_STOP_COND_PCT,           /* scondition */
+        ARG_TOKEN_PLAYABILITY_SMALL_KWG,   /* smallkwg */
         ARG_TOKEN_SIM_WITH_INFERENCE,      /* sinfer */
         ARG_TOKEN_USE_SMALL_PLAYS,         /* sp */
         ARG_TOKEN_SAMPLING_RULE,           /* sr */
@@ -3271,6 +3324,8 @@ void config_fill_autoplay_args(const Config *config,
   config_fill_game_args(config, autoplay_args->game_args);
   autoplay_args->multi_threading_mode = config->multi_threading_mode;
   autoplay_args->cutoff = config->cutoff;
+  // Only the playability command sets this (after this fill); default off.
+  autoplay_args->playability = NULL;
 
   autoplay_args->num_threads = config->num_threads;
   int num_worker_threads_per_sim = 1;
@@ -3472,6 +3527,114 @@ void impl_leave_gen(Config *config, ErrorStack *error_stack) {
   config_autoplay(config, config->autoplay_results, AUTOPLAY_TYPE_LEAVE_GEN,
                   min_rack_targets_str, games_before_force_draw_start,
                   error_stack);
+}
+
+void impl_playability(Config *config, ErrorStack *error_stack) {
+  if (!config_has_game_data(config)) {
+    error_stack_push(
+        error_stack, ERROR_STATUS_CONFIG_LOAD_GAME_DATA_MISSING,
+        string_duplicate("cannot compute playability without lexicon"));
+    return;
+  }
+  // A single full lexicon is scored, so both players must share it.
+  if (!players_data_get_is_shared(config->players_data,
+                                  PLAYERS_DATA_TYPE_KWG)) {
+    error_stack_push(
+        error_stack, ERROR_STATUS_LEAVE_GEN_DIFFERENT_LEXICA_OR_LEAVES,
+        string_duplicate(
+            "cannot compute playability with different lexica for the "
+            "players"));
+    return;
+  }
+
+  if (config->p1_sim_plies > 0 || config->p2_sim_plies > 0) {
+    config_load_win_pcts(config, error_stack);
+    if (!error_stack_is_empty(error_stack)) {
+      return;
+    }
+  }
+
+  word_playability_sort_t sort = WORD_PLAYABILITY_SORT_COUNT;
+  if (config_get_parg_num_set_values(config, ARG_TOKEN_PLAYABILITY_SORT) > 0) {
+    const char *sort_str =
+        config_get_parg_value(config, ARG_TOKEN_PLAYABILITY_SORT, 0);
+    if (has_iprefix(sort_str, "count")) {
+      sort = WORD_PLAYABILITY_SORT_COUNT;
+    } else if (has_iprefix(sort_str, "penalty")) {
+      sort = WORD_PLAYABILITY_SORT_PENALTY;
+    } else if (has_iprefix(sort_str, "bonus")) {
+      sort = WORD_PLAYABILITY_SORT_BONUS;
+    } else {
+      error_stack_push(
+          error_stack, ERROR_STATUS_CONFIG_LOAD_UNRECOGNIZED_ARG,
+          get_formatted_string("invalid playability sort key: %s", sort_str));
+      return;
+    }
+  }
+
+  KWG *small_kwg = NULL;
+  if (config_get_parg_num_set_values(config, ARG_TOKEN_PLAYABILITY_SMALL_KWG) >
+      0) {
+    const char *small_name =
+        config_get_parg_value(config, ARG_TOKEN_PLAYABILITY_SMALL_KWG, 0);
+    small_kwg =
+        kwg_create(config_get_data_paths(config), small_name, error_stack);
+    if (!error_stack_is_empty(error_stack)) {
+      return;
+    }
+  }
+
+  if (sort == WORD_PLAYABILITY_SORT_BONUS && !small_kwg) {
+    error_stack_push(
+        error_stack, ERROR_STATUS_CONFIG_LOAD_UNRECOGNIZED_ARG,
+        string_duplicate("playability sort key 'bonus' requires a small word "
+                         "set (smallkwg)"));
+    kwg_destroy(small_kwg);
+    return;
+  }
+
+  char *out_path = NULL;
+  if (config_get_parg_num_set_values(config, ARG_TOKEN_PLAYABILITY_OUT) > 0) {
+    out_path = string_duplicate(
+        config_get_parg_value(config, ARG_TOKEN_PLAYABILITY_OUT, 0));
+  } else {
+    out_path = string_duplicate("playability.csv");
+  }
+
+  autoplay_results_set_options(config->autoplay_results, "games", error_stack);
+  if (!error_stack_is_empty(error_stack)) {
+    free(out_path);
+    kwg_destroy(small_kwg);
+    return;
+  }
+
+  WordPlayabilityContext *playability_ctx = word_playability_context_create(
+      players_data_get_kwg(config->players_data, 0), small_kwg, config->ld,
+      out_path, sort);
+
+  if (config_get_parg_num_set_values(config, ARG_TOKEN_PLAYABILITY_DUMP) > 0) {
+    const char *dump_prefix =
+        config_get_parg_value(config, ARG_TOKEN_PLAYABILITY_DUMP, 0);
+    word_playability_context_set_dump_prefix(playability_ctx, dump_prefix);
+    char *words_path = get_formatted_string("%s.words", dump_prefix);
+    word_playability_write_word_list(playability_ctx, words_path, error_stack);
+    free(words_path);
+  }
+
+  const char *num_games_str =
+      config_get_parg_value(config, ARG_TOKEN_PLAYABILITY, 0);
+
+  // Like config_autoplay, but inject the playability context after filling.
+  AutoplayArgs args;
+  GameArgs game_args;
+  args.game_args = &game_args;
+  config_fill_autoplay_args(config, &args, AUTOPLAY_TYPE_DEFAULT, num_games_str,
+                            0);
+  args.playability = playability_ctx;
+  autoplay(&args, config->autoplay_results, error_stack);
+
+  word_playability_context_destroy(playability_ctx);
+  kwg_destroy(small_kwg);
 }
 
 // Create
@@ -7656,6 +7819,15 @@ char *str_api_leave_gen(Config *config, ErrorStack *error_stack) {
   return empty_string();
 }
 
+void execute_playability(Config *config, ErrorStack *error_stack) {
+  impl_playability(config, error_stack);
+}
+
+char *str_api_playability(Config *config, ErrorStack *error_stack) {
+  impl_playability(config, error_stack);
+  return empty_string();
+}
+
 void execute_create_data(Config *config, ErrorStack *error_stack) {
   impl_create_data(config, error_stack);
 }
@@ -8041,6 +8213,7 @@ Config *config_create(const ConfigArgs *config_args, ErrorStack *error_stack) {
   cmd(ARG_TOKEN_AUTOPLAY, "autoplay", 2, 2, autoplay, autoplay, false);
   cmd(ARG_TOKEN_CONVERT, "convert", 2, 3, convert, generic, false);
   cmd(ARG_TOKEN_LEAVE_GEN, "leavegen", 2, 2, leave_gen, generic, false);
+  cmd(ARG_TOKEN_PLAYABILITY, "playability", 1, 1, playability, generic, false);
   cmd(ARG_TOKEN_CREATE_DATA, "createdata", 2, 3, create_data, generic, false);
   cmd(ARG_TOKEN_NEXT, "next", 0, 0, next, generic, true);
   cmd(ARG_TOKEN_PREVIOUS, "previous", 0, 0, previous, generic, true);
@@ -8060,6 +8233,10 @@ Config *config_create(const ConfigArgs *config_args, ErrorStack *error_stack) {
   arg(ARG_TOKEN_USE_RIT, "rit", 1, 1);
   arg(ARG_TOKEN_USE_MMAP_FOR_RIT, "ritmmap", 1, 1);
   arg(ARG_TOKEN_LEAVES, "leaves", 1, 1);
+  arg(ARG_TOKEN_PLAYABILITY_SMALL_KWG, "smallkwg", 1, 1);
+  arg(ARG_TOKEN_PLAYABILITY_OUT, "pbout", 1, 1);
+  arg(ARG_TOKEN_PLAYABILITY_SORT, "pbsort", 1, 1);
+  arg(ARG_TOKEN_PLAYABILITY_DUMP, "pbdump", 1, 1);
   arg(ARG_TOKEN_P1_LEXICON, "l1", 1, 1);
   arg(ARG_TOKEN_P1_USE_WMP, "w1", 1, 1);
   arg(ARG_TOKEN_P1_USE_RIT, "rit1", 1, 1);
@@ -8375,6 +8552,11 @@ void config_add_settings_to_string_builder(const Config *config,
     case ARG_TOKEN_AUTOPLAY:
     case ARG_TOKEN_CONVERT:
     case ARG_TOKEN_LEAVE_GEN:
+    case ARG_TOKEN_PLAYABILITY:
+    case ARG_TOKEN_PLAYABILITY_SMALL_KWG:
+    case ARG_TOKEN_PLAYABILITY_OUT:
+    case ARG_TOKEN_PLAYABILITY_SORT:
+    case ARG_TOKEN_PLAYABILITY_DUMP:
     case ARG_TOKEN_CREATE_DATA:
     case ARG_TOKEN_ANALYZE:
     case ARG_TOKEN_LOAD:

--- a/src/impl/config.c
+++ b/src/impl/config.c
@@ -83,6 +83,9 @@ enum {
   // Upper bound on the number of per-stage counts the -pegtopk CLI arg accepts.
   // This caps only the parse buffer; the solver itself imposes no stage limit.
   CONFIG_PEG_MAX_STAGES = 16,
+  // Default byte budget for the klv2clv compact-leaves model when 'clvsize' is
+  // omitted (a few KB; the maker fits as many synergies as fit).
+  DEFAULT_CLV_TARGET_BYTES = 8192,
 };
 
 typedef enum {
@@ -102,6 +105,7 @@ typedef enum {
   ARG_TOKEN_PEG,
   ARG_TOKEN_AUTOPLAY,
   ARG_TOKEN_CONVERT,
+  ARG_TOKEN_CLV_SIZE,
   ARG_TOKEN_P1_NAME,
   ARG_TOKEN_P2_NAME,
   ARG_TOKEN_LEAVE_GEN,
@@ -1132,7 +1136,18 @@ void add_help_arg_to_string_builder(const Config *config, int token,
           "Runs the convert command for the specified type with the given "
           "input and output names. If no output name is specified, the input "
           "name will be used. Note that this will not overwrite the input "
-          "since the output filename will have a different extension.";
+          "since the output filename will have a different extension. The "
+          "klv2clv type fits a small parametric compact-leaves (.clv) model "
+          "approximating the input KLV under the 'clvsize' byte budget, for "
+          "small/retro targets that cannot carry a full KLV.";
+      break;
+    case ARG_TOKEN_CLV_SIZE:
+      usages[0] = "<target_bytes>";
+      examples[0] = "8192";
+      text = "Target byte budget for the klv2clv compact-leaves model. The base "
+             "model (no synergies) is always emitted, so a budget below its "
+             "floor yields a base-only file at the floor size; above the floor "
+             "the file is at most this many bytes (default: 8192).";
       break;
     case ARG_TOKEN_LEAVE_GEN:
       usages[0] = "<gen1_min_rack_target>,<gen1_min_rack_target>,... "
@@ -2178,6 +2193,7 @@ char *impl_help(Config *config, ErrorStack *error_stack) {
     };
     // Game Analysis Options (alphabetical by name)
     static const arg_token_t game_analysis_opts[] = {
+        ARG_TOKEN_CLV_SIZE,                /* clvsize */
         ARG_TOKEN_CUTOFF,                  /* cutoff */
         ARG_TOKEN_ENDGAME_PLIES,           /* eplies */
         ARG_TOKEN_ENDGAME_TOP_K,           /* etopk */
@@ -3461,7 +3477,8 @@ char *status_autoplay(Config *config) {
 
 // Conversion
 
-void config_fill_conversion_args(const Config *config, ConversionArgs *args) {
+void config_fill_conversion_args(const Config *config, ConversionArgs *args,
+                                 ErrorStack *error_stack) {
   args->conversion_type_string =
       config_get_parg_value(config, ARG_TOKEN_CONVERT, 0);
   args->data_paths = config_get_data_paths(config);
@@ -3469,12 +3486,31 @@ void config_fill_conversion_args(const Config *config, ConversionArgs *args) {
       config_get_parg_value(config, ARG_TOKEN_CONVERT, 1);
   args->ld_name = config_get_parg_value(config, ARG_TOKEN_CONVERT, 2);
   args->num_threads = config_get_num_threads(config);
+  args->clv_target_bytes = DEFAULT_CLV_TARGET_BYTES;
+  if (config_get_parg_num_set_values(config, ARG_TOKEN_CLV_SIZE) > 0) {
+    const int clv_target_bytes = string_to_int(
+        config_get_parg_value(config, ARG_TOKEN_CLV_SIZE, 0), error_stack);
+    if (!error_stack_is_empty(error_stack)) {
+      return;
+    }
+    if (clv_target_bytes <= 0) {
+      error_stack_push(
+          error_stack, ERROR_STATUS_CONFIG_LOAD_UNRECOGNIZED_ARG,
+          get_formatted_string("clvsize must be a positive number of bytes: %d",
+                               clv_target_bytes));
+      return;
+    }
+    args->clv_target_bytes = clv_target_bytes;
+  }
 }
 
 void config_convert(const Config *config, ConversionResults *results,
                     ErrorStack *error_stack) {
   ConversionArgs args;
-  config_fill_conversion_args(config, &args);
+  config_fill_conversion_args(config, &args, error_stack);
+  if (!error_stack_is_empty(error_stack)) {
+    return;
+  }
   convert(&args, results, error_stack);
 }
 
@@ -8212,6 +8248,7 @@ Config *config_create(const ConfigArgs *config_args, ErrorStack *error_stack) {
   cmd(ARG_TOKEN_PEG, "peg", 0, 0, peg, peg, false);
   cmd(ARG_TOKEN_AUTOPLAY, "autoplay", 2, 2, autoplay, autoplay, false);
   cmd(ARG_TOKEN_CONVERT, "convert", 2, 3, convert, generic, false);
+  arg(ARG_TOKEN_CLV_SIZE, "clvsize", 1, 1);
   cmd(ARG_TOKEN_LEAVE_GEN, "leavegen", 2, 2, leave_gen, generic, false);
   cmd(ARG_TOKEN_PLAYABILITY, "playability", 1, 1, playability, generic, false);
   cmd(ARG_TOKEN_CREATE_DATA, "createdata", 2, 3, create_data, generic, false);
@@ -8551,6 +8588,7 @@ void config_add_settings_to_string_builder(const Config *config,
     case ARG_TOKEN_PEG_NOPRUNE:
     case ARG_TOKEN_AUTOPLAY:
     case ARG_TOKEN_CONVERT:
+    case ARG_TOKEN_CLV_SIZE:
     case ARG_TOKEN_LEAVE_GEN:
     case ARG_TOKEN_PLAYABILITY:
     case ARG_TOKEN_PLAYABILITY_SMALL_KWG:

--- a/src/impl/convert.c
+++ b/src/impl/convert.c
@@ -4,6 +4,7 @@
 #include "../def/convert_defs.h"
 #include "../def/kwg_defs.h"
 #include "../def/letter_distribution_defs.h"
+#include "../ent/compact_leaves.h"
 #include "../ent/conversion_results.h"
 #include "../ent/data_filepaths.h"
 #include "../ent/dawg_arc_compressed.h"
@@ -18,6 +19,7 @@
 #include "../util/fileproxy.h"
 #include "../util/io_util.h"
 #include "../util/string_util.h"
+#include "compact_leaves_maker.h"
 #include "kwg_maker.h"
 #include "rack_info_table_maker.h"
 #include "wmp_maker.h"
@@ -219,7 +221,7 @@ void convert_with_names(const LetterDistribution *ld,
                         const char *data_paths, const char *input_name,
                         const char *output_name,
                         ConversionResults *conversion_results, int num_threads,
-                        ErrorStack *error_stack) {
+                        int clv_target_bytes, ErrorStack *error_stack) {
   if ((conversion_type == CONVERT_TEXT2DAWG) ||
       (conversion_type == CONVERT_TEXT2GADDAG) ||
       (conversion_type == CONVERT_TEXT2KWG) ||
@@ -273,6 +275,33 @@ void convert_with_names(const LetterDistribution *ld,
     KLV *klv = klv_create(data_paths, input_name, error_stack);
     if (error_stack_is_empty(error_stack)) {
       klv_write_to_csv(klv, ld, data_paths, output_name, NULL, error_stack);
+    }
+    klv_destroy(klv);
+  } else if (conversion_type == CONVERT_KLV2CLV) {
+    KLV *klv = klv_create(data_paths, input_name, error_stack);
+    if (error_stack_is_empty(error_stack)) {
+      char *clv_output_filename = data_filepaths_get_writable_filename(
+          data_paths, output_name, DATA_FILEPATH_TYPE_COMPACT_LEAVES,
+          error_stack);
+      if (error_stack_is_empty(error_stack)) {
+        // Uniform weighting, default (eighth) radix, bit-packed body for the
+        // smallest fit. Frequency-weighted fitting (compact_leaves_read_weights
+        // _csv) and radix selection are available in the maker for callers that
+        // want them; the convert command ships the common case.
+        const size_t target_bytes = (size_t)clv_target_bytes;
+        CompactLeaves *cl = compact_leaves_create_from_klv(
+            klv, ld, NULL, target_bytes, COMPACT_LEAVES_RADIX_EIGHTH, true);
+        compact_leaves_write_to_file(cl, clv_output_filename, error_stack);
+        if (!error_stack_is_empty(error_stack)) {
+          error_stack_push(
+              error_stack, ERROR_STATUS_CONVERT_OUTPUT_FILE_NOT_WRITABLE,
+              get_formatted_string(
+                  "could not write compact leaves to output file: %s",
+                  clv_output_filename));
+        }
+        compact_leaves_destroy(cl);
+      }
+      free(clv_output_filename);
     }
     klv_destroy(klv);
   } else if (conversion_type == CONVERT_KLVWMP2RIT) {
@@ -347,6 +376,8 @@ get_conversion_type_from_string(const char *conversion_type_string) {
     conversion_type = CONVERT_CSV2KLV;
   } else if (strings_equal(conversion_type_string, "klv2csv")) {
     conversion_type = CONVERT_KLV2CSV;
+  } else if (strings_equal(conversion_type_string, "klv2clv")) {
+    conversion_type = CONVERT_KLV2CLV;
   } else if (strings_equal(conversion_type_string, "text2wordmap")) {
     conversion_type = CONVERT_TEXT2WORDMAP;
   } else if (strings_equal(conversion_type_string, "dawg2wordmap")) {
@@ -396,6 +427,7 @@ void convert(const ConversionArgs *args, ConversionResults *conversion_results,
 
   convert_with_names(ld, conversion_type, args->data_paths,
                      args->input_and_output_name, args->input_and_output_name,
-                     conversion_results, args->num_threads, error_stack);
+                     conversion_results, args->num_threads,
+                     args->clv_target_bytes, error_stack);
   ld_destroy(ld);
 }

--- a/src/impl/convert.c
+++ b/src/impl/convert.c
@@ -6,6 +6,7 @@
 #include "../def/letter_distribution_defs.h"
 #include "../ent/conversion_results.h"
 #include "../ent/data_filepaths.h"
+#include "../ent/dawg_arc_compressed.h"
 #include "../ent/dawg_packed.h"
 #include "../ent/dictionary_word.h"
 #include "../ent/klv.h"
@@ -144,6 +145,40 @@ void convert_from_text_with_dwl(const LetterDistribution *ld,
     dawg_packed_destroy(dp);
     kwg_destroy(kwg);
     free(packed_output_filename);
+  } else if (conversion_type == CONVERT_TEXT2DAWG_ARC_COMPRESSED ||
+             conversion_type == CONVERT_TEXT2DAWG_ARC_COMPRESSED_BALANCED) {
+    char *arc_compressed_output_filename = data_filepaths_get_writable_filename(
+        data_paths, output_name, DATA_FILEPATH_TYPE_DAWG_ARC_COMPRESSED,
+        error_stack);
+    if (!error_stack_is_empty(error_stack)) {
+      return;
+    }
+    // Build the reorder DAWG, then arc-compress it (popular table + local gaps
+    // + rank-located escapes) for a smaller resident footprint than the packed
+    // DAWG. Niche, opt-in output for fitting a word list onto retro hardware.
+    // BALANCED trades a little of that RAM win for materially faster traversal.
+    const dawg_arc_compressed_mode_t mode =
+        conversion_type == CONVERT_TEXT2DAWG_ARC_COMPRESSED_BALANCED
+            ? DAWG_ARC_COMPRESSED_MODE_BALANCED
+            : DAWG_ARC_COMPRESSED_MODE_MIN_RAM;
+    KWG *kwg = make_kwg_from_words(strings, KWG_MAKER_OUTPUT_DAWG,
+                                   KWG_MAKER_MERGE_TAIL_REORDER);
+    DawgArcCompressed *dp = dawg_arc_compressed_create_from_kwg(kwg, mode);
+    dawg_arc_compressed_write_to_file(dp, arc_compressed_output_filename,
+                                      error_stack);
+    if (!error_stack_is_empty(error_stack)) {
+      error_stack_push(
+          error_stack, ERROR_STATUS_CONVERT_OUTPUT_FILE_NOT_WRITABLE,
+          get_formatted_string(
+              "could not write arc-compressed dawg to output file: %s",
+              arc_compressed_output_filename));
+    } else {
+      conversion_results_set_number_of_strings(
+          conversion_results, dictionary_word_list_get_count(strings));
+    }
+    dawg_arc_compressed_destroy(dp);
+    kwg_destroy(kwg);
+    free(arc_compressed_output_filename);
   } else {
     char *kwg_output_filename = data_filepaths_get_writable_filename(
         data_paths, output_name, DATA_FILEPATH_TYPE_KWG, error_stack);
@@ -191,6 +226,8 @@ void convert_with_names(const LetterDistribution *ld,
       (conversion_type == CONVERT_TEXT2KWG_TAIL_MERGE) ||
       (conversion_type == CONVERT_TEXT2DAWG_TAIL_REORDER) ||
       (conversion_type == CONVERT_TEXT2DAWG_PACKED) ||
+      (conversion_type == CONVERT_TEXT2DAWG_ARC_COMPRESSED) ||
+      (conversion_type == CONVERT_TEXT2DAWG_ARC_COMPRESSED_BALANCED) ||
       (conversion_type == CONVERT_TEXT2WORDMAP)) {
     DictionaryWordList *strings = dictionary_word_list_create();
     convert_from_text_with_dwl(ld, conversion_type, data_paths, input_name,
@@ -298,6 +335,10 @@ get_conversion_type_from_string(const char *conversion_type_string) {
     conversion_type = CONVERT_TEXT2DAWG_TAIL_REORDER;
   } else if (strings_equal(conversion_type_string, "text2dawgpacked")) {
     conversion_type = CONVERT_TEXT2DAWG_PACKED;
+  } else if (strings_equal(conversion_type_string, "text2acdawg")) {
+    conversion_type = CONVERT_TEXT2DAWG_ARC_COMPRESSED;
+  } else if (strings_equal(conversion_type_string, "text2acdawgbalanced")) {
+    conversion_type = CONVERT_TEXT2DAWG_ARC_COMPRESSED_BALANCED;
   } else if (strings_equal(conversion_type_string, "dawg2text")) {
     conversion_type = CONVERT_DAWG2TEXT;
   } else if (strings_equal(conversion_type_string, "gaddag2text")) {

--- a/src/impl/convert.h
+++ b/src/impl/convert.h
@@ -12,6 +12,9 @@ typedef struct ConversionArgs {
   const char *input_and_output_name;
   const char *ld_name;
   int num_threads;
+  // Target byte budget for the klv2clv compact-leaves model (ignored by other
+  // conversion types). 0 selects the default.
+  int clv_target_bytes;
 } ConversionArgs;
 
 void convert(const ConversionArgs *args, ConversionResults *conversion_results,

--- a/src/impl/word_playability.c
+++ b/src/impl/word_playability.c
@@ -1,0 +1,571 @@
+#include "word_playability.h"
+
+#include "../def/board_defs.h"
+#include "../def/config_defs.h"
+#include "../def/equity_defs.h"
+#include "../def/game_history_defs.h"
+#include "../def/letter_distribution_defs.h"
+#include "../def/move_defs.h"
+#include "../def/rack_defs.h"
+#include "../ent/board.h"
+#include "../ent/dictionary_word.h"
+#include "../ent/equity.h"
+#include "../ent/game.h"
+#include "../ent/kwg.h"
+#include "../ent/letter_distribution.h"
+#include "../ent/move.h"
+#include "../ent/words.h"
+#include "../impl/kwg_maker.h"
+#include "../impl/move_gen.h"
+#include "../util/io_util.h"
+#include "../util/string_util.h"
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// A move forms the main word plus one cross word per fresh tile, so at most
+// RACK_SIZE + 1 words. We only need to know whether the count of a move's words
+// that are absent from the small set is 0, 1, or "2 or more", so the missing
+// counter saturates at 2.
+enum {
+  PB_MAX_WORDS = RACK_SIZE + 1,
+  PB_MISSING_CAP = 2,
+  PB_INITIAL_MOVE_INFO_CAP = 4096,
+  // Cap on moves-above-baseline written per position in a dump. The highest
+  // equity moves matter most as the selected set's baseline rises.
+  PB_DUMP_MOVE_CAP = 32,
+};
+
+// Per-thread dump files are opened during single-threaded worker creation, so
+// a plain counter (no atomics) gives each thread a unique <prefix>.<n>.
+static int pb_dump_file_counter = 0;
+
+// Per-move scratch derived once per position and shared by all three metrics.
+typedef struct PBMoveInfo {
+  Equity equity;
+  game_event_t type;
+  int num_words;                   // formed words found in the full lexicon
+  uint32_t word_idx[PB_MAX_WORDS]; // their full-lexicon indices
+  int missing_count;               // formed words not in the small set, max 2
+  uint32_t missing_word;           // the single missing word when count == 1
+} PBMoveInfo;
+
+struct WordPlayabilityContext {
+  DictionaryWordList *words; // every full-lexicon word, sorted
+  uint32_t num_words;
+  const KWG *small_kwg; // borrowed; NULL disables the bonus metric
+  const LetterDistribution *ld;
+  char *out_path;    // owned
+  char *dump_prefix; // owned; when set, each thread dumps its positions to
+                     // <dump_prefix>.<n> for the offline greedy. NULL = off.
+  word_playability_sort_t sort;
+};
+
+struct WordPlayabilityCounts {
+  uint32_t num_words;
+  uint64_t *count;
+  int64_t *penalty;
+  int64_t *bonus; // NULL when the context has no small set
+  // Diagnostics: positions analyzed and how many had a true bingo (a best move
+  // placing all RACK_SIZE tiles) as the best play. A bingo is 7 tiles from the
+  // rack, distinct from merely forming a 7+ letter word through existing tiles.
+  uint64_t total_positions;
+  uint64_t total_bingos;
+  // Per-thread position dump (NULL unless the context has a dump_prefix). Each
+  // record: int32 seed_baseline_equity, uint16 num_moves, then per move
+  // int32 equity, uint8 num_words, uint32 word_idx[num_words]. Only positions
+  // with >=1 move above the seed baseline are written.
+  FILE *dump_file;
+  // Generation-stamped dedup so each word accrues at most one bonus per
+  // position (the highest-equity move that adds exactly that word), without an
+  // O(num_words) reset each position.
+  uint32_t *bonus_stamp;
+  uint32_t bonus_gen;
+  MoveList *move_list;
+  PBMoveInfo *move_info;
+  int move_info_cap;
+};
+
+// memcmp-then-length ordering, matching dictionary_word_compare, over unblanked
+// machine letters.
+static int pb_word_cmp(const MachineLetter *a, int alen, const MachineLetter *b,
+                       int blen) {
+  const int min_len = alen < blen ? alen : blen;
+  const int cmp = memcmp(a, b, (size_t)min_len);
+  if (cmp != 0) {
+    return cmp;
+  }
+  return alen - blen;
+}
+
+// Index of an (already unblanked) word in the sorted full-lexicon table, or
+// UINT32_MAX if absent (defensive; generated moves only form valid words).
+static uint32_t pb_word_index(const WordPlayabilityContext *ctx,
+                              const MachineLetter *word, int len) {
+  int lo = 0;
+  int hi = (int)ctx->num_words - 1;
+  while (lo <= hi) {
+    const int mid = lo + (hi - lo) / 2;
+    const DictionaryWord *dw = dictionary_word_list_get_word(ctx->words, mid);
+    const int cmp = pb_word_cmp(dictionary_word_get_word(dw),
+                                dictionary_word_get_length(dw), word, len);
+    if (cmp == 0) {
+      return (uint32_t)mid;
+    }
+    if (cmp < 0) {
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return UINT32_MAX;
+}
+
+// Membership of an (already unblanked) word in a KWG's DAWG.
+static bool pb_kwg_contains(const KWG *kwg, const MachineLetter *word,
+                            int len) {
+  if (len <= 0) {
+    return false;
+  }
+  uint32_t node_index = kwg_get_dawg_root_node_index(kwg);
+  for (int i = 0; i < len - 1; i++) {
+    node_index = kwg_get_next_node_index(kwg, node_index, word[i]);
+    if (node_index == 0) {
+      return false;
+    }
+  }
+  return kwg_in_letter_set(kwg, word[len - 1], node_index);
+}
+
+WordPlayabilityContext *
+word_playability_context_create(const KWG *full_kwg, const KWG *small_kwg,
+                                const LetterDistribution *ld, char *out_path,
+                                word_playability_sort_t sort) {
+  WordPlayabilityContext *ctx = malloc_or_die(sizeof(WordPlayabilityContext));
+  ctx->words = dictionary_word_list_create();
+  kwg_write_words(full_kwg, kwg_get_dawg_root_node_index(full_kwg), ctx->words,
+                  NULL);
+  dictionary_word_list_sort(ctx->words);
+  ctx->num_words = (uint32_t)dictionary_word_list_get_count(ctx->words);
+  ctx->small_kwg = small_kwg;
+  ctx->ld = ld;
+  ctx->out_path = out_path;
+  ctx->dump_prefix = NULL;
+  ctx->sort = sort;
+  return ctx;
+}
+
+void word_playability_context_set_dump_prefix(WordPlayabilityContext *ctx,
+                                              const char *dump_prefix) {
+  free(ctx->dump_prefix);
+  ctx->dump_prefix = dump_prefix ? string_duplicate(dump_prefix) : NULL;
+}
+
+// Writes every full-lexicon word, one per line in index order, so the offline
+// greedy can map the dump's word ids back to words (and their lengths).
+void word_playability_write_word_list(const WordPlayabilityContext *ctx,
+                                      const char *path,
+                                      ErrorStack *error_stack) {
+  StringBuilder *sb = string_builder_create();
+  for (uint32_t i = 0; i < ctx->num_words; i++) {
+    const DictionaryWord *dw =
+        dictionary_word_list_get_word(ctx->words, (int)i);
+    const MachineLetter *word = dictionary_word_get_word(dw);
+    const int len = dictionary_word_get_length(dw);
+    for (int li = 0; li < len; li++) {
+      char *hl = ld_ml_to_hl(ctx->ld, word[li]);
+      string_builder_add_string(sb, hl);
+      free(hl);
+    }
+    string_builder_add_string(sb, "\n");
+  }
+  write_string_to_file(path, "w", string_builder_peek(sb), error_stack);
+  string_builder_destroy(sb);
+}
+
+void word_playability_context_destroy(WordPlayabilityContext *ctx) {
+  if (!ctx) {
+    return;
+  }
+  dictionary_word_list_destroy(ctx->words);
+  free(ctx->out_path);
+  free(ctx->dump_prefix);
+  free(ctx);
+}
+
+bool word_playability_context_has_bonus(const WordPlayabilityContext *ctx) {
+  return ctx->small_kwg != NULL;
+}
+
+uint32_t word_playability_context_num_words(const WordPlayabilityContext *ctx) {
+  return ctx->num_words;
+}
+
+uint32_t word_playability_context_word_index(const WordPlayabilityContext *ctx,
+                                             const MachineLetter *word,
+                                             int len) {
+  MachineLetter unblanked[BOARD_DIM] = {0};
+  for (int i = 0; i < len; i++) {
+    unblanked[i] = get_unblanked_machine_letter(word[i]);
+  }
+  return pb_word_index(ctx, unblanked, len);
+}
+
+WordPlayabilityCounts *
+word_playability_counts_create(const WordPlayabilityContext *ctx) {
+  WordPlayabilityCounts *counts = malloc_or_die(sizeof(WordPlayabilityCounts));
+  counts->num_words = ctx->num_words;
+  counts->count = calloc_or_die(ctx->num_words, sizeof(uint64_t));
+  counts->penalty = calloc_or_die(ctx->num_words, sizeof(int64_t));
+  if (ctx->small_kwg) {
+    counts->bonus = calloc_or_die(ctx->num_words, sizeof(int64_t));
+    counts->bonus_stamp = calloc_or_die(ctx->num_words, sizeof(uint32_t));
+  } else {
+    counts->bonus = NULL;
+    counts->bonus_stamp = NULL;
+  }
+  counts->bonus_gen = 0;
+  counts->total_positions = 0;
+  counts->total_bingos = 0;
+  counts->dump_file = NULL;
+  if (ctx->dump_prefix) {
+    char *fname =
+        get_formatted_string("%s.%d", ctx->dump_prefix, pb_dump_file_counter++);
+    counts->dump_file = fopen(fname, "wb");
+    if (!counts->dump_file) {
+      log_fatal("could not open playability dump file: %s", fname);
+    }
+    free(fname);
+  }
+  counts->move_list = move_list_create(DEFAULT_SMALL_MOVE_LIST_CAPACITY);
+  counts->move_info_cap = PB_INITIAL_MOVE_INFO_CAP;
+  counts->move_info =
+      malloc_or_die((size_t)counts->move_info_cap * sizeof(PBMoveInfo));
+  return counts;
+}
+
+void word_playability_counts_destroy(WordPlayabilityCounts *counts) {
+  if (!counts) {
+    return;
+  }
+  free(counts->count);
+  free(counts->penalty);
+  free(counts->bonus);
+  free(counts->bonus_stamp);
+  move_list_destroy(counts->move_list);
+  free(counts->move_info);
+  if (counts->dump_file) {
+    fclose(counts->dump_file);
+  }
+  free(counts);
+}
+
+uint64_t word_playability_counts_get_count(const WordPlayabilityCounts *counts,
+                                           uint32_t word_index) {
+  return counts->count[word_index];
+}
+
+int64_t word_playability_counts_get_penalty(const WordPlayabilityCounts *counts,
+                                            uint32_t word_index) {
+  return counts->penalty[word_index];
+}
+
+int64_t word_playability_counts_get_bonus(const WordPlayabilityCounts *counts,
+                                          uint32_t word_index) {
+  return counts->bonus ? counts->bonus[word_index] : 0;
+}
+
+// True if move `info` forms the full-lexicon word `word_idx`.
+static bool pb_move_forms(const PBMoveInfo *info, uint32_t word_idx) {
+  for (int i = 0; i < info->num_words; i++) {
+    if (info->word_idx[i] == word_idx) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Fills counts->move_info[0..n) from the generated move list, computing each
+// move's formed-word indices and (if a small set exists) how many of its words
+// are absent from it.
+static void pb_fill_move_info(WordPlayabilityCounts *counts,
+                              const WordPlayabilityContext *ctx, Board *board,
+                              int n) {
+  if (n > counts->move_info_cap) {
+    free(counts->move_info);
+    counts->move_info_cap = n;
+    counts->move_info =
+        malloc_or_die((size_t)counts->move_info_cap * sizeof(PBMoveInfo));
+  }
+  MachineLetter unblanked[BOARD_DIM];
+  for (int i = 0; i < n; i++) {
+    const Move *move = move_list_get_move(counts->move_list, i);
+    PBMoveInfo *info = &counts->move_info[i];
+    info->equity = move_get_equity(move);
+    info->type = move_get_type(move);
+    info->num_words = 0;
+    info->missing_count = 0;
+    info->missing_word = UINT32_MAX;
+    if (info->type != GAME_EVENT_TILE_PLACEMENT_MOVE) {
+      continue; // exchanges and passes form no words
+    }
+    FormedWords *fw = formed_words_create(board, move);
+    const int num_formed = formed_words_get_num_words(fw);
+    for (int wi = 0; wi < num_formed; wi++) {
+      const MachineLetter *word = formed_words_get_word(fw, wi);
+      const int len = formed_words_get_word_length(fw, wi);
+      for (int li = 0; li < len; li++) {
+        unblanked[li] = get_unblanked_machine_letter(word[li]);
+      }
+      const uint32_t idx = pb_word_index(ctx, unblanked, len);
+      if (idx == UINT32_MAX) {
+        continue; // defensive: generated moves only form valid words
+      }
+      if (info->num_words < PB_MAX_WORDS) {
+        info->word_idx[info->num_words++] = idx;
+      }
+      if (ctx->small_kwg && info->missing_count < PB_MISSING_CAP &&
+          !pb_kwg_contains(ctx->small_kwg, unblanked, len)) {
+        info->missing_word = idx; // only used when missing_count ends at 1
+        info->missing_count++;
+      }
+    }
+    formed_words_destroy(fw);
+  }
+}
+
+void word_playability_counts_add_position(WordPlayabilityCounts *counts,
+                                          const WordPlayabilityContext *ctx,
+                                          const Game *game) {
+  MoveList *move_list = counts->move_list;
+  move_list_reset(move_list);
+  const MoveGenArgs args = {
+      .game = game,
+      .move_record_type = MOVE_RECORD_ALL,
+      .move_sort_type = MOVE_SORT_EQUITY,
+      .override_kwg = NULL,
+      .eq_margin_movegen = 0,
+      .target_equity = EQUITY_MAX_VALUE,
+      .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+      .move_list = move_list,
+      .tiles_played_bv = NULL,
+      .initial_tiles_bv = 0,
+  };
+  generate_moves(&args);
+  const int n = move_list_get_count(move_list);
+  if (n <= 0) {
+    return;
+  }
+  // MOVE_RECORD_ALL leaves the list as a min-heap; sort to equity-descending so
+  // move 0 is the best and the metric scans run from highest to lowest equity.
+  move_list_sort_moves(move_list);
+  counts->total_positions++;
+  const Move *played = move_list_get_move(move_list, 0);
+  if (move_get_type(played) == GAME_EVENT_TILE_PLACEMENT_MOVE &&
+      move_get_tiles_played(played) == RACK_SIZE) {
+    counts->total_bingos++; // a true bingo: all RACK_SIZE tiles placed
+  }
+  Board *board = game_get_board(game);
+  pb_fill_move_info(counts, ctx, board, n);
+
+  const PBMoveInfo *best = &counts->move_info[0];
+
+  // Mode 1 (count) and Mode 2 (removal penalty) apply only when the best move
+  // is a tile placement (exchanges/passes form no words).
+  if (best->type == GAME_EVENT_TILE_PLACEMENT_MOVE) {
+    for (int k = 0; k < best->num_words; k++) {
+      counts->count[best->word_idx[k]]++;
+    }
+    for (int k = 0; k < best->num_words; k++) {
+      const uint32_t word = best->word_idx[k];
+      bool seen_earlier = false;
+      for (int p = 0; p < k; p++) {
+        if (best->word_idx[p] == word) {
+          seen_earlier = true;
+          break;
+        }
+      }
+      if (seen_earlier) {
+        continue;
+      }
+      // Highest-equity move forming no `word`; the pass sentinel equity is not
+      // a real equity, so passing falls back to an alternative value of 0.
+      int64_t alt_equity = 0;
+      for (int i = 0; i < n; i++) {
+        const PBMoveInfo *info = &counts->move_info[i];
+        if (info->type == GAME_EVENT_PASS) {
+          continue;
+        }
+        if (!pb_move_forms(info, word)) {
+          alt_equity = (int64_t)info->equity;
+          break;
+        }
+      }
+      const int64_t loss = (int64_t)best->equity - alt_equity;
+      if (loss > 0) {
+        counts->penalty[word] += loss;
+      }
+    }
+  }
+
+  // Mode 3 (small-set + this word bonus). Baseline is the highest-equity move
+  // playable with only the small set (no missing words). Moves above it that
+  // become playable by adding exactly one word credit that word; moves at or
+  // below the baseline cannot beat it, so the bonus is skipped there.
+  if (counts->bonus) {
+    int64_t baseline = 0;
+    int baseline_index = n;
+    for (int i = 0; i < n; i++) {
+      const PBMoveInfo *info = &counts->move_info[i];
+      if (info->type == GAME_EVENT_PASS) {
+        continue;
+      }
+      if (info->missing_count == 0) {
+        baseline = (int64_t)info->equity;
+        baseline_index = i;
+        break;
+      }
+    }
+
+    // Dump the position for the offline greedy: the seed baseline and every
+    // move above it (capped), each with its full formed-word-id set. The
+    // offline greedy re-derives the per-set baseline and per-word bonus from
+    // this, so no autoplay re-run is needed when the selected set changes.
+    if (counts->dump_file && baseline_index > 0) {
+      int num =
+          baseline_index < PB_DUMP_MOVE_CAP ? baseline_index : PB_DUMP_MOVE_CAP;
+      const int32_t baseline32 = (int32_t)baseline;
+      const uint16_t num16 = (uint16_t)num;
+      fwrite(&baseline32, sizeof(int32_t), 1, counts->dump_file);
+      fwrite(&num16, sizeof(uint16_t), 1, counts->dump_file);
+      for (int i = 0; i < num; i++) {
+        const PBMoveInfo *info = &counts->move_info[i];
+        const int32_t equity32 = (int32_t)info->equity;
+        const uint8_t nwords = (uint8_t)info->num_words;
+        fwrite(&equity32, sizeof(int32_t), 1, counts->dump_file);
+        fwrite(&nwords, sizeof(uint8_t), 1, counts->dump_file);
+        fwrite(info->word_idx, sizeof(uint32_t), info->num_words,
+               counts->dump_file);
+      }
+    }
+
+    counts->bonus_gen++;
+    for (int i = 0; i < baseline_index; i++) {
+      const PBMoveInfo *info = &counts->move_info[i];
+      if (info->type == GAME_EVENT_PASS || info->missing_count != 1) {
+        continue;
+      }
+      const uint32_t word = info->missing_word;
+      if (counts->bonus_stamp[word] == counts->bonus_gen) {
+        continue; // a higher-equity move already credited this word
+      }
+      counts->bonus_stamp[word] = counts->bonus_gen;
+      const int64_t gain = (int64_t)info->equity - baseline;
+      if (gain > 0) {
+        counts->bonus[word] += gain;
+      }
+    }
+  }
+}
+
+void word_playability_counts_merge(WordPlayabilityCounts *dst,
+                                   const WordPlayabilityCounts *src) {
+  for (uint32_t i = 0; i < dst->num_words; i++) {
+    dst->count[i] += src->count[i];
+    dst->penalty[i] += src->penalty[i];
+  }
+  if (dst->bonus && src->bonus) {
+    for (uint32_t i = 0; i < dst->num_words; i++) {
+      dst->bonus[i] += src->bonus[i];
+    }
+  }
+  dst->total_positions += src->total_positions;
+  dst->total_bingos += src->total_bingos;
+}
+
+uint64_t
+word_playability_counts_get_positions(const WordPlayabilityCounts *counts) {
+  return counts->total_positions;
+}
+
+uint64_t
+word_playability_counts_get_bingos(const WordPlayabilityCounts *counts) {
+  return counts->total_bingos;
+}
+
+typedef struct PBSortEntry {
+  int64_t key;
+  uint32_t word_index;
+} PBSortEntry;
+
+// Descending key; ties broken by ascending word index, which is alphabetical
+// because the word table is sorted.
+static int pb_sort_entry_cmp(const void *a, const void *b) {
+  const PBSortEntry *ea = (const PBSortEntry *)a;
+  const PBSortEntry *eb = (const PBSortEntry *)b;
+  if (ea->key != eb->key) {
+    return ea->key > eb->key ? -1 : 1;
+  }
+  if (ea->word_index != eb->word_index) {
+    return ea->word_index < eb->word_index ? -1 : 1;
+  }
+  return 0;
+}
+
+void word_playability_write_csv(const WordPlayabilityContext *ctx,
+                                const WordPlayabilityCounts *totals,
+                                ErrorStack *error_stack) {
+  const uint32_t num_words = ctx->num_words;
+  PBSortEntry *entries = malloc_or_die((size_t)num_words * sizeof(PBSortEntry));
+  for (uint32_t i = 0; i < num_words; i++) {
+    entries[i].word_index = i;
+    switch (ctx->sort) {
+    case WORD_PLAYABILITY_SORT_PENALTY:
+      entries[i].key = totals->penalty[i];
+      break;
+    case WORD_PLAYABILITY_SORT_BONUS:
+      entries[i].key = totals->bonus ? totals->bonus[i] : 0;
+      break;
+    case WORD_PLAYABILITY_SORT_COUNT:
+    default:
+      entries[i].key = (int64_t)totals->count[i];
+      break;
+    }
+  }
+  qsort(entries, num_words, sizeof(PBSortEntry), pb_sort_entry_cmp);
+
+  StringBuilder *sb = string_builder_create();
+  if (totals->bonus) {
+    string_builder_add_string(sb, "word,count,penalty_millipoints,"
+                                  "bonus_millipoints\n");
+  } else {
+    string_builder_add_string(sb, "word,count,penalty_millipoints\n");
+  }
+  for (uint32_t e = 0; e < num_words; e++) {
+    const uint32_t i = entries[e].word_index;
+    const DictionaryWord *dw =
+        dictionary_word_list_get_word(ctx->words, (int)i);
+    const MachineLetter *word = dictionary_word_get_word(dw);
+    const int len = dictionary_word_get_length(dw);
+    for (int li = 0; li < len; li++) {
+      char *hl = ld_ml_to_hl(ctx->ld, word[li]);
+      string_builder_add_string(sb, hl);
+      free(hl);
+    }
+    if (totals->bonus) {
+      string_builder_add_formatted_string(
+          sb, ",%llu,%lld,%lld\n", (unsigned long long)totals->count[i],
+          (long long)totals->penalty[i], (long long)totals->bonus[i]);
+    } else {
+      string_builder_add_formatted_string(sb, ",%llu,%lld\n",
+                                          (unsigned long long)totals->count[i],
+                                          (long long)totals->penalty[i]);
+    }
+  }
+  write_string_to_file(ctx->out_path, "w", string_builder_peek(sb),
+                       error_stack);
+  string_builder_destroy(sb);
+  free(entries);
+}

--- a/src/impl/word_playability.h
+++ b/src/impl/word_playability.h
@@ -1,0 +1,112 @@
+#ifndef WORD_PLAYABILITY_H
+#define WORD_PLAYABILITY_H
+
+#include "../ent/game.h"
+#include "../ent/kwg.h"
+#include "../ent/letter_distribution.h"
+#include "../util/io_util.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+// Word-playability metrics, collected over an autoplay run (one analysis per
+// position the player on turn faces). For every word in the full lexicon it
+// accumulates three metrics, all derived from the position's full,
+// equity-sorted move list:
+//
+//   count   - uniform play count: +1 for every word (main word AND every cross
+//             /hook word) the best move forms, summed over all positions.
+//   penalty - "equity loss if the player knew every word except this one": for
+//             each word W the best move forms, the equity gap to the best move
+//             that forms no W. Summed in Equity millipoints.
+//   bonus   - "equity gained from knowing a small word set plus this word":
+//             only when a small-set KWG is supplied. Baseline is the best move
+//             whose words are all in the small set; for each move that becomes
+//             playable by adding exactly one word W (all its other words are in
+//             the small set), W accrues the gap over the baseline, but only on
+//             positions where adding W beats the baseline (i.e. a small-set
+//             word is not already best). Summed in Equity millipoints.
+//
+// Equity is summed as int64 millipoints (no floating point); the Equity type is
+// already integer millipoints.
+
+typedef enum {
+  WORD_PLAYABILITY_SORT_COUNT,
+  WORD_PLAYABILITY_SORT_PENALTY,
+  WORD_PLAYABILITY_SORT_BONUS,
+} word_playability_sort_t;
+
+// Shared, read-only context: the enumerated full lexicon, the optional small
+// word set, and output options. One instance is shared across worker threads.
+typedef struct WordPlayabilityContext WordPlayabilityContext;
+
+// Enumerates every word of full_kwg into a sorted table. small_kwg may be NULL
+// (then the bonus metric is omitted). Takes ownership of out_path (frees it on
+// destroy). ld and small_kwg are borrowed (not freed).
+WordPlayabilityContext *
+word_playability_context_create(const KWG *full_kwg, const KWG *small_kwg,
+                                const LetterDistribution *ld, char *out_path,
+                                word_playability_sort_t sort);
+void word_playability_context_destroy(WordPlayabilityContext *ctx);
+bool word_playability_context_has_bonus(const WordPlayabilityContext *ctx);
+
+// Enables the position cache dump: each worker writes its analyzed positions to
+// <dump_prefix>.<n> (binary) for the offline greedy. Run with the small set as
+// the seed so the dumped baseline is the seed baseline.
+void word_playability_context_set_dump_prefix(WordPlayabilityContext *ctx,
+                                              const char *dump_prefix);
+
+// Writes the full lexicon, one word per line in id order, so the offline greedy
+// maps dump word ids back to words.
+void word_playability_write_word_list(const WordPlayabilityContext *ctx,
+                                      const char *path,
+                                      ErrorStack *error_stack);
+uint32_t word_playability_context_num_words(const WordPlayabilityContext *ctx);
+
+// Full-lexicon index of `word` (length `len`); UINT32_MAX if absent. Blank
+// flags on the letters are ignored.
+uint32_t word_playability_context_word_index(const WordPlayabilityContext *ctx,
+                                             const MachineLetter *word,
+                                             int len);
+
+// Per-thread accumulator (count/penalty/bonus arrays + reusable move list and
+// scratch). Bound to a context for the lexicon size.
+typedef struct WordPlayabilityCounts WordPlayabilityCounts;
+
+WordPlayabilityCounts *
+word_playability_counts_create(const WordPlayabilityContext *ctx);
+void word_playability_counts_destroy(WordPlayabilityCounts *counts);
+
+// Per-word accumulated values (for inspection/testing). Penalty and bonus are
+// in Equity millipoints; bonus is 0 when no small set was configured.
+uint64_t word_playability_counts_get_count(const WordPlayabilityCounts *counts,
+                                           uint32_t word_index);
+int64_t word_playability_counts_get_penalty(const WordPlayabilityCounts *counts,
+                                            uint32_t word_index);
+int64_t word_playability_counts_get_bonus(const WordPlayabilityCounts *counts,
+                                          uint32_t word_index);
+
+// Generates the full equity-sorted move list for the player on turn in `game`
+// and folds its three metrics into `counts`. No-op if the position yields no
+// moves. Does not mutate the game.
+void word_playability_counts_add_position(WordPlayabilityCounts *counts,
+                                          const WordPlayabilityContext *ctx,
+                                          const Game *game);
+
+// Adds every per-word total of src into dst (the reduce step).
+void word_playability_counts_merge(WordPlayabilityCounts *dst,
+                                   const WordPlayabilityCounts *src);
+
+// Positions analyzed and how many had a true bingo (best move places all
+// RACK_SIZE tiles) as the best play.
+uint64_t
+word_playability_counts_get_positions(const WordPlayabilityCounts *counts);
+uint64_t
+word_playability_counts_get_bingos(const WordPlayabilityCounts *counts);
+
+// Writes the sorted CSV (sort key descending, ties alphabetical) to the
+// context's output path. Columns: word,count,penalty[,bonus].
+void word_playability_write_csv(const WordPlayabilityContext *ctx,
+                                const WordPlayabilityCounts *totals,
+                                ErrorStack *error_stack);
+
+#endif

--- a/test/compact_leaves_test.c
+++ b/test/compact_leaves_test.c
@@ -1,0 +1,200 @@
+#include "compact_leaves_test.h"
+
+#include "../src/def/letter_distribution_defs.h"
+#include "../src/def/rack_defs.h"
+#include "../src/ent/compact_leaves.h"
+#include "../src/ent/data_filepaths.h"
+#include "../src/ent/equity.h"
+#include "../src/ent/klv.h"
+#include "../src/ent/letter_distribution.h"
+#include "../src/ent/rack.h"
+#include "../src/impl/compact_leaves_maker.h"
+#include "../src/impl/config.h"
+#include "../src/util/io_util.h"
+#include "../src/util/string_util.h"
+#include "test_util.h"
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Asserts the two models are byte-for-byte equivalent in every field, so a
+// file-loaded model is indistinguishable from the in-memory one it was written
+// from.
+static void assert_clv_fields_equal(const CompactLeaves *a,
+                                    const CompactLeaves *b) {
+  assert(a->dist_size == b->dist_size);
+  assert(a->radix_code == b->radix_code);
+  assert(a->radix_millipoints == b->radix_millipoints);
+  assert(a->flags == b->flags);
+  assert(a->coef_bits == b->coef_bits);
+  assert(a->vowel_bits == b->vowel_bits);
+  assert(a->base_ticks == b->base_ticks);
+  assert(a->num_synergies == b->num_synergies);
+  for (int ml = 0; ml < a->dist_size; ml++) {
+    assert(a->tile_ticks[ml] == b->tile_ticks[ml]);
+  }
+  const bool has_dup = (a->flags & COMPACT_LEAVES_FLAG_HAS_DUP) != 0;
+  assert(has_dup == ((b->flags & COMPACT_LEAVES_FLAG_HAS_DUP) != 0));
+  if (has_dup) {
+    assert(a->dup_ticks != NULL && b->dup_ticks != NULL);
+    for (int ml = 0; ml < a->dist_size; ml++) {
+      assert(a->dup_ticks[ml] == b->dup_ticks[ml]);
+    }
+  } else {
+    assert(a->dup_ticks == NULL && b->dup_ticks == NULL);
+  }
+  for (int i = 0; i < COMPACT_LEAVES_VC_TABLE_SIZE; i++) {
+    assert(a->vc_ticks[i] == b->vc_ticks[i]);
+  }
+  for (uint32_t syn_idx = 0; syn_idx < a->num_synergies; syn_idx++) {
+    const CompactLeavesSynergy *sa = &a->synergies[syn_idx];
+    const CompactLeavesSynergy *sb = &b->synergies[syn_idx];
+    assert(sa->num_tiles == sb->num_tiles);
+    assert(sa->value_ticks == sb->value_ticks);
+    assert(memcmp(sa->tiles, sb->tiles, sa->num_tiles) == 0);
+  }
+}
+
+// The quantized leave value must be identical between two models for a spread of
+// sampled leaves (singles, duplicates, and small multi-tile racks). Sampled by
+// machine-letter index so it needs no per-lexicon orthography.
+static void assert_clv_values_equal(const CompactLeaves *a,
+                                    const CompactLeaves *b,
+                                    const LetterDistribution *ld) {
+  const int size = ld_get_size(ld);
+  Rack *leave = rack_create((uint16_t)size);
+
+  // Empty leave is defined to be 0 for both.
+  assert(compact_leaves_get_leave_value(a, leave) == 0);
+  assert(compact_leaves_get_leave_value(b, leave) == 0);
+
+  // Single tiles (incl. blank, ml 0) and doubled tiles.
+  for (int ml = 0; ml < size; ml++) {
+    rack_reset(leave);
+    rack_add_letter(leave, (MachineLetter)ml);
+    assert(compact_leaves_get_leave_value(a, leave) ==
+           compact_leaves_get_leave_value(b, leave));
+    if (ml + 1 < size) {
+      rack_add_letter(leave, (MachineLetter)ml);
+      assert(compact_leaves_get_leave_value(a, leave) ==
+             compact_leaves_get_leave_value(b, leave));
+    }
+  }
+
+  // A few full-width (RACK_SIZE-1) leaves built from low machine letters.
+  for (int start = 0; start + 1 < size && start < 4; start++) {
+    rack_reset(leave);
+    for (int offset = 0; offset < RACK_SIZE - 1; offset++) {
+      const int ml = 1 + ((start + offset) % (size - 1));
+      rack_add_letter(leave, (MachineLetter)ml);
+    }
+    assert(compact_leaves_get_leave_value(a, leave) ==
+           compact_leaves_get_leave_value(b, leave));
+  }
+
+  rack_destroy(leave);
+}
+
+// Builds a CompactLeaves from `lexicon`'s KLV, asserts the budget contract, and
+// checks a write/read round-trip preserves both the fields and the evaluated
+// values. Run for English (CSW21) and Polish (OSPS49); the larger Polish
+// alphabet flexes the per-tile arrays and the vowel bitset.
+static void test_compact_leaves_for_lexicon(const char *lexicon,
+                                            size_t target_bytes,
+                                            bool bit_packed) {
+  char *set_cmd = get_formatted_string("set -lex %s -wmp false", lexicon);
+  Config *config = config_create_or_die(set_cmd);
+  free(set_cmd);
+  const LetterDistribution *ld = config_get_ld(config);
+
+  ErrorStack *error_stack = error_stack_create();
+  KLV *klv = klv_create(config_get_data_paths(config), lexicon, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(klv != NULL);
+
+  CompactLeaves *cl = compact_leaves_create_from_klv(
+      klv, ld, NULL, target_bytes, COMPACT_LEAVES_RADIX_EIGHTH, bit_packed);
+  assert(cl != NULL);
+  assert(cl->dist_size == ld_get_size(ld));
+  assert(cl->radix_code == COMPACT_LEAVES_RADIX_EIGHTH);
+  assert(((cl->flags & COMPACT_LEAVES_FLAG_BITPACKED) != 0) == bit_packed);
+
+  const char *filename = "compact_leaves_round_trip_test.clv";
+  compact_leaves_write_to_file(cl, filename, error_stack);
+  assert(error_stack_is_empty(error_stack));
+
+  // target_bytes here is comfortably above the base-model floor, so the file
+  // must honor the budget.
+  FILE *sized = fopen(filename, "rb");
+  assert(sized != NULL);
+  fseek(sized, 0, SEEK_END);
+  const long file_size = ftell(sized);
+  fclose(sized);
+  assert(file_size > 0);
+  assert((size_t)file_size <= target_bytes);
+
+  CompactLeaves *loaded = compact_leaves_read_from_file(filename, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(loaded != NULL);
+  assert_clv_fields_equal(cl, loaded);
+  assert_clv_values_equal(cl, loaded, ld);
+
+  printf("[%s] compact leaves: dist_size=%u synergies=%u flags=0x%x -> %ld "
+         "bytes (budget %zu)\n",
+         lexicon, cl->dist_size, cl->num_synergies, cl->flags, file_size,
+         target_bytes);
+
+  (void)remove(filename);
+  compact_leaves_destroy(loaded);
+  compact_leaves_destroy(cl);
+  klv_destroy(klv);
+  error_stack_destroy(error_stack);
+  config_destroy(config);
+}
+
+// Exercises the klv2clv convert command end-to-end: convert a small testdata
+// KLV to a .clv on disk and confirm it loads and evaluates.
+static void test_compact_leaves_convert_command(void) {
+  Config *config = config_create_or_die("set -lex CSW21 -wmp false");
+  ErrorStack *error_stack = error_stack_create();
+
+  load_and_exec_config_or_die(
+      config, "convert klv2clv CSW21_small english_small -clvsize 2048");
+
+  char *clv_path = data_filepaths_get_readable_filename(
+      DEFAULT_TEST_DATA_PATH, "CSW21_small", DATA_FILEPATH_TYPE_COMPACT_LEAVES,
+      error_stack);
+  assert(error_stack_is_empty(error_stack));
+
+  CompactLeaves *cl = compact_leaves_read_from_file(clv_path, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(cl != NULL);
+  // english_small has blank + A + B.
+  assert(cl->dist_size == 3);
+
+  // The empty leave evaluates to 0; a one-tile leave is a finite Equity.
+  Rack *leave = rack_create(cl->dist_size);
+  assert(compact_leaves_get_leave_value(cl, leave) == 0);
+  rack_add_letter(leave, 1);
+  const Equity single = compact_leaves_get_leave_value(cl, leave);
+  assert(single > EQUITY_MIN_VALUE && single < EQUITY_MAX_VALUE);
+  rack_destroy(leave);
+
+  (void)remove(clv_path);
+  free(clv_path);
+  compact_leaves_destroy(cl);
+  error_stack_destroy(error_stack);
+  config_destroy(config);
+}
+
+void test_compact_leaves(void) {
+  // Bit-packed (the default the maker/convert ship) and byte-granular bodies.
+  test_compact_leaves_for_lexicon("CSW21", 4096, true);
+  test_compact_leaves_for_lexicon("CSW21", 8192, false);
+  // Polish: large alphabet (no 64-bit BitRack) flexing the per-tile arrays.
+  test_compact_leaves_for_lexicon("OSPS49", 4096, true);
+  test_compact_leaves_convert_command();
+}

--- a/test/compact_leaves_test.h
+++ b/test/compact_leaves_test.h
@@ -1,0 +1,6 @@
+#ifndef COMPACT_LEAVES_TEST_H
+#define COMPACT_LEAVES_TEST_H
+
+void test_compact_leaves(void);
+
+#endif

--- a/test/dawg_arc_compressed_test.c
+++ b/test/dawg_arc_compressed_test.c
@@ -7,6 +7,7 @@
 #include "../src/impl/config.h"
 #include "../src/impl/kwg_maker.h"
 #include "../src/util/io_util.h"
+#include "../src/util/string_util.h"
 #include "test_util.h"
 #include <assert.h>
 #include <stdbool.h>
@@ -83,8 +84,13 @@ static void assert_rejects_bad_header(void) {
   (void)remove(filename);
 }
 
-void test_dawg_arc_compressed(void) {
-  Config *config = config_create_or_die("set -lex CSW21");
+// Builds, compresses, decodes and round-trips the (length-capped) word list of
+// `lexicon`. Run for English (CSW21) and Polish (OSPS49); the larger Polish
+// alphabet flexes the wider tile_bits encoding path.
+static void test_dawg_arc_compressed_for_lexicon(const char *lexicon) {
+  char *set_cmd = get_formatted_string("set -lex %s -wmp false", lexicon);
+  Config *config = config_create_or_die(set_cmd);
+  free(set_cmd);
   Game *game = config_game_create(config);
   const KWG *csw_kwg = player_get_kwg(game_get_player(game, 0));
   DictionaryWordList *all_words = dictionary_word_list_create();
@@ -109,10 +115,11 @@ void test_dawg_arc_compressed(void) {
 
   DawgArcCompressed *dp = dawg_arc_compressed_create_from_kwg(
       reorder_kwg, DAWG_ARC_COMPRESSED_MODE_MIN_RAM);
-  printf("arc-compressed dawg: %u nodes, tile_bits=%u arc_bits=%u field=%u "
+  printf("[%s] arc-compressed dawg: %u nodes, tile_bits=%u arc_bits=%u field=%u "
          "rec_width=%u, popular=%u escapes=%u -> %zu bytes (vs %d bytes at 32 "
          "bits, %.2f%%)\n",
-         dawg_arc_compressed_get_node_count(dp), dp->tile_bits, dp->arc_bits,
+         lexicon, dawg_arc_compressed_get_node_count(dp), dp->tile_bits,
+         dp->arc_bits,
          dp->field, dp->rec_width, dp->popular_count, dp->escape_count,
          dawg_arc_compressed_get_num_bytes(dp), reorder_node_count * 4,
          100.0 * (double)dawg_arc_compressed_get_num_bytes(dp) /
@@ -173,8 +180,6 @@ void test_dawg_arc_compressed(void) {
   DictionaryWordList *expected_loaded = copy_word_list(words);
   assert_same_word_set(expected_loaded, decoded_loaded);
 
-  assert_rejects_bad_header();
-
   (void)remove(filename);
   dictionary_word_list_destroy(decoded);
   dictionary_word_list_destroy(expected);
@@ -187,4 +192,12 @@ void test_dawg_arc_compressed(void) {
   kwg_destroy(reorder_kwg);
   game_destroy(game);
   config_destroy(config);
+}
+
+void test_dawg_arc_compressed(void) {
+  test_dawg_arc_compressed_for_lexicon("CSW21");
+  // Polish: a larger alphabet (no 64-bit BitRack) that flexes the wider
+  // tile_bits arc encoding.
+  test_dawg_arc_compressed_for_lexicon("OSPS49");
+  assert_rejects_bad_header();
 }

--- a/test/dawg_arc_compressed_test.c
+++ b/test/dawg_arc_compressed_test.c
@@ -1,0 +1,190 @@
+#include "../src/def/kwg_defs.h"
+#include "../src/ent/dawg_arc_compressed.h"
+#include "../src/ent/dictionary_word.h"
+#include "../src/ent/game.h"
+#include "../src/ent/kwg.h"
+#include "../src/ent/player.h"
+#include "../src/impl/config.h"
+#include "../src/impl/kwg_maker.h"
+#include "../src/util/io_util.h"
+#include "test_util.h"
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+enum {
+  // Cap word length to emulate a constrained-hardware word list (and keep the
+  // ASAN build fast), matching the packed-DAWG test's corpus shape.
+  MAX_TEST_WORD_LENGTH = 8,
+};
+
+static void assert_same_word_set(DictionaryWordList *expected,
+                                 DictionaryWordList *actual) {
+  dictionary_word_list_sort(expected);
+  dictionary_word_list_sort(actual);
+  assert(dictionary_word_list_get_count(expected) ==
+         dictionary_word_list_get_count(actual));
+  for (int word_idx = 0; word_idx < dictionary_word_list_get_count(expected);
+       word_idx++) {
+    const DictionaryWord *expected_word =
+        dictionary_word_list_get_word(expected, word_idx);
+    const DictionaryWord *actual_word =
+        dictionary_word_list_get_word(actual, word_idx);
+    assert(dictionary_word_get_length(expected_word) ==
+           dictionary_word_get_length(actual_word));
+    assert(memcmp(dictionary_word_get_word(expected_word),
+                  dictionary_word_get_word(actual_word),
+                  dictionary_word_get_length(expected_word)) == 0);
+  }
+}
+
+// Builds the expected word set (a fresh copy of words) so the in-memory and
+// file-loaded decodings can each be checked against it.
+static DictionaryWordList *copy_word_list(const DictionaryWordList *words) {
+  DictionaryWordList *copy = dictionary_word_list_create();
+  for (int word_idx = 0; word_idx < dictionary_word_list_get_count(words);
+       word_idx++) {
+    const DictionaryWord *word = dictionary_word_list_get_word(words, word_idx);
+    dictionary_word_list_add_word(copy, dictionary_word_get_word(word),
+                                  dictionary_word_get_length(word));
+  }
+  return copy;
+}
+
+// A corrupt header (here, an out-of-range arc_bits) must be rejected cleanly
+// rather than triggering a huge allocation or an out-of-range shift.
+static void assert_rejects_bad_header(void) {
+  const char *filename = "dawg_arc_compressed_bad_header_test.acdawg";
+  uint8_t header[DAWG_ARC_COMPRESSED_HEADER_BYTES];
+  memset(header, 0, sizeof(header));
+  for (int magic_idx = 0; magic_idx < 4; magic_idx++) {
+    header[magic_idx] = (uint8_t)DAWG_ARC_COMPRESSED_MAGIC[magic_idx];
+  }
+  header[4] = DAWG_ARC_COMPRESSED_VERSION;
+  header[5] = 5;  // tile_bits
+  header[6] = 99; // arc_bits: out of range
+  header[7] = 15; // rec_width
+  header[8] = 7;  // field
+  ErrorStack *error_stack = error_stack_create();
+  FILE *stream = fopen_safe(filename, "wb", error_stack);
+  assert(error_stack_is_empty(error_stack));
+  fwrite_or_die(header, 1, sizeof(header), stream,
+                "bad arc-compressed dawg header");
+  fclose_or_die(stream);
+
+  const DawgArcCompressed *dp =
+      dawg_arc_compressed_read_from_file(filename, error_stack);
+  assert(dp == NULL);
+  assert(!error_stack_is_empty(error_stack));
+  error_stack_destroy(error_stack);
+  (void)remove(filename);
+}
+
+void test_dawg_arc_compressed(void) {
+  Config *config = config_create_or_die("set -lex CSW21");
+  Game *game = config_game_create(config);
+  const KWG *csw_kwg = player_get_kwg(game_get_player(game, 0));
+  DictionaryWordList *all_words = dictionary_word_list_create();
+  kwg_write_words(csw_kwg, kwg_get_dawg_root_node_index(csw_kwg), all_words,
+                  NULL);
+
+  DictionaryWordList *words = dictionary_word_list_create();
+  for (int word_idx = 0; word_idx < dictionary_word_list_get_count(all_words);
+       word_idx++) {
+    const DictionaryWord *word =
+        dictionary_word_list_get_word(all_words, word_idx);
+    if (dictionary_word_get_length(word) <= MAX_TEST_WORD_LENGTH) {
+      dictionary_word_list_add_word(words, dictionary_word_get_word(word),
+                                    dictionary_word_get_length(word));
+    }
+  }
+  dictionary_word_list_destroy(all_words);
+
+  KWG *reorder_kwg = make_kwg_from_words(words, KWG_MAKER_OUTPUT_DAWG,
+                                         KWG_MAKER_MERGE_TAIL_REORDER);
+  const int reorder_node_count = kwg_get_number_of_nodes(reorder_kwg);
+
+  DawgArcCompressed *dp = dawg_arc_compressed_create_from_kwg(
+      reorder_kwg, DAWG_ARC_COMPRESSED_MODE_MIN_RAM);
+  printf("arc-compressed dawg: %u nodes, tile_bits=%u arc_bits=%u field=%u "
+         "rec_width=%u, popular=%u escapes=%u -> %zu bytes (vs %d bytes at 32 "
+         "bits, %.2f%%)\n",
+         dawg_arc_compressed_get_node_count(dp), dp->tile_bits, dp->arc_bits,
+         dp->field, dp->rec_width, dp->popular_count, dp->escape_count,
+         dawg_arc_compressed_get_num_bytes(dp), reorder_node_count * 4,
+         100.0 * (double)dawg_arc_compressed_get_num_bytes(dp) /
+             (reorder_node_count * 4));
+
+  // Must beat the 32-bit-per-node baseline.
+  assert(dawg_arc_compressed_get_num_bytes(dp) <
+         (size_t)reorder_node_count * 4);
+
+  // The decoded word set must match the source word list.
+  DictionaryWordList *decoded = dictionary_word_list_create();
+  dawg_arc_compressed_write_words(dp, decoded);
+  DictionaryWordList *expected = copy_word_list(words);
+  assert_same_word_set(expected, decoded);
+
+  // BALANCED mode trades RAM for fewer escapes (and thus faster traversal): no
+  // more escapes than MIN_RAM, at least as large, and the same word set.
+  DawgArcCompressed *bal = dawg_arc_compressed_create_from_kwg(
+      reorder_kwg, DAWG_ARC_COMPRESSED_MODE_BALANCED);
+  printf("arc-compressed dawg (balanced): field=%u K=%u escapes=%u -> %zu "
+         "bytes\n",
+         bal->field, bal->popular_count, bal->escape_count,
+         dawg_arc_compressed_get_num_bytes(bal));
+  assert(bal->escape_count <= dp->escape_count);
+  assert(dawg_arc_compressed_get_num_bytes(bal) >=
+         dawg_arc_compressed_get_num_bytes(dp));
+  DictionaryWordList *bal_decoded = dictionary_word_list_create();
+  dawg_arc_compressed_write_words(bal, bal_decoded);
+  DictionaryWordList *bal_expected = copy_word_list(words);
+  assert_same_word_set(bal_expected, bal_decoded);
+  dictionary_word_list_destroy(bal_decoded);
+  dictionary_word_list_destroy(bal_expected);
+  dawg_arc_compressed_destroy(bal);
+
+  // File round-trip: the word set must survive write + read.
+  const char *filename = "dawg_arc_compressed_round_trip_test.acdawg";
+  ErrorStack *error_stack = error_stack_create();
+  dawg_arc_compressed_write_to_file(dp, filename, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  DawgArcCompressed *loaded =
+      dawg_arc_compressed_read_from_file(filename, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(loaded != NULL);
+  assert(loaded->node_count == dp->node_count);
+  assert(loaded->root_index == dp->root_index);
+  assert(loaded->popular_count == dp->popular_count);
+  assert(loaded->escape_count == dp->escape_count);
+  assert(loaded->tile_bits == dp->tile_bits);
+  assert(loaded->arc_bits == dp->arc_bits);
+  assert(loaded->rec_width == dp->rec_width);
+  assert(loaded->field == dp->field);
+  assert(dawg_arc_compressed_get_num_bytes(loaded) ==
+         dawg_arc_compressed_get_num_bytes(dp));
+  assert(memcmp(loaded->bytes, dp->bytes, dp->num_bytes) == 0);
+
+  DictionaryWordList *decoded_loaded = dictionary_word_list_create();
+  dawg_arc_compressed_write_words(loaded, decoded_loaded);
+  DictionaryWordList *expected_loaded = copy_word_list(words);
+  assert_same_word_set(expected_loaded, decoded_loaded);
+
+  assert_rejects_bad_header();
+
+  (void)remove(filename);
+  dictionary_word_list_destroy(decoded);
+  dictionary_word_list_destroy(expected);
+  dictionary_word_list_destroy(decoded_loaded);
+  dictionary_word_list_destroy(expected_loaded);
+  dawg_arc_compressed_destroy(loaded);
+  error_stack_destroy(error_stack);
+  dawg_arc_compressed_destroy(dp);
+  dictionary_word_list_destroy(words);
+  kwg_destroy(reorder_kwg);
+  game_destroy(game);
+  config_destroy(config);
+}

--- a/test/dawg_arc_compressed_test.h
+++ b/test/dawg_arc_compressed_test.h
@@ -1,0 +1,6 @@
+#ifndef DAWG_ARC_COMPRESSED_TEST_H
+#define DAWG_ARC_COMPRESSED_TEST_H
+
+void test_dawg_arc_compressed(void);
+
+#endif

--- a/test/test.c
+++ b/test/test.c
@@ -21,6 +21,7 @@
 #include "convert_test.h"
 #include "create_data_test.h"
 #include "cross_set_test.h"
+#include "dawg_arc_compressed_test.h"
 #include "dawg_packed_test.h"
 #include "endgame_test.h"
 #include "equity_adjustment_test.h"
@@ -62,6 +63,7 @@
 #include "wmp_maker_test.h"
 #include "wmp_move_gen_test.h"
 #include "wmp_test.h"
+#include "word_playability_test.h"
 #include "word_prune_test.h"
 #include "word_test.h"
 #include "zobrist_test.h"
@@ -115,6 +117,8 @@ static TestEntry test_table[] = {
     {"autoplay", test_autoplay},
     {"words", test_words},
     {"wordprune", test_word_prune},
+    {"playability", test_word_playability},
+    {"dawgarccompressed", test_dawg_arc_compressed},
     {"kwgmaker", test_kwg_maker},
     {"cgp", test_cgp},
     {"rl", test_rack_list},

--- a/test/test.c
+++ b/test/test.c
@@ -17,6 +17,7 @@
 #include "cgp_test.h"
 #include "checkpoint_test.h"
 #include "command_test.h"
+#include "compact_leaves_test.h"
 #include "config_test.h"
 #include "convert_test.h"
 #include "create_data_test.h"
@@ -118,6 +119,7 @@ static TestEntry test_table[] = {
     {"words", test_words},
     {"wordprune", test_word_prune},
     {"playability", test_word_playability},
+    {"clv", test_compact_leaves},
     {"dawgarccompressed", test_dawg_arc_compressed},
     {"kwgmaker", test_kwg_maker},
     {"cgp", test_cgp},

--- a/test/word_playability_test.c
+++ b/test/word_playability_test.c
@@ -1,7 +1,9 @@
 #include "word_playability_test.h"
 
 #include "../src/def/game_history_defs.h"
+#include "../src/def/letter_distribution_defs.h"
 #include "../src/def/rack_defs.h"
+#include "../src/ent/dictionary_word.h"
 #include "../src/ent/game.h"
 #include "../src/ent/kwg.h"
 #include "../src/ent/letter_distribution.h"
@@ -11,6 +13,7 @@
 #include "../src/ent/words.h"
 #include "../src/impl/config.h"
 #include "../src/impl/gameplay.h"
+#include "../src/impl/kwg_maker.h"
 #include "../src/impl/word_playability.h"
 #include "../src/util/io_util.h"
 #include "../src/util/string_util.h"
@@ -18,6 +21,7 @@
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 // Sets the player-on-turn's rack and returns the deterministic best play's
 // formed-word full-lexicon indices (and the main word's index).
@@ -48,6 +52,71 @@ static int collect_best_play_words(Game *game,
   formed_words_destroy(fw);
   move_list_destroy(move_list);
   return count;
+}
+
+// Polish (OSPS49) flex: a large alphabet (no 64-bit BitRack) exercises full-
+// lexicon enumeration and word indexing over wider machine letters. Every
+// enumerated word must index back to a valid id, and a non-word must not.
+static void test_word_playability_polish_indexing(void) {
+  Config *config = config_create_or_die("set -lex OSPS49 -wmp false");
+  Game *game = config_game_create(config);
+  const KWG *kwg = player_get_kwg(game_get_player(game, 0));
+
+  WordPlayabilityContext *ctx = word_playability_context_create(
+      kwg, NULL, game_get_ld(game),
+      string_duplicate("playability_polish_test.csv"),
+      WORD_PLAYABILITY_SORT_COUNT);
+  const uint32_t num_words = word_playability_context_num_words(ctx);
+  assert(num_words > 100000); // OSPS49 is a large lexicon
+
+  DictionaryWordList *all_words = dictionary_word_list_create();
+  kwg_write_words(kwg, kwg_get_dawg_root_node_index(kwg), all_words, NULL);
+  const int total = dictionary_word_list_get_count(all_words);
+  assert((uint32_t)total == num_words);
+
+  // Sample across the enumeration; each enumerated word must map to a valid id.
+  for (int word_idx = 0; word_idx < total; word_idx += total / 50 + 1) {
+    const DictionaryWord *word =
+        dictionary_word_list_get_word(all_words, word_idx);
+    const uint32_t id = word_playability_context_word_index(
+        ctx, dictionary_word_get_word(word), dictionary_word_get_length(word));
+    assert(id != UINT32_MAX);
+    assert(id < num_words);
+  }
+
+  // Pick a genuine two-tile non-word (one absent from the enumerated list) and
+  // confirm it indexes as absent. Found by flagging the real two-letter words,
+  // then taking the first combo that is not one -- language-agnostic.
+  const int ld_size = ld_get_size(game_get_ld(game));
+  bool *two_letter_exists = calloc((size_t)ld_size * ld_size, sizeof(bool));
+  for (int word_idx = 0; word_idx < total; word_idx++) {
+    const DictionaryWord *word =
+        dictionary_word_list_get_word(all_words, word_idx);
+    if (dictionary_word_get_length(word) == 2) {
+      const MachineLetter *mls = dictionary_word_get_word(word);
+      two_letter_exists[(int)mls[0] * ld_size + (int)mls[1]] = true;
+    }
+  }
+  MachineLetter not_a_word[2] = {0, 0};
+  bool found_non_word = false;
+  for (int first = 1; first < ld_size && !found_non_word; first++) {
+    for (int second = 1; second < ld_size; second++) {
+      if (!two_letter_exists[first * ld_size + second]) {
+        not_a_word[0] = (MachineLetter)first;
+        not_a_word[1] = (MachineLetter)second;
+        found_non_word = true;
+        break;
+      }
+    }
+  }
+  free(two_letter_exists);
+  assert(found_non_word);
+  assert(word_playability_context_word_index(ctx, not_a_word, 2) == UINT32_MAX);
+
+  dictionary_word_list_destroy(all_words);
+  word_playability_context_destroy(ctx);
+  game_destroy(game);
+  config_destroy(config);
 }
 
 void test_word_playability(void) {
@@ -126,4 +195,6 @@ void test_word_playability(void) {
 
   game_destroy(game);
   config_destroy(config);
+
+  test_word_playability_polish_indexing();
 }

--- a/test/word_playability_test.c
+++ b/test/word_playability_test.c
@@ -1,0 +1,129 @@
+#include "word_playability_test.h"
+
+#include "../src/def/game_history_defs.h"
+#include "../src/def/rack_defs.h"
+#include "../src/ent/game.h"
+#include "../src/ent/kwg.h"
+#include "../src/ent/letter_distribution.h"
+#include "../src/ent/move.h"
+#include "../src/ent/player.h"
+#include "../src/ent/rack.h"
+#include "../src/ent/words.h"
+#include "../src/impl/config.h"
+#include "../src/impl/gameplay.h"
+#include "../src/impl/word_playability.h"
+#include "../src/util/io_util.h"
+#include "../src/util/string_util.h"
+#include "test_util.h"
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// Sets the player-on-turn's rack and returns the deterministic best play's
+// formed-word full-lexicon indices (and the main word's index).
+static int collect_best_play_words(Game *game,
+                                   const WordPlayabilityContext *ctx,
+                                   const char *rack_str, uint32_t *out_indices,
+                                   uint32_t *out_main_index) {
+  const LetterDistribution *ld = game_get_ld(game);
+  const int player_index = game_get_player_on_turn_index(game);
+  Rack *rack = player_get_rack(game_get_player(game, player_index));
+  rack_set_to_string(ld, rack, rack_str);
+
+  MoveList *move_list = move_list_create(10000);
+  const Move *best = get_top_equity_move(game, move_list);
+  assert(move_get_type(best) == GAME_EVENT_TILE_PLACEMENT_MOVE);
+
+  FormedWords *fw = formed_words_create(game_get_board(game), best);
+  const int num_words = formed_words_get_num_words(fw);
+  int count = 0;
+  for (int i = 0; i < num_words; i++) {
+    const uint32_t idx = word_playability_context_word_index(
+        ctx, formed_words_get_word(fw, i), formed_words_get_word_length(fw, i));
+    assert(idx != UINT32_MAX); // every formed word is in the full lexicon
+    out_indices[count++] = idx;
+  }
+  // The main word is the last entry in FormedWords.
+  *out_main_index = out_indices[count - 1];
+  formed_words_destroy(fw);
+  move_list_destroy(move_list);
+  return count;
+}
+
+void test_word_playability(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -k1 CSW21 -k2 CSW21 -s1 equity -s2 equity -r1 all -r2 "
+      "all -numplays 1");
+  Game *game = config_game_create(config);
+  const LetterDistribution *ld = game_get_ld(game);
+  const KWG *kwg = player_get_kwg(game_get_player(game, 0));
+
+  // --- count + penalty (no small set) ---
+  WordPlayabilityContext *ctx = word_playability_context_create(
+      kwg, NULL, ld, string_duplicate("playability_test.csv"),
+      WORD_PLAYABILITY_SORT_COUNT);
+  assert(word_playability_context_num_words(ctx) > 100000); // CSW21 ~280k words
+  assert(!word_playability_context_has_bonus(ctx));
+
+  // Deterministic opening: a fixed rack on the empty board has a fixed best
+  // play. (Movegen reads the rack; the bag state is irrelevant here.)
+  uint32_t formed[RACK_SIZE + 1];
+  uint32_t main_index = 0;
+  const int num_formed =
+      collect_best_play_words(game, ctx, "AEINRST", formed, &main_index);
+  assert(num_formed >= 1);
+
+  WordPlayabilityCounts *counts = word_playability_counts_create(ctx);
+  word_playability_counts_add_position(counts, ctx, game);
+
+  // Every word the best play forms is counted once; the removal penalty is a
+  // sound (non-negative) equity loss.
+  for (int i = 0; i < num_formed; i++) {
+    assert(word_playability_counts_get_count(counts, formed[i]) == 1);
+    // Removal penalty is a sound (non-negative) equity loss. It can be 0 even
+    // for the best play: with rack AEINRST the opening has several equal-equity
+    // anagram bingos, so removing any one word loses nothing (play another).
+    assert(word_playability_counts_get_penalty(counts, formed[i]) >= 0);
+    assert(word_playability_counts_get_bonus(counts, formed[i]) == 0);
+  }
+
+  // Determinism: analyzing the same position again exactly doubles the counts.
+  word_playability_counts_add_position(counts, ctx, game);
+  assert(word_playability_counts_get_count(counts, main_index) == 2);
+
+  // Merge: a second table folded in adds its counts.
+  WordPlayabilityCounts *other = word_playability_counts_create(ctx);
+  word_playability_counts_add_position(other, ctx, game);
+  word_playability_counts_merge(counts, other);
+  assert(word_playability_counts_get_count(counts, main_index) == 3);
+  word_playability_counts_destroy(other);
+
+  word_playability_counts_destroy(counts);
+  word_playability_context_destroy(ctx);
+
+  // --- bonus (with a smaller lexicon as the small set) ---
+  ErrorStack *error_stack = error_stack_create();
+  KWG *small_kwg =
+      kwg_create(config_get_data_paths(config), "NWL20", error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(small_kwg != NULL);
+  error_stack_destroy(error_stack);
+  WordPlayabilityContext *bonus_ctx = word_playability_context_create(
+      kwg, small_kwg, ld, string_duplicate("playability_bonus_test.csv"),
+      WORD_PLAYABILITY_SORT_BONUS);
+  assert(word_playability_context_has_bonus(bonus_ctx));
+
+  WordPlayabilityCounts *bonus_counts =
+      word_playability_counts_create(bonus_ctx);
+  word_playability_counts_add_position(bonus_counts, bonus_ctx, game);
+  // Bonus is a non-negative equity gain for every word.
+  for (uint32_t i = 0; i < word_playability_context_num_words(bonus_ctx); i++) {
+    assert(word_playability_counts_get_bonus(bonus_counts, i) >= 0);
+  }
+  word_playability_counts_destroy(bonus_counts);
+  word_playability_context_destroy(bonus_ctx);
+  kwg_destroy(small_kwg);
+
+  game_destroy(game);
+  config_destroy(config);
+}

--- a/test/word_playability_test.h
+++ b/test/word_playability_test.h
@@ -1,0 +1,6 @@
+#ifndef WORD_PLAYABILITY_TEST_H
+#define WORD_PLAYABILITY_TEST_H
+
+void test_word_playability(void);
+
+#endif

--- a/tools/offline_greedy.c
+++ b/tools/offline_greedy.c
@@ -1,0 +1,239 @@
+// Offline value-per-byte dictionary subset selection from a playability cache.
+//
+// Reads a word list (<prefix>.words, id = 0-based line) and one or more binary
+// position dumps (<prefix>.<n>) produced by `playability ... -pbdump`. Runs the
+// greedy: each batch recomputes, for the current selected set S, every
+// candidate word's marginal bonus over S (re-derived from the cached positions,
+// no autoplay), divides by its prefix-sharing node cost, and adds the top
+// batch. The seed (all 2- and 3-letter words) is always available.
+//
+// Emits the selection order (seed words, then chosen 4+ words in greedy order)
+// to the output file, one word per line, so any byte budget can be sliced by
+// building the acdawg of a prefix of the order.
+//
+// Usage: offline_greedy <words> <batch> <out_order> <dump1> [dump2 ...]
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void *xmalloc(size_t n) {
+  void *p = malloc(n);
+  if (!p) { fprintf(stderr, "OOM %zu\n", n); exit(1); }
+  return p;
+}
+static void *xrealloc(void *p, size_t n) {
+  p = realloc(p, n);
+  if (!p) { fprintf(stderr, "OOM %zu\n", n); exit(1); }
+  return p;
+}
+
+// --- word list ---
+static char **g_word;   // word[i] = string for id i
+static int *g_len;      // length of word i
+static int g_nwords;
+
+static void load_words(const char *path) {
+  FILE *f = fopen(path, "r");
+  if (!f) { fprintf(stderr, "cannot open %s\n", path); exit(1); }
+  int cap = 1 << 18;
+  g_word = xmalloc((size_t)cap * sizeof(char *));
+  g_len = xmalloc((size_t)cap * sizeof(int));
+  char line[128];
+  g_nwords = 0;
+  while (fgets(line, sizeof(line), f)) {
+    int L = (int)strlen(line);
+    while (L > 0 && (line[L - 1] == '\n' || line[L - 1] == '\r')) L--;
+    line[L] = '\0';
+    if (g_nwords == cap) {
+      cap *= 2;
+      g_word = xrealloc(g_word, (size_t)cap * sizeof(char *));
+      g_len = xrealloc(g_len, (size_t)cap * sizeof(int));
+    }
+    g_word[g_nwords] = xmalloc((size_t)L + 1);
+    memcpy(g_word[g_nwords], line, (size_t)L + 1);
+    g_len[g_nwords] = L;
+    g_nwords++;
+  }
+  fclose(f);
+}
+
+// --- cached positions (flat) ---
+typedef struct { int32_t baseline; uint32_t mstart; uint16_t mcount; } Pos;
+typedef struct { int32_t equity; uint32_t wstart; uint8_t wcount; } Mv;
+static Pos *g_pos; static long g_npos, g_pos_cap;
+static Mv *g_mv; static long g_nmv, g_mv_cap;
+static uint32_t *g_mvw; static long g_nmvw, g_mvw_cap; // 4+ word ids only
+
+static void load_dump(const char *path) {
+  FILE *f = fopen(path, "rb");
+  if (!f) { fprintf(stderr, "cannot open %s\n", path); exit(1); }
+  int32_t baseline; uint16_t nmoves;
+  while (fread(&baseline, sizeof(int32_t), 1, f) == 1) {
+    if (fread(&nmoves, sizeof(uint16_t), 1, f) != 1) break;
+    if (g_npos == g_pos_cap) {
+      g_pos_cap = g_pos_cap ? g_pos_cap * 2 : (1 << 20);
+      g_pos = xrealloc(g_pos, (size_t)g_pos_cap * sizeof(Pos));
+    }
+    Pos *p = &g_pos[g_npos];
+    p->baseline = baseline;
+    p->mstart = (uint32_t)g_nmv;
+    p->mcount = nmoves;
+    for (int m = 0; m < nmoves; m++) {
+      int32_t equity; uint8_t nwords;
+      if (fread(&equity, sizeof(int32_t), 1, f) != 1) { fclose(f); return; }
+      if (fread(&nwords, sizeof(uint8_t), 1, f) != 1) { fclose(f); return; }
+      uint32_t ids[16];
+      if (nwords > 16) { fprintf(stderr, "nwords too big\n"); exit(1); }
+      if (fread(ids, sizeof(uint32_t), nwords, f) != nwords) { fclose(f); return; }
+      // keep only 4+ letter ids (2-3 letter words are always in the seed)
+      uint8_t kept = 0;
+      uint32_t keep[16];
+      for (int k = 0; k < nwords; k++) {
+        if (g_len[ids[k]] >= 4) keep[kept++] = ids[k];
+      }
+      if (g_nmv == g_mv_cap) {
+        g_mv_cap = g_mv_cap ? g_mv_cap * 2 : (1 << 21);
+        g_mv = xrealloc(g_mv, (size_t)g_mv_cap * sizeof(Mv));
+      }
+      Mv *mv = &g_mv[g_nmv];
+      mv->equity = equity;
+      mv->wstart = (uint32_t)g_nmvw;
+      mv->wcount = kept;
+      while (g_nmvw + kept > g_mvw_cap) {
+        g_mvw_cap = g_mvw_cap ? g_mvw_cap * 2 : (1 << 22);
+        g_mvw = xrealloc(g_mvw, (size_t)g_mvw_cap * sizeof(uint32_t));
+      }
+      memcpy(&g_mvw[g_nmvw], keep, (size_t)kept * sizeof(uint32_t));
+      g_nmvw += kept;
+      g_nmv++;
+    }
+    g_npos++;
+  }
+  fclose(f);
+}
+
+// --- prefix-sharing node-cost trie (A-Z) ---
+static int (*g_trie)[26]; static int g_trie_nodes, g_trie_cap;
+static int trie_new_node(void) {
+  if (g_trie_nodes == g_trie_cap) {
+    g_trie_cap = g_trie_cap ? g_trie_cap * 2 : (1 << 20);
+    g_trie = xrealloc(g_trie, (size_t)g_trie_cap * sizeof(*g_trie));
+  }
+  memset(g_trie[g_trie_nodes], 0, sizeof(g_trie[0])); // 0 = no child
+  return g_trie_nodes++;
+}
+static void trie_add(const char *w, int L) {
+  int node = 0;
+  for (int i = 0; i < L; i++) {
+    int c = w[i] - 'A';
+    if (c < 0 || c >= 26) return;
+    if (!g_trie[node][c]) g_trie[node][c] = trie_new_node();
+    node = g_trie[node][c];
+  }
+}
+static int trie_cost(const char *w, int L) { // new nodes = L - shared prefix
+  int node = 0, shared = 0;
+  for (int i = 0; i < L; i++) {
+    int c = w[i] - 'A';
+    if (c < 0 || c >= 26 || !g_trie[node][c]) break;
+    node = g_trie[node][c]; shared++;
+  }
+  return L - shared;
+}
+
+typedef struct { double ratio; int w; } Cand;
+static int cand_cmp(const void *a, const void *b) {
+  double ra = ((const Cand *)a)->ratio, rb = ((const Cand *)b)->ratio;
+  return ra < rb ? 1 : (ra > rb ? -1 : 0); // descending by ratio
+}
+
+int main(int argc, char **argv) {
+  if (argc < 5) {
+    fprintf(stderr, "usage: %s <words> <batch> <out_order> <dump...>\n", argv[0]);
+    return 1;
+  }
+  const char *words_path = argv[1];
+  int batch = atoi(argv[2]);
+  const char *out_path = argv[3];
+  load_words(words_path);
+  fprintf(stderr, "words: %d\n", g_nwords);
+  for (int a = 4; a < argc; a++) { load_dump(argv[a]); }
+  fprintf(stderr, "positions: %ld, moves: %ld, move-words(4+): %ld\n",
+          g_npos, g_nmv, g_nmvw);
+
+  // in_S over 4+ words; seed (len<=3) is implicitly always available.
+  char *in_S = calloc((size_t)g_nwords, 1);
+  int64_t *bonus = xmalloc((size_t)g_nwords * sizeof(int64_t));
+  uint32_t *stamp = calloc((size_t)g_nwords, sizeof(uint32_t)); // per-pos dedup
+  if (!in_S || !stamp) { fprintf(stderr, "OOM\n"); return 1; }
+  uint32_t gen = 0;
+
+  // trie seeded with all 2-3 letter words (their prefixes are free)
+  trie_new_node(); // root = 0
+  for (int i = 0; i < g_nwords; i++) if (g_len[i] <= 3) trie_add(g_word[i], g_len[i]);
+
+  // output order: seed words first
+  FILE *out = fopen(out_path, "w");
+  if (!out) { fprintf(stderr, "cannot open %s\n", out_path); return 1; }
+  for (int i = 0; i < g_nwords; i++) if (g_len[i] <= 3) fprintf(out, "%s\n", g_word[i]);
+
+  long selected = 0;
+  for (;;) {
+    memset(bonus, 0, (size_t)g_nwords * sizeof(int64_t));
+    // recompute bonus over current S
+    for (long pi = 0; pi < g_npos; pi++) {
+      Pos *p = &g_pos[pi];
+      int64_t baseline = p->baseline;
+      gen++;
+      // collect missing==1 candidates until first all-in-S move
+      uint32_t cw[64]; int32_t ceq[64]; int nc = 0;
+      for (int m = 0; m < p->mcount; m++) {
+        Mv *mv = &g_mv[p->mstart + m];
+        int missing = 0; uint32_t mw = 0;
+        for (int k = 0; k < mv->wcount; k++) {
+          uint32_t w = g_mvw[mv->wstart + k];
+          if (!in_S[w]) { missing++; mw = w; if (missing >= 2) break; }
+        }
+        if (missing == 0) { if (mv->equity > baseline) baseline = mv->equity; break; }
+        if (missing == 1 && nc < 64) { cw[nc] = mw; ceq[nc] = mv->equity; nc++; }
+      }
+      for (int k = 0; k < nc; k++) {
+        uint32_t w = cw[k];
+        if (stamp[w] == gen) continue; // first (highest) per word per position
+        stamp[w] = gen;
+        if (ceq[k] > baseline) bonus[w] += (int64_t)ceq[k] - baseline;
+      }
+    }
+    // Rank all positive-bonus 4+ candidates by bonus/cost (cost from the trie
+    // as it stands at the start of the batch), take the top `batch`.
+    static Cand *cand = NULL; static int cand_cap = 0;
+    int ncand = 0;
+    for (int w = 0; w < g_nwords; w++) {
+      if (g_len[w] < 4 || in_S[w] || bonus[w] <= 0) continue;
+      int cost = trie_cost(g_word[w], g_len[w]); if (cost < 1) cost = 1;
+      if (ncand == cand_cap) {
+        cand_cap = cand_cap ? cand_cap * 2 : (1 << 16);
+        cand = xrealloc(cand, (size_t)cand_cap * sizeof(Cand));
+      }
+      cand[ncand].ratio = (double)bonus[w] / cost;
+      cand[ncand].w = w;
+      ncand++;
+    }
+    if (ncand == 0) break; // converged: no value-adding words remain
+    qsort(cand, (size_t)ncand, sizeof(Cand), cand_cmp);
+    int take = ncand < batch ? ncand : batch;
+    for (int i = 0; i < take; i++) {
+      int w = cand[i].w;
+      in_S[w] = 1;
+      trie_add(g_word[w], g_len[w]);
+      fprintf(out, "%s\n", g_word[w]);
+      selected++;
+    }
+    fprintf(stderr, "selected %ld (+%d, %d candidates) ...\n", selected, take,
+            ncand);
+  }
+  fclose(out);
+  fprintf(stderr, "DONE selected %ld 4+ words\n", selected);
+  return 0;
+}

--- a/tools/offline_greedy.c
+++ b/tools/offline_greedy.c
@@ -22,6 +22,7 @@ static void *xmalloc(size_t n) {
   if (!p) { fprintf(stderr, "OOM %zu\n", n); exit(1); }
   return p;
 }
+
 static void *xrealloc(void *p, size_t n) {
   p = realloc(p, n);
   if (!p) { fprintf(stderr, "OOM %zu\n", n); exit(1); }
@@ -123,6 +124,7 @@ static int trie_new_node(void) {
   memset(g_trie[g_trie_nodes], 0, sizeof(g_trie[0])); // 0 = no child
   return g_trie_nodes++;
 }
+
 static void trie_add(const char *w, int L) {
   int node = 0;
   for (int i = 0; i < L; i++) {
@@ -132,6 +134,7 @@ static void trie_add(const char *w, int L) {
     node = g_trie[node][c];
   }
 }
+
 static int trie_cost(const char *w, int L) { // new nodes = L - shared prefix
   int node = 0, shared = 0;
   for (int i = 0; i < L; i++) {

--- a/tools/offline_greedy_README.md
+++ b/tools/offline_greedy_README.md
@@ -1,0 +1,47 @@
+# Wordlist subset selection for small lexica
+
+Greedily selects the highest-value subset of a lexicon that fits a target
+dictionary size, for small/embedded targets (retro engines, 2^17-edge formats,
+etc.). It maximizes *playing strength per byte* rather than capping by word
+length: it front-loads the cheap, high-value words (Q-without-U plays, bingo
+stems that share existing prefixes) and starves the low-value mid-length words.
+
+## Pipeline
+
+1. **Dump positions** (one autoplay pass; the expensive step, done once):
+
+   ```
+   magpie
+   set -lex CSW24 -k1 CSW24 -k2 CSW24 -threads N -gp false
+   playability <num_games> -smallkwg CSW24_2to3 -pbdump cache/pb
+   ```
+
+   This writes `cache/pb.<n>` (per worker) and `cache/pb.words`. Each position
+   record holds the seed baseline equity and the moves above it with their
+   formed-word ids. `-smallkwg` is the seed set whose baseline the bonus is
+   measured against (e.g. all 2- and 3-letter words).
+
+2. **Run the greedy** (offline, seconds; no re-simulation as the set grows):
+
+   ```
+   cc -O2 -o offline_greedy tools/offline_greedy.c
+   ./offline_greedy cache/pb.words <batch> order.txt cache/pb.*[0-9]
+   ```
+
+   `order.txt` is the selection order: the seed words, then the chosen 4+ letter
+   words in greedy (value-per-byte) order. The greedy recomputes each candidate's
+   marginal bonus over the current set from the cache (so the value signal can use
+   millions of games), divides by its prefix-sharing node cost, and stops when no
+   remaining word improves play.
+
+3. **Materialize at a byte budget**: take a prefix of `order.txt`, **sort it**
+   (the DAWG builder needs sorted input), and build the dictionary:
+
+   ```
+   sort <(head -N order.txt) > subset.txt   # placed under data/lexica/
+   magpie ; set -lex CSW24 ; convert text2acdawg subset
+   ```
+
+   Binary-search `N` for the acdawg size you want.
+
+The bonus metric and the `-pbdump` cache come from `src/impl/word_playability.c`.


### PR DESCRIPTION
Draft. Five focused commits aimed at small / retro / embedded targets.

## acdawg — arc-compressed DAWG
Bit-packed arc-compressed DAWG built from the reorder-merged DAWG. Each arc encodes as a popular-table index, a signed local gap, or an escape (~1.7 bytes/word for CSW24). `MIN_RAM` and `BALANCED` build modes trade escape rate (size) against traversal speed. Adds the `text2acdawg` / `text2acdawgbalanced` convert types, the `.acdawg` filepath type, and a decode/round-trip test (`dawgarccompressed`).

## clv — compact leaves
A few-KB parametric approximation of a KLV (per-tile + duplicate + vowel/consonant-count + synergy terms, quantized to a small radix) for targets that can't carry a full ~3.7 MB KLV. Ships the format reader/writer, the maker (`compact_leaves_create_from_klv`, target-size fitting, CSV weights, RMS eval), and a `klv2clv` convert command: `convert klv2clv <lex> -clvsize <bytes>` reads `<lex>.klv2` and fits a `.clv` under the byte budget (default 8192). Frequency-weighted fitting and radix selection remain available in the maker API for callers that need them.

## playability — per-word value metrics + position cache
New `playability <num_games>` autoplay command writing a sorted CSV of per-word metrics (all int64 millipoints, no floating point): play count (main word + hooks), removal penalty (equity lost if only that word were unknown), and addition bonus over a small seed set (`-smallkwg`). Adds a true-bingo counter and a `-pbdump` position cache (seed baseline + above-baseline moves with their formed-word ids). Includes the `playability` unit test.

## wordlist subset selection for small lexica
`tools/offline_greedy.c`: offline value-per-byte greedy over a `-pbdump` cache. Selects the strongest subset of a lexicon that fits a target dictionary size, front-loading high-value prefix-sharing words (Q-without-U, bingo stems) over length-capping. Recomputes marginal bonus per batch from the cache with no autoplay re-run, so the value signal can draw on millions of games. README documents the dump → greedy → sort+materialize pipeline.

On 1M game pairs, the value-per-byte subset reaches roughly full-CSW24 strength (~49.9% win) at ~256 KB / ~152K words, beating top-count, top-penalty, and length-capping selections at every budget.

## Notes
- Unrelated in-progress work (dawg_layered, dawg explorer, bench tooling) is deliberately excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LvFYMgVajp5e5U4m2rtaB
