### PR TITLE
Makefile: generate the header-dependency files it already -includes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,12 @@ ldflags.cov := -pthread
 
 CFLAGS := ${cflags.${BUILD}}
 
+# Emit a .d makefile fragment next to each .o listing the headers it includes
+# (-MMD) plus phony targets for those headers (-MP, so deleting a header does
+# not break the build). These fragments are -included at the bottom, so editing
+# a header recompiles exactly the .c files that include it -- no `make clean`.
+DEPFLAGS := -MMD -MP
+
 ifndef BOARD_DIM
 BOARD_DIM = 15
 endif
@@ -86,14 +92,14 @@ magpie_test: $(OBJ_SRC) $(OBJ_TEST) | $(BIN_DIR)
 	$(CC) $(LDFLAGS) $(LFLAGS) $^ $(LDLIBS) -o $(BIN_DIR)/$@
 
 $(OBJ_DIR)/$(SRC_DIR)/%.o: $(SRC_DIR)/%.c | $(OBJ_DIR) $(OBJ_DIR)/$(SRC_DIR) $(SRC_OBJ_SUBDIRS)
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) $(DEPFLAGS) -c $< -o $@
 
 $(OBJ_DIR)/$(CMD_DIR)/%.o: $(CMD_DIR)/%.c | $(OBJ_DIR) $(OBJ_DIR)/$(CMD_DIR)
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) $(DEPFLAGS) -c $< -o $@
 
 # Test files: use test_release flags if BUILD=release, otherwise use dev flags
 $(OBJ_DIR)/$(TEST_DIR)/%.o: $(TEST_DIR)/%.c | $(OBJ_DIR) $(OBJ_DIR)/$(TEST_DIR) $(TEST_OBJ_SUBDIRS)
-	$(CC) $(if $(filter release,$(BUILD)),${cflags.test_release},$(CFLAGS)) -DBOARD_DIM=$(BOARD_DIM) -DRACK_SIZE=$(RACK_SIZE) -c $< -o $@
+	$(CC) $(if $(filter release,$(BUILD)),${cflags.test_release},$(CFLAGS)) $(DEPFLAGS) -DBOARD_DIM=$(BOARD_DIM) -DRACK_SIZE=$(RACK_SIZE) -c $< -o $@
 
 $(BIN_DIR) $(OBJ_DIR) $(OBJ_DIR)/$(SRC_DIR) $(OBJ_DIR)/$(CMD_DIR) $(OBJ_DIR)/$(TEST_DIR) $(SRC_OBJ_SUBDIRS) $(TEST_OBJ_SUBDIRS):
 	mkdir -p $@

--- a/Makefile-wasm
+++ b/Makefile-wasm
@@ -41,6 +41,11 @@ lflags.test := -sNODERAWFS=1 \
 
 LDLIBS := -lm
 
+# Emit a .d makefile fragment next to each .o (header deps) so the -included
+# fragments below let a header edit recompile exactly its dependents -- no
+# `make clean`. -MP adds phony header targets so a deleted header won't error.
+DEPFLAGS := -MMD -MP
+
 .PHONY: all clean
 
 all: magpie_wasm
@@ -54,13 +59,13 @@ magpie_wasm_test: $(OBJ_SRC) $(OBJ_TEST) | $(TEST_BIN_DIR)
 	-sINITIAL_MEMORY=512MB
 
 $(OBJ_DIR)/$(SRC_DIR)/%.o: $(SRC_DIR)/%.c | $(OBJ_DIR) $(OBJ_DIR)/$(SRC_DIR) $(SRC_OBJ_SUBDIRS)
-	emcc $(cflags.release) -c $< -o $@
+	emcc $(cflags.release) $(DEPFLAGS) -c $< -o $@
 
 $(OBJ_DIR)/$(CMD_DIR)/%.o: $(CMD_DIR)/%.c | $(OBJ_DIR) $(OBJ_DIR)/$(CMD_DIR)
-	emcc $(cflags.release) -c $< -o $@
+	emcc $(cflags.release) $(DEPFLAGS) -c $< -o $@
 
 $(OBJ_DIR)/$(TEST_DIR)/%.o: $(TEST_DIR)/%.c | $(OBJ_DIR) $(OBJ_DIR)/$(TEST_DIR)
-	emcc $(cflags.release) -c $< -o $@
+	emcc $(cflags.release) $(DEPFLAGS) -c $< -o $@
 
 $(BIN_DIR) $(TEST_BIN_DIR) $(OBJ_DIR) $(OBJ_DIR)/$(SRC_DIR) $(OBJ_DIR)/$(CMD_DIR) $(OBJ_DIR)/$(TEST_DIR) $(SRC_OBJ_SUBDIRS):
 	mkdir -p $@


### PR DESCRIPTION
## Problem

Both `Makefile` and `Makefile-wasm` end with:

```make
-include $(OBJ_SRC:.o=.d)
-include $(OBJ_CMD:.o=.d)
-include $(OBJ_TEST:.o=.d)
```

…but the compile rules never passed `-MMD`, so those `.d` dependency fragments were **never generated**. The `-include` silently found nothing, so **editing a header did not recompile the `.c` files that include it**. The de-facto workaround was `make clean` after every header change.

## Fix

Add `-MMD -MP` to every compile rule (native `cc` and wasm `emcc`). Each object now emits a `.d` listing the headers it included; the existing `-include` picks them up; a header edit recompiles exactly its dependents.

`-MP` adds phony targets for the headers so deleting a header doesn't break the build.

## Verification (native)

```
make clean && make magpie          # generates 69 .d files
touch src/ent/dawg_arc_compressed.h && make magpie
  -> recompiles exactly: dawg_arc_compressed.c, convert.c   (the only includers)
touch src/ent/equity.h && make magpie
  -> recompiles every dependent across the tree
```

## Scope / limitation

This tracks **header** dependencies only. Changing a command-line `-D` flag (`BUILD=`, `BOARD_DIM=`, `RACK_SIZE=`) is invisible to make and **still requires `make clean`** — e.g. the existing `unit-tests-super` job already does `make clean` between `BOARD_DIM=15` and `21`, which remains correct. A per-flag object directory could remove that too, as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LvFYMgVajp5e5U4m2rtaB
