### PR TITLE
Web UI: browser analysis board over WASM

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -99,7 +99,7 @@ jobs:
           - shard: config
             tests: "config movegen gameplay players string alpha ld l leavemap kwg bag rack bitrack board layout cs move game vm shadow eq eqadj stats infer rv am"
           - shard: rest
-            tests: "hm math bai command gcg words wordprune kwgmaker cgp rl ch cv cd wmp wmpmaker wmg winpct zobrist tt load"
+            tests: "hm math bai command gcg words wordprune kwgmaker cgp jsonapi rl ch cv cd wmp wmpmaker wmg winpct zobrist tt load"
           - shard: ap_rit
             tests: "ap_rit"
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode
 bin
 obj
+obj-*
 cov
 covhtml
 *.gcda

--- a/Makefile-wasm
+++ b/Makefile-wasm
@@ -22,7 +22,8 @@ ldflags.release := -Llib -pthread
 lflags.shell := -s EXPORTED_RUNTIME_METHODS=["cwrap","stringToNewUTF8","UTF8ToString","PThread","HEAPU8"] \
 	-s EXPORTED_FUNCTIONS=_free,_main,_malloc,_precache_file_data,$\
 	_wasm_magpie_init,_wasm_magpie_destroy,_wasm_run_command,_wasm_run_command_async,$\
-	_wasm_get_output,_wasm_get_error,_wasm_get_status,_wasm_get_thread_status,_wasm_stop_command\
+	_wasm_get_output,_wasm_get_error,_wasm_get_status,_wasm_get_thread_status,_wasm_stop_command,$\
+	_wasm_get_state_json,_wasm_get_moves_json,_wasm_get_endgame_json\
 	-sPTHREAD_POOL_SIZE="navigator.hardwareConcurrency + 3" \
 	-sPTHREAD_POOL_SIZE_STRICT=0 \
 	-s ALLOW_BLOCKING_ON_MAIN_THREAD=1 \

--- a/src/impl/cmd_api.c
+++ b/src/impl/cmd_api.c
@@ -6,6 +6,7 @@
 #include "../util/string_util.h"
 #include "config.h"
 #include "exec.h"
+#include "json_api.h"
 #include <stdlib.h>
 
 struct Magpie {
@@ -53,6 +54,18 @@ char *magpie_get_last_command_status_message(Magpie *mp) {
 
 char *magpie_get_last_command_output(const Magpie *mp) {
   return string_duplicate(mp->output);
+}
+
+char *magpie_get_state_json(const Magpie *mp) {
+  return json_api_get_state(mp->config);
+}
+
+char *magpie_get_moves_json(const Magpie *mp) {
+  return json_api_get_moves(mp->config);
+}
+
+char *magpie_get_endgame_json(const Magpie *mp) {
+  return json_api_get_endgame(mp->config);
 }
 
 void magpie_stop_current_command(const Magpie *mp) {

--- a/src/impl/cmd_api.h
+++ b/src/impl/cmd_api.h
@@ -49,6 +49,12 @@ char *magpie_get_last_command_status_message(Magpie *mp);
 
 char *magpie_get_last_command_output(const Magpie *mp);
 
+// JSON views of the current state for UI consumers. Each returns a heap string
+// the caller must free (never NULL). See src/impl/json_api.h for the schema.
+char *magpie_get_state_json(const Magpie *mp);
+char *magpie_get_moves_json(const Magpie *mp);
+char *magpie_get_endgame_json(const Magpie *mp);
+
 void magpie_stop_current_command(const Magpie *mp);
 
 // Returns the current thread status as an int:

--- a/src/impl/json_api.c
+++ b/src/impl/json_api.c
@@ -1,0 +1,459 @@
+#include "json_api.h"
+
+#include "../def/board_defs.h"
+#include "../def/game_history_defs.h"
+#include "../def/letter_distribution_defs.h"
+#include "../def/players_data_defs.h"
+#include "../ent/bag.h"
+#include "../ent/board.h"
+#include "../ent/board_layout.h"
+#include "../ent/bonus_square.h"
+#include "../ent/endgame_results.h"
+#include "../ent/equity.h"
+#include "../ent/game.h"
+#include "../ent/letter_distribution.h"
+#include "../ent/move.h"
+#include "../ent/player.h"
+#include "../ent/players_data.h"
+#include "../ent/rack.h"
+#include "../ent/sim_results.h"
+#include "../ent/stats.h"
+#include "../str/move_string.h"
+#include "../str/rack_string.h"
+#include "../util/string_util.h"
+#include "cgp.h"
+#include "config.h"
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Upper bound on the number of moves serialized in one json_api_get_moves call.
+// Generate can produce thousands of plays; the UI only ever displays the top
+// handful, so capping keeps the payload small. "total" reports the true count.
+enum { JSON_MAX_MOVES = 300 };
+
+// Appends a JSON string literal (surrounding quotes plus escaping) for s.
+// A NULL s is emitted as an empty string "".
+static void json_add_escaped_string(StringBuilder *sb, const char *s) {
+  string_builder_add_char(sb, '"');
+  if (s) {
+    for (const char *p = s; *p; p++) {
+      const unsigned char c = (unsigned char)*p;
+      switch (c) {
+      case '"':
+        string_builder_add_string(sb, "\\\"");
+        break;
+      case '\\':
+        string_builder_add_string(sb, "\\\\");
+        break;
+      case '\n':
+        string_builder_add_string(sb, "\\n");
+        break;
+      case '\r':
+        string_builder_add_string(sb, "\\r");
+        break;
+      case '\t':
+        string_builder_add_string(sb, "\\t");
+        break;
+      default:
+        if (c < 0x20) {
+          string_builder_add_formatted_string(sb, "\\u%04x", (unsigned int)c);
+        } else {
+          string_builder_add_char(sb, (char)c);
+        }
+        break;
+      }
+    }
+  }
+  string_builder_add_char(sb, '"');
+}
+
+// Appends the user-visible display string for a machine letter as a JSON
+// string literal. Blanks render lowercase (handled by ld_ml_to_hl).
+static void json_add_tile_letter(StringBuilder *sb,
+                                 const LetterDistribution *ld,
+                                 MachineLetter ml) {
+  char *hl = ld_ml_to_hl(ld, ml);
+  json_add_escaped_string(sb, hl);
+  free(hl);
+}
+
+// Returns the premium-square code for a bonus square: one of
+// "tws"/"dws"/"qws"/"tls"/"dls"/"qls"/"brk", or "" for a plain square.
+static const char *json_bonus_code(BonusSquare bonus_square) {
+  if (bonus_square_is_brick(bonus_square)) {
+    return "brk";
+  }
+  const uint8_t word_mult = bonus_square_get_word_multiplier(bonus_square);
+  const uint8_t letter_mult = bonus_square_get_letter_multiplier(bonus_square);
+  if (word_mult == 3) {
+    return "tws";
+  }
+  if (word_mult == 2) {
+    return "dws";
+  }
+  if (word_mult == 4) {
+    return "qws";
+  }
+  if (letter_mult == 3) {
+    return "tls";
+  }
+  if (letter_mult == 2) {
+    return "dls";
+  }
+  if (letter_mult == 4) {
+    return "qls";
+  }
+  return "";
+}
+
+// Appends one board cell object: {"l":<letter or "">,"b":<bonus
+// code>[,"k":true]}.
+static void json_add_cell(StringBuilder *sb, const Board *board,
+                          const LetterDistribution *ld, int row, int col) {
+  // Read in natural (row, col) orientation without mutating the board: if it is
+  // transposed, swap the physical coordinates instead of toggling transpose
+  // (a getter must be side-effect-free and safe to call alongside the engine).
+  int read_row = row;
+  int read_col = col;
+  if (board_get_transposed(board)) {
+    read_row = col;
+    read_col = row;
+  }
+  const MachineLetter ml = board_get_letter(board, read_row, read_col);
+  const bool is_empty = (ml == ALPHABET_EMPTY_SQUARE_MARKER);
+  const BonusSquare bonus_square =
+      board_get_bonus_square(board, read_row, read_col);
+  string_builder_add_string(sb, "{\"l\":");
+  if (is_empty) {
+    string_builder_add_string(sb, "\"\"");
+  } else {
+    json_add_tile_letter(sb, ld, ml);
+  }
+  string_builder_add_formatted_string(sb, ",\"b\":\"%s\"",
+                                      json_bonus_code(bonus_square));
+  if (!is_empty && get_is_blanked(ml)) {
+    string_builder_add_string(sb, ",\"k\":true");
+  }
+  string_builder_add_char(sb, '}');
+}
+
+// Appends a player's rack tiles as a JSON array of {"l":<letter>,"k":<blank>}.
+static void json_add_rack_tiles(StringBuilder *sb, const Rack *rack,
+                                const LetterDistribution *ld) {
+  string_builder_add_char(sb, '[');
+  bool first = true;
+  const int dist_size = rack_get_dist_size(rack);
+  for (int ml = 1; ml < dist_size; ml++) {
+    const int count = rack_get_letter(rack, (MachineLetter)ml);
+    for (int copy = 0; copy < count; copy++) {
+      if (!first) {
+        string_builder_add_char(sb, ',');
+      }
+      first = false;
+      string_builder_add_string(sb, "{\"l\":");
+      json_add_tile_letter(sb, ld, (MachineLetter)ml);
+      string_builder_add_string(sb, ",\"k\":false}");
+    }
+  }
+  const int blanks = rack_get_letter(rack, BLANK_MACHINE_LETTER);
+  for (int copy = 0; copy < blanks; copy++) {
+    if (!first) {
+      string_builder_add_char(sb, ',');
+    }
+    first = false;
+    string_builder_add_string(sb, "{\"l\":");
+    json_add_tile_letter(sb, ld, BLANK_MACHINE_LETTER);
+    string_builder_add_string(sb, ",\"k\":true}");
+  }
+  string_builder_add_char(sb, ']');
+}
+
+// Appends the geometry fields shared by every move:
+//   "type":"play"|"exch"|"pass","desc":"...","row":N,"col":N,
+//   "vertical":bool,"placed":[{"row":N,"col":N,"l":"X"[,"k":true]}, ...]
+// "placed" holds only the tiles laid from the rack (played-through squares are
+// skipped). board may be NULL for moves with no placement (pass/exchange).
+static void json_add_move_geometry(StringBuilder *sb, const Board *board,
+                                   const LetterDistribution *ld,
+                                   const Move *move) {
+  const game_event_t type = move_get_type(move);
+  const char *type_str = "play";
+  if (type == GAME_EVENT_PASS) {
+    type_str = "pass";
+  } else if (type == GAME_EVENT_EXCHANGE) {
+    type_str = "exch";
+  }
+  string_builder_add_formatted_string(sb,
+                                      "\"type\":\"%s\",\"desc\":", type_str);
+  StringBuilder *desc_sb = string_builder_create();
+  string_builder_add_move_description(desc_sb, move, ld);
+  char *desc = string_builder_dump(desc_sb, NULL);
+  string_builder_destroy(desc_sb);
+  json_add_escaped_string(sb, desc);
+  free(desc);
+
+  const int row = move_get_row_start(move);
+  const int col = move_get_col_start(move);
+  const bool vertical = board_is_dir_vertical(move_get_dir(move));
+  string_builder_add_formatted_string(
+      sb, ",\"row\":%d,\"col\":%d,\"vertical\":%s,\"placed\":[", row, col,
+      vertical ? "true" : "false");
+  if (type == GAME_EVENT_TILE_PLACEMENT_MOVE && board) {
+    const int length = move_get_tiles_length(move);
+    int cur_row = row;
+    int cur_col = col;
+    bool first = true;
+    for (int tile_idx = 0; tile_idx < length; tile_idx++) {
+      const MachineLetter ml = move_get_tile(move, tile_idx);
+      if (ml != PLAYED_THROUGH_MARKER) {
+        if (!first) {
+          string_builder_add_char(sb, ',');
+        }
+        first = false;
+        string_builder_add_formatted_string(
+            sb, "{\"row\":%d,\"col\":%d,\"l\":", cur_row, cur_col);
+        json_add_tile_letter(sb, ld, ml);
+        if (get_is_blanked(ml)) {
+          string_builder_add_string(sb, ",\"k\":true");
+        }
+        string_builder_add_char(sb, '}');
+      }
+      if (vertical) {
+        cur_row++;
+      } else {
+        cur_col++;
+      }
+    }
+  }
+  string_builder_add_char(sb, ']');
+}
+
+char *json_api_get_state(const Config *config) {
+  StringBuilder *sb = string_builder_create();
+  const Game *game = config ? config_get_game(config) : NULL;
+  if (!game) {
+    string_builder_add_string(sb,
+                              "{\"ok\":false,\"error\":\"no game loaded\"}");
+    char *out = string_builder_dump(sb, NULL);
+    string_builder_destroy(sb);
+    return out;
+  }
+
+  // Read-only: json_add_cell handles a transposed board by swapping coordinates
+  // rather than mutating it, so this getter never writes shared game state.
+  const Board *board = game_get_board(game);
+  const LetterDistribution *ld = game_get_ld(game);
+
+  const BoardLayout *board_layout = config_get_board_layout(config);
+  const char *lexicon = players_data_get_data_name(
+      config_get_players_data(config), PLAYERS_DATA_TYPE_KWG, 0);
+
+  string_builder_add_formatted_string(
+      sb, "{\"ok\":true,\"dim\":%d,\"layout\":", BOARD_DIM);
+  json_add_escaped_string(sb, board_layout ? board_layout_get_name(board_layout)
+                                           : "");
+  string_builder_add_string(sb, ",\"lexicon\":");
+  json_add_escaped_string(sb, lexicon);
+  string_builder_add_string(sb, ",\"ld\":");
+  json_add_escaped_string(sb, ld_get_name(ld));
+  string_builder_add_formatted_string(sb, ",\"onTurn\":%d,\"bagCount\":%d",
+                                      game_get_player_on_turn_index(game),
+                                      bag_get_letters(game_get_bag(game)));
+  int center_row = BOARD_DIM / 2;
+  int center_col = BOARD_DIM / 2;
+  if (board_layout) {
+    center_row = board_layout_get_start_coord(board_layout, 0);
+    center_col = board_layout_get_start_coord(board_layout, 1);
+  }
+  string_builder_add_formatted_string(sb, ",\"center\":{\"row\":%d,\"col\":%d}",
+                                      center_row, center_col);
+
+  string_builder_add_string(sb, ",\"players\":[");
+  for (int player_idx = 0; player_idx < 2; player_idx++) {
+    const Player *player = game_get_player(game, player_idx);
+    const Rack *rack = player_get_rack(player);
+    if (player_idx) {
+      string_builder_add_char(sb, ',');
+    }
+    string_builder_add_formatted_string(
+        sb, "{\"score\":%d,\"rack\":", equity_to_int(player_get_score(player)));
+    StringBuilder *rack_sb = string_builder_create();
+    string_builder_add_rack(rack_sb, rack, ld, false);
+    char *rack_str = string_builder_dump(rack_sb, NULL);
+    string_builder_destroy(rack_sb);
+    json_add_escaped_string(sb, rack_str);
+    free(rack_str);
+    string_builder_add_string(sb, ",\"tiles\":");
+    json_add_rack_tiles(sb, rack, ld);
+    string_builder_add_char(sb, '}');
+  }
+  string_builder_add_char(sb, ']');
+
+  string_builder_add_string(sb, ",\"board\":[");
+  for (int row = 0; row < BOARD_DIM; row++) {
+    if (row) {
+      string_builder_add_char(sb, ',');
+    }
+    string_builder_add_char(sb, '[');
+    for (int col = 0; col < BOARD_DIM; col++) {
+      if (col) {
+        string_builder_add_char(sb, ',');
+      }
+      json_add_cell(sb, board, ld, row, col);
+    }
+    string_builder_add_char(sb, ']');
+  }
+  string_builder_add_char(sb, ']');
+
+  char *cgp = game_get_cgp(game, true);
+  string_builder_add_string(sb, ",\"cgp\":");
+  json_add_escaped_string(sb, cgp);
+  free(cgp);
+
+  string_builder_add_char(sb, '}');
+  char *out = string_builder_dump(sb, NULL);
+  string_builder_destroy(sb);
+  return out;
+}
+
+char *json_api_get_moves(const Config *config) {
+  StringBuilder *sb = string_builder_create();
+  const Game *game = config ? config_get_game(config) : NULL;
+  const MoveList *move_list = config ? config_get_move_list(config) : NULL;
+  const int total = move_list ? move_list_get_count(move_list) : 0;
+  if (!game || total == 0) {
+    string_builder_add_string(
+        sb, "{\"ok\":true,\"hasMoves\":false,\"hasSim\":false,\"moves\":[]}");
+    char *out = string_builder_dump(sb, NULL);
+    string_builder_destroy(sb);
+    return out;
+  }
+
+  const Board *board = game_get_board(game);
+  const LetterDistribution *ld = game_get_ld(game);
+  const Rack *gen_rack = move_list_get_rack(move_list);
+  const int emit_count = total < JSON_MAX_MOVES ? total : JSON_MAX_MOVES;
+
+  const SimResults *sim_results = config_get_sim_results(config);
+  const bool has_sim =
+      sim_results && sim_results_get_valid_for_current_game_state(sim_results);
+  double win_pct[JSON_MAX_MOVES];
+  double equity_mean[JSON_MAX_MOVES];
+  bool simmed[JSON_MAX_MOVES];
+  memset(simmed, 0, sizeof(simmed));
+  uint64_t iterations = 0;
+  if (has_sim) {
+    iterations = sim_results_get_iteration_count(sim_results);
+    const int num_plays = sim_results_get_number_of_plays(sim_results);
+    for (int play_idx = 0; play_idx < num_plays; play_idx++) {
+      const SimmedPlay *simmed_play =
+          sim_results_get_simmed_play(sim_results, play_idx);
+      const int move_idx = simmed_play_get_play_index_by_sort_type(simmed_play);
+      if (move_idx >= 0 && move_idx < emit_count) {
+        // win_pct_stat mean is a fraction in [0,1]; scale to a percentage to
+        // match the engine's own displays (analyze.c, sim_string.c).
+        win_pct[move_idx] =
+            stat_get_mean(simmed_play_get_win_pct_stat(simmed_play)) * 100.0;
+        equity_mean[move_idx] =
+            stat_get_mean(simmed_play_get_equity_stat(simmed_play));
+        simmed[move_idx] = true;
+      }
+    }
+  }
+
+  string_builder_add_formatted_string(
+      sb,
+      "{\"ok\":true,\"hasMoves\":true,\"hasSim\":%s,\"total\":%d,"
+      "\"iterations\":%llu,\"moves\":[",
+      has_sim ? "true" : "false", total, (unsigned long long)iterations);
+  for (int move_idx = 0; move_idx < emit_count; move_idx++) {
+    const Move *move = move_list_get_move(move_list, move_idx);
+    const game_event_t type = move_get_type(move);
+    if (move_idx) {
+      string_builder_add_char(sb, ',');
+    }
+    string_builder_add_formatted_string(sb, "{\"i\":%d,", move_idx);
+    json_add_move_geometry(sb, board, ld, move);
+    const int score =
+        (type == GAME_EVENT_PASS) ? 0 : equity_to_int(move_get_score(move));
+    string_builder_add_formatted_string(sb, ",\"score\":%d,\"equity\":", score);
+    if (type == GAME_EVENT_PASS) {
+      string_builder_add_string(sb, "null");
+    } else {
+      string_builder_add_formatted_string(
+          sb, "%.3f", equity_to_double(move_get_equity(move)));
+    }
+    string_builder_add_string(sb, ",\"leave\":");
+    if (gen_rack) {
+      StringBuilder *leave_sb = string_builder_create();
+      string_builder_add_move_leave(leave_sb, gen_rack, move, ld);
+      char *leave = string_builder_dump(leave_sb, NULL);
+      string_builder_destroy(leave_sb);
+      json_add_escaped_string(sb, leave);
+      free(leave);
+    } else {
+      string_builder_add_string(sb, "\"\"");
+    }
+    if (simmed[move_idx]) {
+      string_builder_add_formatted_string(sb, ",\"win\":%.4f,\"eqMean\":%.4f",
+                                          win_pct[move_idx],
+                                          equity_mean[move_idx]);
+    }
+    string_builder_add_char(sb, '}');
+  }
+  string_builder_add_string(sb, "]}");
+  char *out = string_builder_dump(sb, NULL);
+  string_builder_destroy(sb);
+  return out;
+}
+
+char *json_api_get_endgame(const Config *config) {
+  StringBuilder *sb = string_builder_create();
+  EndgameResults *endgame_results =
+      config ? config_get_endgame_results(config) : NULL;
+  const Game *game = config ? config_get_game(config) : NULL;
+  if (!game || !endgame_results ||
+      !endgame_results_get_valid_for_current_game_state(endgame_results)) {
+    string_builder_add_string(sb, "{\"ok\":true,\"valid\":false}");
+    char *out = string_builder_dump(sb, NULL);
+    string_builder_destroy(sb);
+    return out;
+  }
+
+  const LetterDistribution *ld = game_get_ld(game);
+  const int value =
+      endgame_results_get_value(endgame_results, ENDGAME_RESULT_BEST);
+  const int depth =
+      endgame_results_get_depth(endgame_results, ENDGAME_RESULT_BEST);
+  const double seconds = endgame_results_get_seconds_elapsed(endgame_results);
+  const int num_pvs = endgame_results_get_num_pvs(endgame_results);
+
+  string_builder_add_formatted_string(
+      sb,
+      "{\"ok\":true,\"valid\":true,\"value\":%d,\"depth\":%d,"
+      "\"seconds\":%.3f,\"numPvs\":%d,\"best\":",
+      value, depth, seconds, num_pvs);
+
+  endgame_results_lock(endgame_results, ENDGAME_RESULT_BEST);
+  const PVLine *pv_line =
+      endgame_results_get_pvline(endgame_results, ENDGAME_RESULT_BEST);
+  if (pv_line && pv_line->num_moves > 0) {
+    const Game *pv_game = pv_line->game ? pv_line->game : game;
+    const Board *board = game_get_board(pv_game);
+    Move best_move;
+    small_move_to_move(&best_move, &pv_line->moves[0], board);
+    string_builder_add_char(sb, '{');
+    json_add_move_geometry(sb, board, ld, &best_move);
+    string_builder_add_char(sb, '}');
+  } else {
+    string_builder_add_string(sb, "null");
+  }
+  endgame_results_unlock(endgame_results, ENDGAME_RESULT_BEST);
+
+  string_builder_add_char(sb, '}');
+  char *out = string_builder_dump(sb, NULL);
+  string_builder_destroy(sb);
+  return out;
+}

--- a/src/impl/json_api.h
+++ b/src/impl/json_api.h
@@ -1,0 +1,30 @@
+#ifndef JSON_API_H
+#define JSON_API_H
+
+#include "config.h"
+
+// JSON serialization of MAGPIE state for UI consumers (e.g. the WASM web UI).
+//
+// Every function returns a newly heap-allocated, NUL-terminated JSON string
+// that the caller must free(). None of them ever return NULL: when the
+// requested data is unavailable they return a small JSON object describing the
+// situation (e.g. {"ok":false,...} or {"ok":true,"hasMoves":false,...}).
+//
+// These are read-only views of the current Config state; run the relevant
+// command (cgp / generate / simulate / endgame) first to populate it.
+
+// Board grid, premium squares, player racks/scores, turn, bag, the active
+// lexicon / letter distribution / board layout, and the position's CGP string.
+char *json_api_get_state(const Config *config);
+
+// The most recently generated move list. When valid simulation results exist
+// for the current position, each simmed play also carries its win% and mean
+// equity. Moves are emitted in the order generate produced them (best first).
+char *json_api_get_moves(const Config *config);
+
+// A summary of the most recent endgame solve: value, depth, elapsed seconds,
+// principal-variation count, and the best move (with placed-tile geometry for
+// board highlighting). Full PV detail is available via the "shendgame" command.
+char *json_api_get_endgame(const Config *config);
+
+#endif

--- a/test/json_api_test.c
+++ b/test/json_api_test.c
@@ -1,0 +1,83 @@
+#include "json_api_test.h"
+
+#include "../src/impl/config.h"
+#include "../src/impl/json_api.h"
+#include "test_util.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void assert_json_contains(const char *json, const char *needle) {
+  if (!json || !strstr(json, needle)) {
+    (void)fprintf(stderr, "expected JSON to contain '%s' but it did not:\n%s\n",
+                  needle, json ? json : "(null)");
+    assert(0);
+  }
+}
+
+static void assert_json_absent(const char *json, const char *needle) {
+  if (json && strstr(json, needle)) {
+    (void)fprintf(stderr, "expected JSON to NOT contain '%s' but it did:\n%s\n",
+                  needle, json);
+    assert(0);
+  }
+}
+
+void test_json_api(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -s1 equity -s2 equity -r1 all -r2 all -numplays 30 -wmp "
+      "false");
+
+  // A board with HELLO across row 8 and a blank-played h at row 9, plus a rack.
+  load_and_exec_config_or_die(
+      config, "cgp 15/15/15/15/15/15/15/4HELLO6/4h10/15/15/15/15/15/15 "
+              "AEINRST/ 12/7 0");
+
+  // State view: structure, metadata, the on-board letters, premiums, the blank.
+  char *state = json_api_get_state(config);
+  assert_json_contains(state, "\"ok\":true");
+  assert_json_contains(state, "\"dim\":15");
+  assert_json_contains(state, "\"lexicon\":\"CSW21\"");
+  assert_json_contains(state, "\"center\":{\"row\":7,\"col\":7}");
+  assert_json_contains(state, "\"board\":[");
+  assert_json_contains(state, "\"players\":[");
+  assert_json_contains(state, "\"rack\":\"AEINRST\"");
+  assert_json_contains(state, "\"score\":12");
+  assert_json_contains(state, "\"cgp\":\"");
+  // A premium square code and the played blank flag must be present.
+  assert_json_contains(state, "\"b\":\"tws\"");
+  assert_json_contains(state, "\"k\":true");
+  // The blank h is lowercase; the real tiles are uppercase.
+  assert_json_contains(state, "\"l\":\"H\"");
+  assert_json_contains(state, "\"l\":\"h\"");
+  free(state);
+
+  // No moves generated yet.
+  char *no_moves = json_api_get_moves(config);
+  assert_json_contains(no_moves, "\"hasMoves\":false");
+  free(no_moves);
+
+  // No endgame solved yet.
+  char *no_endgame = json_api_get_endgame(config);
+  assert_json_contains(no_endgame, "\"valid\":false");
+  free(no_endgame);
+
+  // Generate and re-check: structured moves with geometry, score, equity,
+  // leave.
+  load_and_exec_config_or_die(config, "generate");
+  char *moves = json_api_get_moves(config);
+  assert_json_contains(moves, "\"hasMoves\":true");
+  assert_json_contains(moves, "\"hasSim\":false");
+  assert_json_contains(moves, "\"moves\":[{");
+  assert_json_contains(moves, "\"type\":\"play\"");
+  assert_json_contains(moves, "\"placed\":[");
+  assert_json_contains(moves, "\"score\":");
+  assert_json_contains(moves, "\"equity\":");
+  assert_json_contains(moves, "\"leave\":");
+  // Sim-only fields must not appear without a simulation.
+  assert_json_absent(moves, "\"win\":");
+  free(moves);
+
+  config_destroy(config);
+}

--- a/test/json_api_test.h
+++ b/test/json_api_test.h
@@ -1,0 +1,6 @@
+#ifndef JSON_API_TEST_H
+#define JSON_API_TEST_H
+
+void test_json_api(void);
+
+#endif

--- a/test/test.c
+++ b/test/test.c
@@ -31,6 +31,7 @@
 #include "heat_map_test.h"
 #include "infer_cmp_test.h"
 #include "infer_test.h"
+#include "json_api_test.h"
 #include "klv_test.h"
 #include "kwg_alpha_test.h"
 #include "kwg_maker_test.h"
@@ -117,6 +118,7 @@ static TestEntry test_table[] = {
     {"wordprune", test_word_prune},
     {"kwgmaker", test_kwg_maker},
     {"cgp", test_cgp},
+    {"jsonapi", test_json_api},
     {"rl", test_rack_list},
     {"ch", test_checkpoint},
     {"klv", test_klv},

--- a/wasmentry/api.c
+++ b/wasmentry/api.c
@@ -7,8 +7,6 @@
 #include <string.h>
 
 static Magpie *wasm_magpie = NULL;
-static pthread_t command_handler_thread;
-static bool command_handler_running = false;
 
 // Thread argument for async command execution
 typedef struct {
@@ -108,6 +106,29 @@ char *wasm_get_status(void) {
     return NULL;
   }
   return magpie_get_last_command_status_message(wasm_magpie);
+}
+
+// JSON state views for the web UI. Each returns a malloc'd string the JS side
+// reads with UTF8ToString then releases with _free.
+char *wasm_get_state_json(void) {
+  if (!wasm_magpie) {
+    return NULL;
+  }
+  return magpie_get_state_json(wasm_magpie);
+}
+
+char *wasm_get_moves_json(void) {
+  if (!wasm_magpie) {
+    return NULL;
+  }
+  return magpie_get_moves_json(wasm_magpie);
+}
+
+char *wasm_get_endgame_json(void) {
+  if (!wasm_magpie) {
+    return NULL;
+  }
+  return magpie_get_endgame_json(wasm_magpie);
 }
 
 // Returns 0=uninitialized, 1=started, 2=user_interrupt, 3=finished

--- a/wasmentry/tests/webui.test.js
+++ b/wasmentry/tests/webui.test.js
@@ -1,0 +1,127 @@
+import { test, expect } from "@playwright/test";
+
+// End-to-end smoke tests for the mouse-oriented analysis board (webui/).
+// Each test drives the full path: page -> worker -> WASM -> JSON exports -> UI.
+
+const MIDGAME_CGP =
+  "C14/O2TOY9/mIRADOR8/F4DAB2PUGH1/I5GOOEY3V/T4XI2MALTHA/14N/6GUM3OWN/7PEW2DOE/9EF1DOR/2KUNA1J1BEVELS/3TURRETs2S2/7A4T2/7N7/7S7 EEEIILZ/ 336/298 0 -lex NWL23";
+const ENDGAME_CGP =
+  "GATELEGs1POGOED/R4MOOLI3X1/AA10U2/YU4BREDRIN2/1TITULE3E1IN1/1E4N3c1BOK/1C2O4CHARD1/QI1FLAWN2E1OE1/IS2E1HIN1A1W2/1MOTIVATE1T1S2/1S2N5S4/3PERJURY5/15/15/15 FV/AADIZ 442/388 0 -lex CSW24";
+
+async function waitReady(page) {
+  const errors = [];
+  page.on("pageerror", (e) => errors.push(String(e)));
+  await page.goto("/webui/");
+  await expect(page.locator("#status")).toContainText("Ready", {
+    timeout: 60000,
+  });
+  await expect(page.locator("#board .cell")).toHaveCount(225);
+  return errors;
+}
+
+test.describe("MAGPIE web UI", () => {
+  test("loads, generates plays, previews and selects a move; fits the window", async ({
+    page,
+  }) => {
+    test.setTimeout(120000);
+    const errors = await waitReady(page);
+
+    // Everything fits in the viewport — no page scroll.
+    const overflow = await page.evaluate(
+      () =>
+        document.documentElement.scrollHeight -
+        document.documentElement.clientHeight,
+    );
+    expect(overflow).toBeLessThanOrEqual(2);
+
+    // Set the on-turn rack and generate.
+    await page.locator(".player-card.on-turn .rack-input").fill("AEINRST");
+    await page.click("#btn-generate");
+
+    await expect(page.locator("#moves-body tr td.play").first()).not.toHaveText(
+      "",
+      { timeout: 60000 },
+    );
+    expect(await page.locator("#moves-body tr").count()).toBeGreaterThan(5);
+    await expect(page.locator("#status")).toContainText("plays");
+
+    // Hover previews placed tiles (ghosts); clicking pins the highlight.
+    await page.locator("#moves-body tr").first().hover();
+    await expect(page.locator("#board .cell.ghost").first()).toBeVisible();
+    await page.locator("#moves-body tr").first().click();
+    await expect(page.locator("#board .cell.highlight").first()).toBeVisible();
+
+    expect(errors, errors.join("\n")).toEqual([]);
+  });
+
+  test("loads a CGP via the inline field", async ({ page }) => {
+    test.setTimeout(120000);
+    const errors = await waitReady(page);
+
+    await page.click("#btn-load-cgp");
+    await page.locator("#cgp-input").fill(MIDGAME_CGP);
+    await page.click("#cgp-load-btn");
+
+    // Lexicon switched, the on-turn rack and a board full of tiles loaded.
+    await expect(page.locator("#lexicon")).toHaveValue("NWL23", {
+      timeout: 60000,
+    });
+    await expect(page.locator(".player-card.on-turn .rack-input")).toHaveValue(
+      "EEEIILZ",
+    );
+    expect(await page.locator("#board .cell.tile").count()).toBeGreaterThan(20);
+
+    // Tiles show point values (Woogles-style subscripts).
+    expect(await page.locator("#board .cell.tile .pt").count()).toBeGreaterThan(
+      0,
+    );
+
+    expect(errors, errors.join("\n")).toEqual([]);
+  });
+
+  test("plays through a game (advances the position move by move)", async ({
+    page,
+  }) => {
+    test.setTimeout(120000);
+    const errors = await waitReady(page);
+
+    // Load an endgame position where both players have racks.
+    await page.click("#btn-load-cgp");
+    await page.locator("#cgp-input").fill(ENDGAME_CGP);
+    await page.click("#cgp-load-btn");
+    await expect(page.locator("#lexicon")).toHaveValue("CSW24", {
+      timeout: 60000,
+    });
+
+    const tileCount = () => page.locator("#board .cell.tile").count();
+    const before = await tileCount();
+
+    // Generate, then commit the top play.
+    await page.click("#btn-generate");
+    await expect(page.locator("#moves-body tr td.play").first()).not.toHaveText(
+      "",
+      { timeout: 60000 },
+    );
+    await page.locator('#moves-body .mini[data-act="play"]').first().click();
+
+    // The board gained the committed tiles and the play list cleared.
+    await expect
+      .poll(tileCount, { timeout: 60000 })
+      .toBeGreaterThan(before);
+    await expect(page.locator("#moves-body td.empty")).toBeVisible();
+
+    // Now the other player is on turn — generate and commit again.
+    const afterFirst = await tileCount();
+    await page.click("#btn-generate");
+    await expect(page.locator("#moves-body tr td.play").first()).not.toHaveText(
+      "",
+      { timeout: 60000 },
+    );
+    await page.locator('#moves-body .mini[data-act="play"]').first().click();
+    await expect
+      .poll(tileCount, { timeout: 60000 })
+      .toBeGreaterThan(afterFirst);
+
+    expect(errors, errors.join("\n")).toEqual([]);
+  });
+});

--- a/wasmentry/wasm-worker.js
+++ b/wasmentry/wasm-worker.js
@@ -12,6 +12,9 @@ let wasmGetError = null;
 let wasmGetStatus = null;
 let wasmGetThreadStatus = null;
 let wasmStop = null;
+let wasmGetStateJson = null;
+let wasmGetMovesJson = null;
+let wasmGetEndgameJson = null;
 
 let isInitialized = false;
 let isRunning = false;
@@ -54,7 +57,16 @@ let statusCheckInterval = null;
           postMessage({ type: 'log', text: 'WASM instantiating... (this is normal on mobile)' });
           return;
         }
-        postMessage({ type: 'error', text: text });
+        // Only treat genuinely fatal runtime output as an error. Benign
+        // Emscripten/pthread chatter on stderr (e.g. terminated-worker notices)
+        // must NOT be posted as 'error', or it would spuriously fail an
+        // in-flight command. True engine command failures are reported via the
+        // structured wasm_get_error channel, and fatal aborts kill the process.
+        if (/abort|RuntimeError|out of memory|Cannot enlarge memory|stack overflow|uncaught exception/i.test(text)) {
+          postMessage({ type: 'error', text: text });
+        } else {
+          postMessage({ type: 'log', text: text });
+        }
       },
       locateFile: (path, prefix) => {
         // Files are in the same directory as the worker
@@ -86,6 +98,9 @@ let statusCheckInterval = null;
     wasmGetStatus = Module.cwrap('wasm_get_status', 'number', []);
     wasmGetThreadStatus = Module.cwrap('wasm_get_thread_status', 'number', []);
     wasmStop = Module.cwrap('wasm_stop_command', null, []);
+    wasmGetStateJson = Module.cwrap('wasm_get_state_json', 'number', []);
+    wasmGetMovesJson = Module.cwrap('wasm_get_moves_json', 'number', []);
+    wasmGetEndgameJson = Module.cwrap('wasm_get_endgame_json', 'number', []);
 
     postMessage({ type: 'ready' });
     postMessage({ type: 'log', text: 'Worker ready!' });
@@ -112,7 +127,7 @@ onmessage = async (e) => {
         break;
 
       case 'run':
-        handleRun(data);
+        await handleRun(data);
         break;
 
       case 'stop':
@@ -123,11 +138,34 @@ onmessage = async (e) => {
         handleDestroy();
         break;
 
+      case 'getState':
+        handleGetJson(wasmGetStateJson, 'state', data && data.requestId);
+        break;
+
+      case 'getMoves':
+        handleGetJson(wasmGetMovesJson, 'moves', data && data.requestId);
+        break;
+
+      case 'getEndgame':
+        handleGetJson(wasmGetEndgameJson, 'endgame', data && data.requestId);
+        break;
+
       default:
         postMessage({ type: 'error', text: `Unknown message type: ${type}` });
     }
   } catch (error) {
-    postMessage({ type: 'error', text: `Error: ${error.message}` });
+    // For JSON getters, reply on their own channel (with the requestId) so the
+    // caller's promise settles instead of hanging; otherwise post a generic error.
+    const replyType = { getState: 'state', getMoves: 'moves', getEndgame: 'endgame' }[type];
+    if (replyType) {
+      postMessage({
+        type: replyType,
+        data: { ok: false, error: error.message },
+        requestId: data && data.requestId,
+      });
+    } else {
+      postMessage({ type: 'error', text: `Error: ${error.message}` });
+    }
   }
 };
 
@@ -201,6 +239,7 @@ async function handleRun({ commands }) {
 
   isRunning = true;
 
+  try {
   // Execute commands sequentially
   for (let i = 0; i < commands.length; i++) {
     const cmd = commands[i];
@@ -272,16 +311,47 @@ async function handleRun({ commands }) {
       Module._free(errorPtr);
       if (error && error.trim()) {
         postMessage({ type: 'error', text: `Command "${cmd}" failed: ${error}` });
-        isRunning = false;
         return;
       }
     }
   }
 
-  // Commands completed successfully
-  postMessage({ type: 'log', text: 'All commands completed' });
-  isRunning = false;
-  postMessage({ type: 'complete' });
+    // Commands completed successfully
+    postMessage({ type: 'log', text: 'All commands completed' });
+    postMessage({ type: 'complete' });
+  } catch (err) {
+    // A synchronous throw (e.g. OOM in stringToNewUTF8) must still post a
+    // terminal message and reset isRunning, or the UI would wedge forever.
+    postMessage({ type: 'error', text: `Command failed: ${err && err.message ? err.message : err}` });
+  } finally {
+    isRunning = false;
+  }
+}
+
+// Calls a JSON-returning WASM export, reads + frees the returned C string,
+// parses it, and posts the result back as { type, data, requestId }. Only call
+// this when no command is running so the read sees a stable game state.
+function handleGetJson(getter, type, requestId) {
+  if (!Module || !isInitialized) {
+    postMessage({ type, data: { ok: false, error: 'MAGPIE not initialized' }, requestId });
+    return;
+  }
+  if (!getter) {
+    postMessage({ type, data: { ok: false, error: 'getter unavailable' }, requestId });
+    return;
+  }
+  const ptr = getter();
+  let parsed = { ok: false, error: 'empty result' };
+  if (ptr) {
+    const json = Module.UTF8ToString(ptr);
+    Module._free(ptr);
+    try {
+      parsed = JSON.parse(json);
+    } catch (err) {
+      parsed = { ok: false, error: `JSON parse error: ${err.message}`, raw: json };
+    }
+  }
+  postMessage({ type, data: parsed, requestId });
 }
 
 function startStatusPolling() {

--- a/webui/README.md
+++ b/webui/README.md
@@ -1,0 +1,97 @@
+# MAGPIE Web UI — Analysis Board
+
+A mouse-oriented, browser-based analysis board for MAGPIE, running the engine
+entirely client-side via WebAssembly. Set up a position by clicking, then
+generate plays, run a Monte-Carlo simulation, solve the endgame, or run an
+inference — all locally in the browser.
+
+It is a sibling of the keyboard-driven notcurses TUI, translated to the mouse:
+click a square to place tiles, click moves to preview them on the board, sort
+the play list by clicking column headers.
+
+## Quick start
+
+```bash
+# 1. Build the WASM artifacts (writes wasmentry/magpie_wasm.{mjs,wasm}).
+#    Use a separate object dir so a native build's objects aren't clobbered.
+make -f Makefile-wasm OBJ_DIR=obj-wasm magpie_wasm
+
+# 2. Make sure the data files exist (lexica, leaves, winpct, layout).
+./download_data.sh        # only needed on a fresh clone
+
+# 3. Serve the repo root with the required COOP/COEP headers.
+python3 webui/serve.py    # then open http://localhost:8080/webui/
+```
+
+`SharedArrayBuffer` (and therefore the engine's threads) requires the
+`Cross-Origin-Opener-Policy: same-origin` and
+`Cross-Origin-Embedder-Policy: require-corp` headers; `serve.py` sends them.
+Any other static host works too as long as it sends those two headers.
+
+## Using it
+
+- **Place tiles:** click a board square to set the entry cursor, click it again
+  to flip between across/down, then click letters in the palette. Toggle
+  **Blank** for a designated blank (rendered lowercase). **⌫** removes the last
+  tile; right-clicking a square erases it. Typing on the keyboard works too.
+- **Racks:** click a rack to focus it, then use the palette (letters / **Blank**
+  for `?`), type directly, click a tile to remove it, or hit **Random**. Use
+  **swap to move** to analyze the other player.
+- **Analyze:** **Generate** lists plays; **Simulate** adds win% and mean equity;
+  **Endgame** solves and highlights the best move; **Infer** runs an inference.
+- **Plays:** hover a row to preview it on the board, click to pin the
+  highlight, click column headers to sort, **Play** to apply it and advance.
+- **Positions:** **Load** a built-in sample, **Copy CGP**, **Load CGP…** (an
+  inline field — paste and press Enter), **New** for an empty board.
+
+The look matches the MAGPIE TUI: amber wood tiles with point-value subscripts,
+the on-turn rack and selection highlights in green, blanks in red italic. The
+board auto-sizes so the whole UI fits the window without scrolling.
+
+## How it works
+
+The page drives the existing Web Worker (`wasmentry/wasm-worker.js`), which was
+extended with three JSON accessors exported from the engine:
+
+| Export                  | C entry point          | Returns                              |
+| ----------------------- | ---------------------- | ------------------------------------ |
+| `wasm_get_state_json`   | `json_api_get_state`   | board, premiums, racks, scores, CGP  |
+| `wasm_get_moves_json`   | `json_api_get_moves`   | generated plays (+ sim win%/equity)  |
+| `wasm_get_endgame_json` | `json_api_get_endgame` | endgame value/depth + best move      |
+
+The board, racks, and scores are edited in the browser; before each analysis the
+UI serializes them to a CGP string and syncs it into the engine, then reads the
+structured JSON back to render. See `src/impl/json_api.{c,h}` for the schema.
+
+## Embedding
+
+The directory is self-contained and iframe-friendly. To embed it in a docs site,
+serve `webui/` (with the engine artifacts and `data/`) under the COOP/COEP
+headers above and point an `<iframe>` at `index.html`. The hosting page must
+itself be cross-origin-isolated to embed a `require-corp` frame.
+
+## Tests
+
+Browser end-to-end tests live in `wasmentry/tests/webui.test.js` (Playwright)
+and cover loading + generating, loading a CGP via the inline field, and playing
+through a game. They reuse the existing Playwright config (which serves the repo
+root with COOP/COEP):
+
+```bash
+cd wasmentry
+npm install
+npx playwright install chromium
+npx playwright test tests/webui.test.js --project=chromium
+```
+
+## Notes / limitations
+
+- Ships the English lexica MAGPIE has data files for (CSW21/24, NWL20/23,
+  TWL06/14/98) on the standard 15x15 board. Other letter distributions/layouts
+  are future work.
+- **Play** advances the position locally (places the tiles, sets the mover's
+  rack to its leave, flips the turn) rather than committing through the engine:
+  the engine's `commit` command currently mis-validates plays that run through
+  existing tiles. Advancing locally is also a better fit for analysis — you
+  choose the next rack instead of a random draw.
+- Inference is exposed but minimal; it shows the engine's text output.

--- a/webui/app.js
+++ b/webui/app.js
@@ -1,0 +1,1013 @@
+// MAGPIE analysis board — mouse-oriented web UI over the WASM engine.
+//
+// Talks to the existing wasmentry/wasm-worker.js (extended with JSON getters).
+// The board/racks are edited client-side; before each analysis run we serialize
+// the position to a CGP string and sync it into the engine, then read structured
+// JSON back for rendering.
+
+import { Board, tilePoints } from './board.js';
+
+const WORKER_URL = '../wasmentry/wasm-worker.js';
+const DATA_ROOT = '/data';
+const RACK_SIZE = 7;
+
+// English lexica we ship the data files for. All map to the english letter
+// distribution and the standard 15x15 layout.
+const LEXICA = ['CSW21', 'CSW24', 'NWL23', 'NWL20', 'TWL14', 'TWL06', 'TWL98'];
+
+const SAMPLES = {
+  Midgame:
+    'C14/O2TOY9/mIRADOR8/F4DAB2PUGH1/I5GOOEY3V/T4XI2MALTHA/14N/6GUM3OWN/7PEW2DOE/9EF1DOR/2KUNA1J1BEVELS/3TURRETs2S2/7A4T2/7N7/7S7 EEEIILZ/ 336/298 0 -lex NWL23',
+  Endgame:
+    'GATELEGs1POGOED/R4MOOLI3X1/AA10U2/YU4BREDRIN2/1TITULE3E1IN1/1E4N3c1BOK/1C2O4CHARD1/QI1FLAWN2E1OE1/IS2E1HIN1A1W2/1MOTIVATE1T1S2/1S2N5S4/3PERJURY5/15/15/15 FV/AADIZ 442/388 0 -lex CSW24',
+};
+
+// ---------------------------------------------------------------------------
+// Worker bridge: a small promise-based RPC over postMessage.
+// ---------------------------------------------------------------------------
+class Bridge {
+  constructor(url, handlers) {
+    this.handlers = handlers || {};
+    this.worker = new Worker(url, { type: 'module' });
+    this._pending = null; // sequential op: { resolve, reject, expect, outputs }
+    this._jsonWaiters = new Map(); // requestId -> resolve
+    this._reqId = 0;
+    this.ready = new Promise((res) => {
+      this._resolveReady = res;
+    });
+    this.worker.onmessage = (e) => this._route(e.data);
+    this.worker.onerror = (err) => {
+      const text = err && (err.message || err.filename) ? `${err.message || ''} ${err.filename || ''}` : 'worker error';
+      if (this.handlers.onError) {
+        this.handlers.onError(text);
+      }
+      if (this._pending) {
+        const p = this._pending;
+        this._pending = null;
+        p.reject(new Error(text));
+      }
+      // Settle any outstanding JSON getters so their awaiters don't hang if the
+      // worker dies outright.
+      for (const [, resolve] of this._jsonWaiters) {
+        resolve({ ok: false, error: text });
+      }
+      this._jsonWaiters.clear();
+    };
+  }
+
+  _route(msg) {
+    const { type } = msg;
+    if (type === 'ready') {
+      this._resolveReady();
+      return;
+    }
+    if (type === 'log') {
+      if (this.handlers.onLog) {
+        this.handlers.onLog(msg.text);
+      }
+      return;
+    }
+    if (type === 'status') {
+      if (this.handlers.onStatus) {
+        this.handlers.onStatus(msg.text);
+      }
+      return;
+    }
+    if (type === 'output') {
+      if (this._pending) {
+        this._pending.outputs.push(msg.text);
+      }
+      if (this.handlers.onOutput) {
+        this.handlers.onOutput(msg.text);
+      }
+      return;
+    }
+    if (type === 'error') {
+      if (this.handlers.onError) {
+        this.handlers.onError(msg.text);
+      }
+      if (this._pending) {
+        const p = this._pending;
+        this._pending = null;
+        p.reject(new Error(msg.text));
+      }
+      return;
+    }
+    if (type === 'state' || type === 'moves' || type === 'endgame') {
+      const cb = this._jsonWaiters.get(msg.requestId);
+      if (cb) {
+        this._jsonWaiters.delete(msg.requestId);
+        cb(msg.data);
+      }
+      return;
+    }
+    if (this._pending && type === this._pending.expect) {
+      const p = this._pending;
+      this._pending = null;
+      p.resolve({ outputs: p.outputs });
+    }
+  }
+
+  _op(type, data, expect) {
+    return new Promise((resolve, reject) => {
+      this._pending = { resolve, reject, expect, outputs: [] };
+      this.worker.postMessage({ type, data });
+    });
+  }
+
+  init(dataPath) {
+    return this._op('init', { dataPath }, 'init_complete');
+  }
+
+  precache(filename, url) {
+    return this._op('precache', { filename, url }, 'precache_complete');
+  }
+
+  runCommands(commands) {
+    return this._op('run', { commands }, 'complete');
+  }
+
+  getJson(kind) {
+    const requestId = ++this._reqId;
+    const type = { getState: 'state', getMoves: 'moves', getEndgame: 'endgame' }[kind];
+    return new Promise((resolve) => {
+      this._jsonWaiters.set(requestId, resolve);
+      this.worker.postMessage({ type: kind, data: { requestId } });
+    });
+  }
+
+  stop() {
+    this.worker.postMessage({ type: 'stop' });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// App
+// ---------------------------------------------------------------------------
+const $ = (id) => document.getElementById(id);
+
+const state = {
+  lexicon: 'CSW21',
+  onTurn: 0,
+  players: [
+    { rack: '', score: 0 },
+    { rack: '', score: 0 },
+  ],
+  bagCount: 0,
+  cgp: '',
+  moves: [],
+  selectedMove: null,
+  sortKey: 'equity',
+  sortDir: -1,
+  hasSim: false,
+  blankMode: false,
+  focus: { kind: 'board' },
+  busy: false,
+};
+
+const precached = new Set();
+let board = null;
+let bridge = null;
+let threads = Math.min(Math.max(navigator.hardwareConcurrency || 4, 1), 16);
+
+function setStatus(text, kind = '') {
+  const el = $('status');
+  el.textContent = text;
+  el.className = 'status' + (kind ? ' ' + kind : '');
+}
+
+function logLine(text) {
+  const el = $('results');
+  el.textContent += text + '\n';
+  el.scrollTop = el.scrollHeight;
+}
+
+function clearResults() {
+  $('results').textContent = '';
+}
+
+function setBusy(busy) {
+  state.busy = busy;
+  document.querySelectorAll('button[data-act]').forEach((b) => {
+    b.disabled = busy;
+  });
+  if (board) {
+    board.setEditable(!busy);
+  }
+  $('stop').disabled = !busy;
+}
+
+// --- CGP serialization -----------------------------------------------------
+function buildCgp() {
+  const boardStr = board.cgpBoard();
+  const on = state.onTurn;
+  const off = 1 - on;
+  const rackOn = state.players[on].rack || '';
+  const rackOff = state.players[off].rack || '';
+  const scoreOn = state.players[on].score | 0;
+  const scoreOff = state.players[off].score | 0;
+  return `${boardStr} ${rackOn}/${rackOff} ${scoreOn}/${scoreOff} 0`;
+}
+
+// --- Lexicon / data files --------------------------------------------------
+function lexFiles(lex) {
+  return [
+    `data/lexica/${lex}.kwg`,
+    `data/lexica/${lex}.klv2`,
+    'data/letterdistributions/english.csv',
+    'data/strategy/winpct.csv',
+    'data/layouts/standard15.txt',
+  ];
+}
+
+async function ensureLexicon(lex) {
+  for (const filename of lexFiles(lex)) {
+    if (precached.has(filename)) {
+      continue;
+    }
+    await bridge.precache(filename, `${DATA_ROOT}/${filename.slice('data/'.length)}`);
+    precached.add(filename);
+  }
+}
+
+// --- Apply engine state to the UI ------------------------------------------
+function applyState(data) {
+  if (!data || data.ok === false) {
+    setStatus('Engine state unavailable' + (data && data.error ? `: ${data.error}` : ''), 'error');
+    return;
+  }
+  board.load(data);
+  if (Array.isArray(data.players) && data.players.length === 2) {
+    state.players = data.players.map((p) => ({ rack: p.rack || '', score: p.score | 0, tiles: p.tiles || [] }));
+  }
+  if (typeof data.onTurn === 'number') {
+    state.onTurn = data.onTurn;
+  }
+  if (typeof data.bagCount === 'number') {
+    state.bagCount = data.bagCount;
+  }
+  if (data.cgp) {
+    state.cgp = data.cgp;
+  }
+  if (data.lexicon) {
+    state.lexicon = data.lexicon;
+    const sel = $('lexicon');
+    if (sel.value !== data.lexicon && LEXICA.includes(data.lexicon)) {
+      sel.value = data.lexicon;
+    }
+  }
+  renderPlayers();
+  renderMeta();
+}
+
+function applyMoves(data) {
+  if (!data || data.ok === false) {
+    state.moves = [];
+    state.hasSim = false;
+    renderMoves();
+    return;
+  }
+  state.moves = data.hasMoves ? data.moves : [];
+  state.hasSim = !!data.hasSim;
+  state.selectedMove = null;
+  board.setHighlight(null);
+  board.setPreview(null);
+  if (state.hasSim) {
+    state.sortKey = 'win';
+  } else {
+    state.sortKey = 'equity';
+  }
+  state.sortDir = -1;
+  renderMoves();
+  const sub = data.hasSim ? ` · sim ${formatInt(data.iterations)} iters` : '';
+  setStatus(`${data.total || state.moves.length} plays${sub}`, 'success');
+}
+
+// Clears the play list and any board preview/highlight. Called after committing
+// a move and whenever the board or a rack is edited (which makes the engine's
+// generated move list — and thus a pending Play — stale).
+function clearPlays() {
+  if (state.moves.length === 0 && !state.selectedMove) {
+    return;
+  }
+  state.moves = [];
+  state.hasSim = false;
+  state.selectedMove = null;
+  board.setPreview(null);
+  board.setHighlight(null);
+  renderMoves();
+}
+
+// --- Rendering: players, meta ----------------------------------------------
+function renderPlayers() {
+  const container = $('players');
+  container.innerHTML = '';
+  // On-turn card first.
+  const order = [state.onTurn, 1 - state.onTurn];
+  for (const idx of order) {
+    const player = state.players[idx];
+    const card = document.createElement('div');
+    card.className = 'player-card' + (idx === state.onTurn ? ' on-turn' : '');
+
+    const head = document.createElement('div');
+    head.className = 'player-head';
+    const label = document.createElement('span');
+    label.className = 'player-label';
+    label.textContent = idx === state.onTurn ? '● To move' : 'Opponent';
+    head.appendChild(label);
+
+    const scoreWrap = document.createElement('label');
+    scoreWrap.className = 'score';
+    scoreWrap.textContent = 'Score ';
+    const scoreInput = document.createElement('input');
+    scoreInput.type = 'number';
+    scoreInput.value = String(player.score | 0);
+    scoreInput.addEventListener('change', () => {
+      player.score = parseInt(scoreInput.value, 10) || 0;
+    });
+    scoreWrap.appendChild(scoreInput);
+    head.appendChild(scoreWrap);
+    card.appendChild(head);
+
+    const rackRow = document.createElement('div');
+    rackRow.className = 'rack' + (state.focus.kind === 'rack' && state.focus.index === idx ? ' focused' : '');
+    rackRow.title = 'Click to focus, then use the tile palette. Click a tile to remove it.';
+    rackRow.addEventListener('click', (e) => {
+      if (e.target === rackRow || e.target.classList.contains('rack-empty')) {
+        focusRack(idx);
+      }
+    });
+    const tiles = parseRackTiles(player.rack);
+    if (tiles.length === 0) {
+      const empty = document.createElement('span');
+      empty.className = 'rack-empty';
+      empty.textContent = 'empty rack — click to edit';
+      rackRow.appendChild(empty);
+    } else {
+      tiles.forEach((t, ti) => {
+        const tEl = document.createElement('span');
+        tEl.className = 'tile-face' + (t === '?' ? ' blank' : '');
+        tEl.textContent = t;
+        tEl.title = 'Remove';
+        const points = tilePoints(t, t === '?');
+        if (points != null && points > 0) {
+          const pt = document.createElement('span');
+          pt.className = 'pt';
+          pt.textContent = String(points);
+          tEl.appendChild(pt);
+        }
+        tEl.addEventListener('click', () => {
+          const arr = parseRackTiles(player.rack);
+          arr.splice(ti, 1);
+          player.rack = arr.join('');
+          clearPlays();
+          renderPlayers();
+        });
+        rackRow.appendChild(tEl);
+      });
+    }
+    card.appendChild(rackRow);
+
+    const tools = document.createElement('div');
+    tools.className = 'rack-tools';
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'rack-input';
+    input.placeholder = 'type rack (use ? for blank)';
+    input.value = player.rack;
+    input.maxLength = RACK_SIZE;
+    input.addEventListener('input', () => {
+      player.rack = input.value.toUpperCase().replace(/[^A-Z?]/g, '').slice(0, RACK_SIZE);
+      input.value = player.rack;
+      clearPlays();
+    });
+    input.addEventListener('change', () => renderPlayers());
+    tools.appendChild(input);
+
+    const focusBtn = document.createElement('button');
+    focusBtn.type = 'button';
+    focusBtn.className = 'mini';
+    focusBtn.textContent = 'Palette';
+    focusBtn.addEventListener('click', () => focusRack(idx));
+    tools.appendChild(focusBtn);
+
+    if (idx === state.onTurn) {
+      const randomBtn = document.createElement('button');
+      randomBtn.type = 'button';
+      randomBtn.className = 'mini';
+      randomBtn.dataset.act = 'random';
+      randomBtn.textContent = 'Random';
+      randomBtn.addEventListener('click', () => randomRack());
+      tools.appendChild(randomBtn);
+    }
+
+    const swapBtn = document.createElement('button');
+    swapBtn.type = 'button';
+    swapBtn.className = 'mini';
+    swapBtn.textContent = idx === state.onTurn ? '↕ swap to move' : 'make to move';
+    swapBtn.addEventListener('click', () => {
+      state.onTurn = 1 - state.onTurn;
+      renderPlayers();
+    });
+    tools.appendChild(swapBtn);
+
+    card.appendChild(tools);
+    container.appendChild(card);
+  }
+}
+
+function renderMeta() {
+  $('meta').textContent = `${state.lexicon} · bag ${state.bagCount}`;
+}
+
+function parseRackTiles(rack) {
+  return (rack || '').split('');
+}
+
+function focusRack(idx) {
+  state.focus = { kind: 'rack', index: idx };
+  board.clearCursor();
+  renderPlayers();
+  updatePaletteHint();
+}
+
+// --- Move list -------------------------------------------------------------
+function sortedMoves() {
+  const moves = state.moves.slice();
+  const key = state.sortKey;
+  const dir = state.sortDir;
+  moves.sort((a, b) => {
+    let av;
+    let bv;
+    if (key === 'win') {
+      av = a.win == null ? -Infinity : a.win;
+      bv = b.win == null ? -Infinity : b.win;
+    } else if (key === 'score') {
+      av = a.score;
+      bv = b.score;
+    } else if (key === 'equity') {
+      const ae = state.hasSim && a.eqMean != null ? a.eqMean : a.equity;
+      const be = state.hasSim && b.eqMean != null ? b.eqMean : b.equity;
+      av = ae == null ? -Infinity : ae;
+      bv = be == null ? -Infinity : be;
+    } else {
+      av = a.i;
+      bv = b.i;
+    }
+    if (av < bv) {
+      return -dir;
+    }
+    if (av > bv) {
+      return dir;
+    }
+    return a.i - b.i;
+  });
+  return moves;
+}
+
+function renderMoves() {
+  const tbody = $('moves-body');
+  tbody.innerHTML = '';
+  const head = $('moves-head');
+  head.querySelector('[data-col="win"]').style.display = state.hasSim ? '' : 'none';
+  const moves = sortedMoves();
+  if (moves.length === 0) {
+    const tr = document.createElement('tr');
+    const td = document.createElement('td');
+    td.colSpan = 6;
+    td.className = 'empty';
+    td.textContent = 'No plays yet — set a rack and click Generate or Simulate.';
+    tr.appendChild(td);
+    tbody.appendChild(tr);
+    return;
+  }
+  for (const move of moves) {
+    const tr = document.createElement('tr');
+    if (state.selectedMove && state.selectedMove.i === move.i) {
+      tr.className = 'selected';
+    }
+    tr.appendChild(td(move.desc, 'play'));
+    tr.appendChild(td(String(move.score), 'num'));
+    // After a sim, prefer the simmed mean equity; otherwise the static equity.
+    const eq = state.hasSim && move.eqMean != null ? move.eqMean : move.equity;
+    tr.appendChild(td(eq == null ? '—' : eq.toFixed(1), 'num'));
+    const winTd = td(move.win == null ? '—' : move.win.toFixed(1), 'num');
+    winTd.style.display = state.hasSim ? '' : 'none';
+    tr.appendChild(winTd);
+    tr.appendChild(td(move.leave || '', 'leave'));
+    const playTd = document.createElement('td');
+    const playBtn = document.createElement('button');
+    playBtn.type = 'button';
+    playBtn.className = 'mini';
+    playBtn.dataset.act = 'play';
+    playBtn.textContent = 'Play';
+    playBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      playMove(move);
+    });
+    playTd.appendChild(playBtn);
+    tr.appendChild(playTd);
+
+    tr.addEventListener('mouseenter', () => board.setPreview(move.placed));
+    tr.addEventListener('mouseleave', () => board.setPreview(state.selectedMove ? state.selectedMove.placed : null));
+    tr.addEventListener('click', () => selectMove(move));
+    tbody.appendChild(tr);
+  }
+}
+
+function td(text, cls) {
+  const cell = document.createElement('td');
+  cell.textContent = text;
+  if (cls) {
+    cell.className = cls;
+  }
+  return cell;
+}
+
+function selectMove(move) {
+  state.selectedMove = move;
+  board.setHighlight(move.placed);
+  board.setPreview(move.placed);
+  renderMoves();
+}
+
+// --- Palette ---------------------------------------------------------------
+function buildPalette() {
+  const palette = $('palette');
+  palette.innerHTML = '';
+  const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+  for (const letter of letters) {
+    const b = document.createElement('button');
+    b.type = 'button';
+    b.className = 'pal';
+    b.textContent = letter;
+    b.addEventListener('click', () => paletteKey(letter));
+    palette.appendChild(b);
+  }
+  const blank = document.createElement('button');
+  blank.type = 'button';
+  blank.className = 'pal pal-blank';
+  blank.id = 'pal-blank';
+  blank.textContent = 'Blank';
+  blank.addEventListener('click', () => paletteBlank());
+  palette.appendChild(blank);
+
+  const back = document.createElement('button');
+  back.type = 'button';
+  back.className = 'pal pal-wide';
+  back.textContent = '⌫';
+  back.title = 'Backspace';
+  back.addEventListener('click', () => paletteBackspace());
+  palette.appendChild(back);
+
+  const clear = document.createElement('button');
+  clear.type = 'button';
+  clear.className = 'pal pal-wide';
+  clear.textContent = 'Clear';
+  clear.title = 'Clear board / rack';
+  clear.addEventListener('click', () => paletteClear());
+  palette.appendChild(clear);
+
+  updatePaletteHint();
+}
+
+function updatePaletteHint() {
+  const hint = $('palette-hint');
+  const blankBtn = $('pal-blank');
+  if (state.focus.kind === 'rack') {
+    hint.textContent = `Editing ${state.focus.index === state.onTurn ? 'to-move' : 'opponent'} rack — letters add tiles, Blank adds "?".`;
+    if (blankBtn) {
+      blankBtn.classList.remove('active');
+    }
+  } else {
+    hint.textContent = board.cursor
+      ? `Placing at ${cellName(board.cursor)} (${board.cursor.dir === 'h' ? 'across' : 'down'}) — click the square again to flip direction.`
+      : 'Click a board square to start placing tiles.';
+    if (blankBtn) {
+      blankBtn.classList.toggle('active', state.blankMode);
+    }
+  }
+}
+
+function cellName(cur) {
+  return 'ABCDEFGHIJKLMNOPQRSTUVWXY'[cur.col] + (cur.row + 1);
+}
+
+function paletteKey(letter) {
+  if (state.busy) {
+    return;
+  }
+  if (state.focus.kind === 'rack') {
+    const player = state.players[state.focus.index];
+    if (parseRackTiles(player.rack).length < RACK_SIZE) {
+      player.rack = (player.rack + letter).toUpperCase();
+      clearPlays();
+      renderPlayers();
+    }
+    return;
+  }
+  if (!board.cursor) {
+    setStatus('Click a board square first to place tiles.', '');
+    return;
+  }
+  board.placeLetter(letter, state.blankMode);
+  if (state.blankMode) {
+    state.blankMode = false;
+  }
+  updatePaletteHint();
+}
+
+function paletteBlank() {
+  if (state.busy) {
+    return;
+  }
+  if (state.focus.kind === 'rack') {
+    const player = state.players[state.focus.index];
+    if (parseRackTiles(player.rack).length < RACK_SIZE) {
+      player.rack = player.rack + '?';
+      clearPlays();
+      renderPlayers();
+    }
+    return;
+  }
+  state.blankMode = !state.blankMode;
+  updatePaletteHint();
+}
+
+function paletteBackspace() {
+  if (state.busy) {
+    return;
+  }
+  if (state.focus.kind === 'rack') {
+    const player = state.players[state.focus.index];
+    const arr = parseRackTiles(player.rack);
+    arr.pop();
+    player.rack = arr.join('');
+    clearPlays();
+    renderPlayers();
+    return;
+  }
+  board.backspace();
+}
+
+function paletteClear() {
+  if (state.busy) {
+    return;
+  }
+  if (state.focus.kind === 'rack') {
+    state.players[state.focus.index].rack = '';
+    clearPlays();
+    renderPlayers();
+    return;
+  }
+  board.clearBoard();
+}
+
+// --- Keyboard (bonus; mouse is primary) ------------------------------------
+function onKeydown(e) {
+  if (e.target.tagName === 'INPUT' || e.target.tagName === 'SELECT' || e.target.tagName === 'TEXTAREA') {
+    return;
+  }
+  if (state.busy) {
+    return;
+  }
+  if (state.focus.kind !== 'board' || !board.cursor) {
+    return;
+  }
+  if (/^[a-zA-Z]$/.test(e.key)) {
+    board.placeLetter(e.key.toUpperCase(), e.shiftKey || state.blankMode);
+    state.blankMode = false;
+    updatePaletteHint();
+    e.preventDefault();
+  } else if (e.key === 'Backspace') {
+    board.backspace();
+    e.preventDefault();
+  } else if (e.key === ' ') {
+    board.setCursor(board.cursor.row, board.cursor.col, board.cursor.dir === 'h' ? 'v' : 'h');
+    updatePaletteHint();
+    e.preventDefault();
+  } else if (e.key === 'Escape') {
+    board.clearCursor();
+    updatePaletteHint();
+  } else if (e.key.startsWith('Arrow')) {
+    const cur = board.cursor;
+    let { row, col } = cur;
+    if (e.key === 'ArrowUp') {
+      row = Math.max(0, row - 1);
+    } else if (e.key === 'ArrowDown') {
+      row = Math.min(board.dim - 1, row + 1);
+    } else if (e.key === 'ArrowLeft') {
+      col = Math.max(0, col - 1);
+    } else if (e.key === 'ArrowRight') {
+      col = Math.min(board.dim - 1, col + 1);
+    }
+    board.setCursor(row, col, cur.dir);
+    updatePaletteHint();
+    e.preventDefault();
+  }
+}
+
+// --- Engine actions --------------------------------------------------------
+async function syncPosition() {
+  await ensureLexicon(state.lexicon);
+  const cgp = buildCgp();
+  const res = await bridge.runCommands([`set -lex ${state.lexicon}`, `cgp ${cgp}`]);
+  return res;
+}
+
+async function withBusy(label, fn) {
+  if (state.busy) {
+    return;
+  }
+  setBusy(true);
+  setStatus(label + '…');
+  try {
+    await fn();
+  } catch (err) {
+    setStatus(`${label} failed: ${err.message}`, 'error');
+    logLine(`❌ ${err.message}`);
+  } finally {
+    setBusy(false);
+  }
+}
+
+function generate() {
+  return withBusy('Generating', async () => {
+    await ensureLexicon(state.lexicon);
+    const cgp = buildCgp();
+    await bridge.runCommands([`set -lex ${state.lexicon}`, `cgp ${cgp}`, 'generate']);
+    applyState(await bridge.getJson('getState'));
+    applyMoves(await bridge.getJson('getMoves'));
+  });
+}
+
+function simulate() {
+  return withBusy('Simulating', async () => {
+    await ensureLexicon(state.lexicon);
+    const cgp = buildCgp();
+    const plies = parseInt($('opt-plies').value, 10) || 2;
+    const tlim = parseInt($('opt-tlim').value, 10) || 5;
+    await bridge.runCommands([
+      `set -lex ${state.lexicon} -plies ${plies}`,
+      `cgp ${cgp}`,
+      'generate',
+      `simulate -threads ${threads} -tlim ${tlim}`,
+    ]);
+    applyState(await bridge.getJson('getState'));
+    applyMoves(await bridge.getJson('getMoves'));
+  });
+}
+
+function endgame() {
+  return withBusy('Solving endgame', async () => {
+    await ensureLexicon(state.lexicon);
+    const cgp = buildCgp();
+    const eplies = parseInt($('opt-eplies').value, 10) || 5;
+    clearResults();
+    const res = await bridge.runCommands([
+      `set -lex ${state.lexicon} -eplies ${eplies} -ttfraction 0.25`,
+      `cgp ${cgp}`,
+      'endgame',
+      'shendgame',
+    ]);
+    applyState(await bridge.getJson('getState'));
+    const eg = await bridge.getJson('getEndgame');
+    if (eg && eg.valid) {
+      if (eg.best) {
+        board.setHighlight(eg.best.placed);
+      }
+      setStatus(`Endgame: ${eg.value >= 0 ? '+' : ''}${eg.value} (depth ${eg.depth}, ${eg.seconds.toFixed(1)}s)`, 'success');
+    } else {
+      setStatus('Endgame produced no result', '');
+    }
+    (res.outputs || []).forEach((o) => logLine(o));
+  });
+}
+
+function infer() {
+  return withBusy('Inferring', async () => {
+    await ensureLexicon(state.lexicon);
+    const cgp = buildCgp();
+    clearResults();
+    const res = await bridge.runCommands([`set -lex ${state.lexicon}`, `cgp ${cgp}`, 'infer', 'shinference']);
+    applyState(await bridge.getJson('getState'));
+    (res.outputs || []).forEach((o) => logLine(o));
+    setStatus('Inference complete', 'success');
+  });
+}
+
+// Resets to an empty board with empty racks. Used for both startup and the
+// "New game" button. (The `newgame` command needs a GCG filename when the
+// fgrequired option is on, so an empty CGP is the reliable reset for analysis.)
+async function loadEmptyPosition() {
+  await ensureLexicon(state.lexicon);
+  board.clearBoard();
+  await bridge.runCommands([
+    `set -lex ${state.lexicon}`,
+    `cgp ${board.cgpBoard()} / 0/0 0`,
+  ]);
+  applyState(await bridge.getJson('getState'));
+  clearPlays();
+}
+
+function newGame() {
+  return withBusy('New game', loadEmptyPosition);
+}
+
+function playMove(move) {
+  // Advance the position client-side: place the move's tiles, set the mover's
+  // rack to its leave, add the score, and flip the turn — then re-sync the
+  // engine via CGP. (We deliberately do not auto-draw: in analysis you control
+  // the next rack. The engine's commit command also mis-validates plays that
+  // run through existing tiles, so applying locally is both correct and apt.)
+  const mover = state.onTurn;
+  if (move.type === 'play') {
+    board.applyPlaced(move.placed);
+  }
+  if (move.type !== 'pass' && typeof move.score === 'number') {
+    state.players[mover].score = (state.players[mover].score | 0) + move.score;
+  }
+  state.players[mover].rack = (move.leave || '').toUpperCase();
+  state.onTurn = 1 - mover;
+  clearPlays();
+  renderPlayers();
+  return withBusy(`Played ${move.desc}`, async () => {
+    await ensureLexicon(state.lexicon);
+    const cgp = buildCgp();
+    await bridge.runCommands([`set -lex ${state.lexicon}`, `cgp ${cgp}`]);
+    applyState(await bridge.getJson('getState'));
+  });
+}
+
+function randomRack() {
+  return withBusy('Random rack', async () => {
+    await ensureLexicon(state.lexicon);
+    const cgp = buildCgp();
+    await bridge.runCommands([`set -lex ${state.lexicon}`, `cgp ${cgp}`, 'rrack']);
+    applyState(await bridge.getJson('getState'));
+    clearPlays();
+  });
+}
+
+async function loadCgpString(cgpString) {
+  const trimmed = cgpString.trim();
+  if (!trimmed) {
+    return;
+  }
+  const lexMatch = trimmed.match(/-lex\s+(\S+)/);
+  if (lexMatch && LEXICA.includes(lexMatch[1])) {
+    state.lexicon = lexMatch[1];
+    $('lexicon').value = state.lexicon;
+  }
+  await withBusy('Loading CGP', async () => {
+    await ensureLexicon(state.lexicon);
+    const cmd = /-lex\s+\S+/.test(trimmed) ? trimmed : `${trimmed} -lex ${state.lexicon}`;
+    await bridge.runCommands([`set -lex ${state.lexicon}`, `cgp ${cmd}`]);
+    applyState(await bridge.getJson('getState'));
+    clearPlays();
+  });
+}
+
+// --- Wiring ----------------------------------------------------------------
+function wireUi() {
+  const lexSel = $('lexicon');
+  LEXICA.forEach((lex) => {
+    const opt = document.createElement('option');
+    opt.value = lex;
+    opt.textContent = lex;
+    lexSel.appendChild(opt);
+  });
+  lexSel.value = state.lexicon;
+  lexSel.addEventListener('change', () => {
+    state.lexicon = lexSel.value;
+    renderMeta();
+  });
+
+  $('btn-generate').addEventListener('click', generate);
+  $('btn-simulate').addEventListener('click', simulate);
+  $('btn-endgame').addEventListener('click', endgame);
+  $('btn-infer').addEventListener('click', infer);
+  $('btn-new').addEventListener('click', newGame);
+  $('stop').addEventListener('click', () => bridge.stop());
+
+  $('btn-copy-cgp').addEventListener('click', async () => {
+    const cgp = state.cgp || `${buildCgp()} -lex ${state.lexicon}`;
+    try {
+      await navigator.clipboard.writeText(cgp);
+      setStatus('CGP copied to clipboard', 'success');
+    } catch (err) {
+      window.prompt('Copy this CGP:', cgp);
+    }
+  });
+  // Inline Load-CGP panel (prompt() is blocked in cross-origin iframes and is
+  // hard to test, so use an in-page field).
+  const loadPanel = $('loadcgp-panel');
+  const cgpInput = $('cgp-input');
+  const openLoad = () => {
+    loadPanel.hidden = false;
+    cgpInput.value = state.cgp || '';
+    cgpInput.focus();
+    cgpInput.select();
+    board.fit();
+  };
+  const closeLoad = () => {
+    loadPanel.hidden = true;
+    board.fit();
+  };
+  const submitLoad = () => {
+    const cgp = cgpInput.value.trim();
+    closeLoad();
+    if (cgp) {
+      loadCgpString(cgp);
+    }
+  };
+  $('btn-load-cgp').addEventListener('click', () => {
+    if (loadPanel.hidden) {
+      openLoad();
+    } else {
+      closeLoad();
+    }
+  });
+  $('cgp-load-btn').addEventListener('click', submitLoad);
+  $('cgp-cancel-btn').addEventListener('click', closeLoad);
+  cgpInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      submitLoad();
+    } else if (e.key === 'Escape') {
+      closeLoad();
+    }
+  });
+
+  const sampleSel = $('sample');
+  Object.keys(SAMPLES).forEach((name) => {
+    const opt = document.createElement('option');
+    opt.value = name;
+    opt.textContent = name;
+    sampleSel.appendChild(opt);
+  });
+  $('btn-sample').addEventListener('click', () => loadCgpString(SAMPLES[sampleSel.value]));
+
+  // Sortable headers.
+  $('moves-head').querySelectorAll('[data-sort]').forEach((th) => {
+    th.addEventListener('click', () => {
+      const key = th.dataset.sort;
+      if (state.sortKey === key) {
+        state.sortDir = -state.sortDir;
+      } else {
+        state.sortKey = key;
+        state.sortDir = -1;
+      }
+      renderMoves();
+    });
+  });
+
+  document.addEventListener('keydown', onKeydown);
+  window.addEventListener('resize', () => board.fit());
+}
+
+async function boot() {
+  board = new Board($('board'), {
+    onCursorChange: (cur) => {
+      if (cur) {
+        state.focus = { kind: 'board' };
+        renderPlayers();
+      }
+      updatePaletteHint();
+    },
+    onEdit: () => clearPlays(),
+  });
+  buildPalette();
+  wireUi();
+  renderPlayers();
+  renderMoves();
+  renderMeta();
+  board.fit();
+  requestAnimationFrame(() => board.fit());
+
+  bridge = new Bridge(WORKER_URL, {
+    onLog: (t) => console.debug('[worker]', t),
+    onStatus: (t) => console.debug('[status]', t),
+    onOutput: (t) => console.debug('[output]', t),
+    onError: (t) => console.error('[worker error]', t),
+  });
+
+  setStatus('Loading WASM…');
+  try {
+    await bridge.ready;
+    setStatus('Loading lexicon data…');
+    await ensureLexicon(state.lexicon);
+    await bridge.init('data');
+    // Establish a known empty position so the board renders premium squares.
+    await loadEmptyPosition();
+    setStatus('Ready — click a square to place tiles, set a rack, then Generate.', 'success');
+  } catch (err) {
+    setStatus('Failed to initialize: ' + err.message, 'error');
+    logLine('❌ ' + err.message);
+  }
+}
+
+function formatInt(n) {
+  return (n || 0).toLocaleString();
+}
+
+boot();

--- a/webui/board.js
+++ b/webui/board.js
@@ -1,0 +1,371 @@
+// Board view + editor for the MAGPIE analysis board.
+//
+// Owns the visual 15x15 (or 21x21) grid, the fixed premium-square layout, the
+// editable letters/blanks, the mouse entry cursor, and move previews. The app
+// drives it: load() adopts engine state, the palette calls placeLetter(), and
+// before each analysis run the app reads cgpBoard() to sync the engine.
+
+const COL_LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXY';
+
+// English tile point values, used to render Woogles-style subscripts. Letters
+// not in the map (other distributions) simply render without a value.
+export const TILE_POINTS = {
+  A: 1, B: 3, C: 3, D: 2, E: 1, F: 4, G: 2, H: 4, I: 1, J: 8, K: 5, L: 1, M: 3,
+  N: 1, O: 1, P: 3, Q: 10, R: 1, S: 1, T: 1, U: 1, V: 4, W: 4, X: 8, Y: 4, Z: 10,
+};
+
+// Returns the point value for a displayed tile, or null when unknown / blank.
+export function tilePoints(letterUpper, isBlank) {
+  if (isBlank) {
+    return 0;
+  }
+  const value = TILE_POINTS[letterUpper];
+  return value === undefined ? null : value;
+}
+
+export class Board {
+  constructor(rootEl, { onCursorChange, onEdit } = {}) {
+    this.root = rootEl;
+    this.onCursorChange = onCursorChange || (() => {});
+    this.onEdit = onEdit || (() => {});
+    this.editable = true; // set false while an engine op is in flight
+    this.dim = 15;
+    this.layout = []; // [row][col] -> bonus code ("", "dls", ...)
+    this.cells = []; // [row][col] -> { letter, blank }
+    this.center = { row: 7, col: 7 };
+    this.cursor = null; // { row, col, dir: 'h' | 'v' }
+    this.preview = null; // array of { row, col, l, k } ghost tiles
+    this.highlight = null; // array of { row, col } persistent highlight
+    this.cellEls = [];
+    this._build(15);
+  }
+
+  // (Re)builds the DOM grid for a given dimension and wires cell events.
+  _build(dim) {
+    this.dim = dim;
+    this.root.style.setProperty('--dim', String(dim));
+    this.root.innerHTML = '';
+    this.cellEls = [];
+
+    const grid = document.createElement('div');
+    grid.className = 'grid';
+
+    // top-left corner spacer
+    grid.appendChild(this._labelCell(''));
+    // column letters
+    for (let col = 0; col < dim; col++) {
+      grid.appendChild(this._labelCell(COL_LETTERS[col]));
+    }
+    for (let row = 0; row < dim; row++) {
+      grid.appendChild(this._labelCell(String(row + 1)));
+      const rowEls = [];
+      for (let col = 0; col < dim; col++) {
+        const cell = document.createElement('button');
+        cell.type = 'button';
+        cell.className = 'cell';
+        cell.dataset.row = String(row);
+        cell.dataset.col = String(col);
+        cell.addEventListener('click', () => this._onCellClick(row, col));
+        cell.addEventListener('contextmenu', (e) => {
+          e.preventDefault();
+          this.eraseCell(row, col);
+        });
+        grid.appendChild(cell);
+        rowEls.push(cell);
+      }
+      this.cellEls.push(rowEls);
+    }
+    this.root.appendChild(grid);
+
+    // Start with a consistent empty model so cgpBoard()/render() are safe to
+    // call before the first load() (e.g. when boot syncs an empty position).
+    this.cells = [];
+    this.layout = [];
+    for (let row = 0; row < dim; row++) {
+      const cellsRow = [];
+      const layoutRow = [];
+      for (let col = 0; col < dim; col++) {
+        cellsRow.push({ letter: '', blank: false });
+        layoutRow.push('');
+      }
+      this.cells.push(cellsRow);
+      this.layout.push(layoutRow);
+    }
+  }
+
+  _labelCell(text) {
+    const el = document.createElement('div');
+    el.className = 'label';
+    el.textContent = text;
+    return el;
+  }
+
+  // Adopts engine state: fixed premium layout + letters + center + dimension.
+  load(state) {
+    const board = state.board || [];
+    const dim = state.dim || board.length || 15;
+    if (dim !== this.dim || this.cellEls.length !== dim) {
+      this._build(dim);
+    }
+    this.center = state.center || { row: (dim / 2) | 0, col: (dim / 2) | 0 };
+    this.layout = [];
+    this.cells = [];
+    for (let row = 0; row < dim; row++) {
+      const layoutRow = [];
+      const cellsRow = [];
+      for (let col = 0; col < dim; col++) {
+        const c = (board[row] && board[row][col]) || { l: '', b: '' };
+        layoutRow.push(c.b || '');
+        if (c.l) {
+          cellsRow.push({ letter: c.k ? c.l.toUpperCase() : c.l, blank: !!c.k });
+        } else {
+          cellsRow.push({ letter: '', blank: false });
+        }
+      }
+      this.layout.push(layoutRow);
+      this.cells.push(cellsRow);
+    }
+    this.preview = null;
+    this.highlight = null;
+    this.render();
+    this.fit();
+  }
+
+  setEditable(editable) {
+    this.editable = editable;
+  }
+
+  _onCellClick(row, col) {
+    if (!this.editable) {
+      return;
+    }
+    if (this.cursor && this.cursor.row === row && this.cursor.col === col) {
+      this.cursor.dir = this.cursor.dir === 'h' ? 'v' : 'h';
+    } else {
+      this.cursor = { row, col, dir: this.cursor ? this.cursor.dir : 'h' };
+    }
+    this.onCursorChange(this.cursor);
+    this.render();
+  }
+
+  setCursor(row, col, dir) {
+    this.cursor = { row, col, dir: dir || 'h' };
+    this.onCursorChange(this.cursor);
+    this.render();
+  }
+
+  clearCursor() {
+    this.cursor = null;
+    this.onCursorChange(null);
+    this.render();
+  }
+
+  _advance(step) {
+    if (!this.cursor) {
+      return;
+    }
+    if (this.cursor.dir === 'h') {
+      this.cursor.col = Math.max(0, Math.min(this.dim - 1, this.cursor.col + step));
+    } else {
+      this.cursor.row = Math.max(0, Math.min(this.dim - 1, this.cursor.row + step));
+    }
+  }
+
+  // Places a letter at the cursor (blank => lowercase designated tile) and
+  // advances. Returns false if there is no active cursor.
+  placeLetter(letter, blank) {
+    if (!this.cursor) {
+      return false;
+    }
+    const { row, col } = this.cursor;
+    this.cells[row][col] = { letter: letter.toUpperCase(), blank: !!blank };
+    this._advance(1);
+    this.render();
+    this.onEdit();
+    return true;
+  }
+
+  // Removes the tile just before the cursor and steps back onto it.
+  backspace() {
+    if (!this.cursor) {
+      return;
+    }
+    this._advance(-1);
+    const { row, col } = this.cursor;
+    this.cells[row][col] = { letter: '', blank: false };
+    this.render();
+    this.onEdit();
+  }
+
+  eraseCell(row, col) {
+    if (!this.editable) {
+      return;
+    }
+    this.cells[row][col] = { letter: '', blank: false };
+    this.render();
+    this.onEdit();
+  }
+
+  clearBoard() {
+    for (let row = 0; row < this.dim; row++) {
+      for (let col = 0; col < this.dim; col++) {
+        this.cells[row][col] = { letter: '', blank: false };
+      }
+    }
+    this.render();
+    this.onEdit();
+  }
+
+  // Applies a played move's tiles to the board model (used when advancing the
+  // game). Unlike the editing mutators this does not fire onEdit.
+  applyPlaced(placed) {
+    if (!placed) {
+      return;
+    }
+    for (const t of placed) {
+      this.cells[t.row][t.col] = { letter: t.l.toUpperCase(), blank: !!t.k };
+    }
+    this.render();
+  }
+
+  setPreview(placed) {
+    this.preview = placed && placed.length ? placed : null;
+    this.render();
+  }
+
+  setHighlight(placed) {
+    this.highlight = placed && placed.length ? placed : null;
+    this.render();
+  }
+
+  // Renders the board portion of a CGP string: run-length-encoded rows joined
+  // by '/'. Blanks are emitted lowercase, played tiles uppercase.
+  cgpBoard() {
+    const rows = [];
+    for (let row = 0; row < this.dim; row++) {
+      let str = '';
+      let run = 0;
+      for (let col = 0; col < this.dim; col++) {
+        const cell = this.cells[row][col];
+        if (!cell.letter) {
+          run++;
+          continue;
+        }
+        if (run > 0) {
+          str += run;
+          run = 0;
+        }
+        str += cell.blank ? cell.letter.toLowerCase() : cell.letter.toUpperCase();
+      }
+      if (run > 0) {
+        str += run;
+      }
+      rows.push(str);
+    }
+    return rows.join('/');
+  }
+
+  isEmpty() {
+    for (let row = 0; row < this.dim; row++) {
+      for (let col = 0; col < this.dim; col++) {
+        if (this.cells[row][col].letter) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  render() {
+    const previewMap = new Map();
+    if (this.preview) {
+      for (const t of this.preview) {
+        previewMap.set(t.row * this.dim + t.col, t);
+      }
+    }
+    const highlightSet = new Set();
+    if (this.highlight) {
+      for (const t of this.highlight) {
+        highlightSet.add(t.row * this.dim + t.col);
+      }
+    }
+    for (let row = 0; row < this.dim; row++) {
+      for (let col = 0; col < this.dim; col++) {
+        const el = this.cellEls[row][col];
+        const cell = this.cells[row][col];
+        const bonus = this.layout[row] ? this.layout[row][col] || '' : '';
+        const key = row * this.dim + col;
+        const ghost = previewMap.get(key);
+
+        el.className = 'cell';
+        if (bonus) {
+          el.classList.add('b-' + bonus);
+        }
+        if (this.center && this.center.row === row && this.center.col === col) {
+          el.classList.add('center');
+        }
+
+        let text = '';
+        let points = null;
+        if (cell.letter) {
+          text = cell.blank ? cell.letter.toLowerCase() : cell.letter;
+          points = tilePoints(cell.letter.toUpperCase(), cell.blank);
+          el.classList.add('tile');
+          if (cell.blank) {
+            el.classList.add('blank');
+          }
+        } else if (ghost) {
+          text = ghost.k ? ghost.l.toLowerCase() : ghost.l;
+          points = tilePoints(ghost.l.toUpperCase(), ghost.k);
+          el.classList.add('ghost');
+          if (ghost.k) {
+            el.classList.add('blank');
+          }
+        } else if (bonus && bonus !== 'brk') {
+          text = bonus.toUpperCase();
+          el.classList.add('premium-label');
+        }
+
+        if (highlightSet.has(key)) {
+          el.classList.add('highlight');
+        }
+        if (this.cursor && this.cursor.row === row && this.cursor.col === col) {
+          el.classList.add('cursor');
+          el.classList.add(this.cursor.dir === 'h' ? 'cursor-h' : 'cursor-v');
+        }
+        if (points != null && points > 0) {
+          el.textContent = text;
+          const pt = document.createElement('span');
+          pt.className = 'pt';
+          pt.textContent = String(points);
+          el.appendChild(pt);
+        } else {
+          el.textContent = text;
+        }
+      }
+    }
+  }
+
+  // Sizes the grid to the largest square that fits its container, and exposes
+  // the per-cell pixel size as --cell so text scales with the board.
+  fit() {
+    const grid = this.root.querySelector('.grid');
+    if (!grid) {
+      return;
+    }
+    const avail = Math.min(this.root.clientWidth, this.root.clientHeight);
+    if (avail <= 0) {
+      return;
+    }
+    const side = Math.floor(avail);
+    grid.style.width = side + 'px';
+    grid.style.height = side + 'px';
+    // The grid is one 16px label track + `dim` cell tracks separated by 1px
+    // gaps (dim gaps total). Subtract both so --cell (used only for font sizing)
+    // tracks the real rendered cell size.
+    const labelPx = 16;
+    const gaps = this.dim;
+    const cellPx = Math.max(8, (side - labelPx - gaps) / this.dim);
+    grid.style.setProperty('--cell', cellPx + 'px');
+  }
+}

--- a/webui/index.html
+++ b/webui/index.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MAGPIE — Analysis Board</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="topbar">
+      <div class="brand">MAGPIE <span>analysis board</span></div>
+      <div class="topbar-controls">
+        <label class="ctl">Lexicon <select id="lexicon"></select></label>
+        <span class="ctl sample-ctl">
+          <select id="sample"></select>
+          <button type="button" id="btn-sample" class="ghost-btn" data-act="sample">Load</button>
+        </span>
+        <button type="button" id="btn-new" class="ghost-btn" data-act="new">New</button>
+        <button type="button" id="btn-copy-cgp" class="ghost-btn">Copy CGP</button>
+        <button type="button" id="btn-load-cgp" class="ghost-btn">Load CGP…</button>
+      </div>
+    </header>
+
+    <div id="loadcgp-panel" class="loadcgp-panel" hidden>
+      <input
+        type="text"
+        id="cgp-input"
+        class="cgp-input"
+        placeholder="Paste a CGP string and press Load (e.g. 15/15/… AEINRST/ 0/0 0 -lex CSW21)"
+      />
+      <button type="button" id="cgp-load-btn" class="primary" data-act="loadcgp">Load</button>
+      <button type="button" id="cgp-cancel-btn" class="ghost-btn">Cancel</button>
+    </div>
+
+    <div id="status" class="status">Loading…</div>
+
+    <main class="layout">
+      <section class="board-area">
+        <div id="board" class="board"></div>
+        <div class="palette-wrap">
+          <div id="palette-hint" class="palette-hint">Click a board square to start placing tiles.</div>
+          <div id="palette" class="palette"></div>
+        </div>
+      </section>
+
+      <aside class="side">
+        <div class="panel">
+          <div class="panel-head">
+            <span>Players</span>
+            <span id="meta" class="meta"></span>
+          </div>
+          <div id="players" class="players"></div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-head"><span>Analysis</span></div>
+          <div class="actions">
+            <button type="button" id="btn-generate" class="primary" data-act="generate">Generate</button>
+            <button type="button" id="btn-simulate" class="primary" data-act="simulate">Simulate</button>
+            <button type="button" id="btn-endgame" class="primary" data-act="endgame">Endgame</button>
+            <button type="button" id="btn-infer" class="primary" data-act="infer">Infer</button>
+            <button type="button" id="stop" class="danger" disabled>Stop</button>
+          </div>
+          <div class="opts">
+            <label>sim plies <input type="number" id="opt-plies" value="2" min="1" max="10" /></label>
+            <label>sim secs <input type="number" id="opt-tlim" value="5" min="1" max="120" /></label>
+            <label>eg plies <input type="number" id="opt-eplies" value="5" min="1" max="25" /></label>
+          </div>
+        </div>
+
+        <div class="panel grow">
+          <div class="panel-head"><span>Plays</span></div>
+          <div class="moves-scroll">
+            <table class="moves">
+              <thead id="moves-head">
+                <tr>
+                  <th data-sort="i">Play</th>
+                  <th data-sort="score" class="num">Score</th>
+                  <th data-sort="equity" class="num">Equity</th>
+                  <th data-sort="win" data-col="win" class="num">Win%</th>
+                  <th>Leave</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody id="moves-body"></tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="panel out-panel">
+          <div class="panel-head"><span>Engine output</span></div>
+          <pre id="results" class="results"></pre>
+        </div>
+      </aside>
+    </main>
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/webui/serve.py
+++ b/webui/serve.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Serve the MAGPIE web UI with the headers WASM threads require.
+
+Serves the repository root (so /webui, /wasmentry, and /data all resolve)
+regardless of the directory this is launched from, and sends the
+Cross-Origin-Opener-Policy / Cross-Origin-Embedder-Policy headers needed for
+SharedArrayBuffer (pthreads).
+
+Usage:
+    python3 webui/serve.py [port]      # default port 8080
+Then open http://localhost:8080/webui/
+"""
+
+import http.server
+import os
+import socket
+import socketserver
+import sys
+from functools import partial
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+class CORSRequestHandler(http.server.SimpleHTTPRequestHandler):
+    def end_headers(self):
+        self.send_header("Cross-Origin-Opener-Policy", "same-origin")
+        self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Cache-Control", "no-store, no-cache, must-revalidate")
+        super().end_headers()
+
+    def do_OPTIONS(self):
+        self.send_response(200)
+        self.end_headers()
+
+
+def main():
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8080
+    handler = partial(CORSRequestHandler, directory=REPO_ROOT)
+    socketserver.TCPServer.allow_reuse_address = True
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.connect(("8.8.8.8", 80))
+        local_ip = sock.getsockname()[0]
+        sock.close()
+    except OSError:
+        local_ip = "localhost"
+
+    with socketserver.TCPServer(("0.0.0.0", port), handler) as httpd:
+        print(f"Serving {REPO_ROOT}")
+        print(f"  Desktop: http://localhost:{port}/webui/")
+        print(f"  LAN:     http://{local_ip}:{port}/webui/")
+        print("COOP/COEP enabled (SharedArrayBuffer ready). Ctrl+C to stop.")
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            print("\nStopped.")
+
+
+if __name__ == "__main__":
+    main()

--- a/webui/style.css
+++ b/webui/style.css
@@ -1,0 +1,677 @@
+:root {
+  /* Green-on-near-black chrome with amber tiles — the MAGPIE TUI palette. */
+  --bg: rgb(7, 12, 9);
+  --panel: rgb(13, 19, 15);
+  --panel-2: rgb(19, 27, 22);
+  --line: rgb(36, 48, 40);
+  --fg: rgb(222, 230, 224);
+  --fg-dim: rgb(120, 140, 128);
+  --accent: rgb(120, 220, 140);
+  --accent-dim: rgb(52, 110, 74);
+  --amber: rgb(230, 194, 130);
+  --amber-dim: rgb(120, 95, 50);
+
+  /* Premium squares (MAGPIE TUI / classic Scrabble). */
+  --tws-bg: rgb(91, 35, 47);
+  --tws-fg: rgb(204, 117, 133);
+  --dws-bg: rgb(124, 63, 77);
+  --dws-fg: rgb(216, 154, 160);
+  --tls-bg: rgb(31, 68, 88);
+  --tls-fg: rgb(88, 139, 168);
+  --dls-bg: rgb(51, 94, 122);
+  --dls-fg: rgb(125, 168, 200);
+  --qws-bg: rgb(70, 40, 92);
+  --qws-fg: rgb(170, 130, 210);
+  --qls-bg: rgb(36, 82, 92);
+  --qls-fg: rgb(120, 180, 195);
+  --empty-bg: rgb(24, 32, 27);
+  --brick-bg: rgb(6, 9, 7);
+
+  /* Amber wood tiles with dark letters. */
+  --tile-bg: rgb(216, 182, 118);
+  --tile-fg: rgb(38, 28, 10);
+  --blank-fg: rgb(168, 54, 54);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  font-size: 14px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* --- Top bar ------------------------------------------------------------- */
+.topbar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 14px;
+  background: var(--panel);
+  border-bottom: 1px solid var(--line);
+  flex-wrap: wrap;
+}
+
+.brand {
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  font-size: 17px;
+  color: var(--accent);
+}
+
+.brand span {
+  color: var(--fg-dim);
+  font-weight: 500;
+  font-size: 12px;
+  margin-left: 4px;
+}
+
+.topbar-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.ctl {
+  color: var(--fg-dim);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.sample-ctl {
+  display: inline-flex;
+  gap: 4px;
+}
+
+select,
+input[type="number"],
+input[type="text"] {
+  background: var(--panel-2);
+  color: var(--fg);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 5px 8px;
+  font: inherit;
+}
+
+input[type="number"] {
+  width: 52px;
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+  border-radius: 6px;
+  border: 1px solid var(--line);
+  background: var(--panel-2);
+  color: var(--fg);
+  padding: 6px 11px;
+}
+
+button:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+
+button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.ghost-btn {
+  background: transparent;
+}
+
+.primary {
+  background: var(--accent-dim);
+  border-color: var(--accent-dim);
+  color: rgb(232, 248, 236);
+  font-weight: 600;
+}
+
+.primary:hover:not(:disabled) {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: rgb(10, 24, 14);
+}
+
+.danger {
+  background: transparent;
+  border-color: rgb(120, 50, 50);
+  color: rgb(220, 140, 140);
+}
+
+/* --- Inline Load-CGP panel ---------------------------------------------- */
+.loadcgp-panel {
+  flex: 0 0 auto;
+  display: flex;
+  gap: 8px;
+  padding: 8px 14px;
+  background: var(--panel-2);
+  border-bottom: 1px solid var(--line);
+}
+
+.loadcgp-panel[hidden] {
+  display: none;
+}
+
+.cgp-input {
+  flex: 1;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}
+
+/* --- Status ------------------------------------------------------------- */
+.status {
+  flex: 0 0 auto;
+  padding: 6px 14px;
+  background: var(--panel-2);
+  border-bottom: 1px solid var(--line);
+  color: var(--fg-dim);
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.status.success {
+  color: var(--accent);
+}
+
+.status.error {
+  color: rgb(240, 120, 120);
+}
+
+/* --- Main layout (fills remaining height, no page scroll) --------------- */
+.layout {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(360px, 430px);
+  gap: 12px;
+  padding: 12px;
+  overflow: hidden;
+}
+
+@media (max-width: 820px) {
+  body {
+    overflow: auto;
+  }
+  .layout {
+    grid-template-columns: 1fr;
+    overflow: visible;
+  }
+}
+
+/* --- Board -------------------------------------------------------------- */
+.board-area {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 0;
+  min-width: 0;
+}
+
+.board {
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.grid {
+  --lab: 16px;
+  display: grid;
+  grid-template-columns: var(--lab) repeat(var(--dim), 1fr);
+  grid-template-rows: var(--lab) repeat(var(--dim), 1fr);
+  gap: 1px;
+  user-select: none;
+}
+
+.label {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--fg-dim);
+  font-size: calc(var(--cell, 28px) * 0.32);
+  font-variant-numeric: tabular-nums;
+}
+
+.cell {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 2px;
+  padding: 0;
+  background: var(--empty-bg);
+  color: var(--fg-dim);
+  font-size: calc(var(--cell, 28px) * 0.5);
+  font-weight: 700;
+  line-height: 1;
+  overflow: hidden;
+}
+
+.cell:hover {
+  outline: 1px solid var(--accent);
+  outline-offset: -1px;
+}
+
+.cell .pt {
+  position: absolute;
+  right: 7%;
+  bottom: 4%;
+  font-size: calc(var(--cell, 28px) * 0.26);
+  font-weight: 700;
+  opacity: 0.8;
+}
+
+.cell.premium-label {
+  font-size: calc(var(--cell, 28px) * 0.26);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.b-tws {
+  background: var(--tws-bg);
+  color: var(--tws-fg);
+}
+.b-dws {
+  background: var(--dws-bg);
+  color: var(--dws-fg);
+}
+.b-tls {
+  background: var(--tls-bg);
+  color: var(--tls-fg);
+}
+.b-dls {
+  background: var(--dls-bg);
+  color: var(--dls-fg);
+}
+.b-qws {
+  background: var(--qws-bg);
+  color: var(--qws-fg);
+}
+.b-qls {
+  background: var(--qls-bg);
+  color: var(--qls-fg);
+}
+.b-brk {
+  background: var(--brick-bg);
+}
+
+.cell.center.premium-label {
+  color: transparent;
+}
+
+.cell.center.premium-label::after {
+  content: "★";
+  color: var(--dws-fg);
+  font-size: calc(var(--cell, 28px) * 0.6);
+}
+
+.cell.tile {
+  background: var(--tile-bg);
+  color: var(--tile-fg);
+  font-weight: 800;
+}
+
+.cell.tile.blank {
+  color: var(--blank-fg);
+  font-style: italic;
+}
+
+.cell.ghost {
+  background: rgba(120, 220, 140, 0.26);
+  color: var(--accent);
+  box-shadow: inset 0 0 0 1px var(--accent-dim);
+}
+
+.cell.highlight {
+  box-shadow: inset 0 0 0 2px var(--accent);
+}
+
+.cell.cursor {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.cell.cursor-h::before,
+.cell.cursor-v::before {
+  content: "";
+  position: absolute;
+  width: 0;
+  height: 0;
+  opacity: 0.85;
+}
+
+.cell.cursor-h::before {
+  right: 2px;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 6px solid var(--accent);
+}
+
+.cell.cursor-v::before {
+  bottom: 2px;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 6px solid var(--accent);
+}
+
+/* --- Palette ------------------------------------------------------------ */
+.palette-wrap {
+  flex: 0 0 auto;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 8px;
+}
+
+.palette-hint {
+  color: var(--fg-dim);
+  font-size: 12px;
+  margin-bottom: 6px;
+  min-height: 15px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.palette {
+  display: grid;
+  grid-template-columns: repeat(14, 1fr);
+  gap: 4px;
+}
+
+.pal {
+  padding: 6px 0;
+  background: var(--panel-2);
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.pal-blank,
+.pal-wide {
+  grid-column: span 2;
+}
+
+.pal-blank.active {
+  background: var(--accent-dim);
+  color: rgb(232, 248, 236);
+  border-color: var(--accent);
+}
+
+/* --- Side panels -------------------------------------------------------- */
+.side {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  overflow: hidden;
+  flex: 0 0 auto;
+}
+
+.panel.grow {
+  flex: 1 1 auto;
+  min-height: 80px;
+  display: flex;
+  flex-direction: column;
+}
+
+.panel-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 12px;
+  background: var(--panel-2);
+  border-bottom: 1px solid var(--line);
+  font-weight: 600;
+  font-size: 12px;
+  color: var(--accent);
+}
+
+.meta {
+  font-weight: 500;
+  color: var(--amber);
+}
+
+.players {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  background: var(--line);
+}
+
+.player-card {
+  background: var(--panel);
+  padding: 8px 12px;
+}
+
+.player-card.on-turn {
+  background: rgba(120, 220, 140, 0.07);
+}
+
+.player-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.player-label {
+  font-weight: 600;
+  color: var(--amber);
+}
+
+.on-turn .player-label {
+  color: var(--accent);
+}
+
+.score {
+  color: var(--fg-dim);
+}
+
+.score input {
+  width: 64px;
+}
+
+.rack {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  min-height: 34px;
+  align-items: center;
+  padding: 4px;
+  border: 1px dashed var(--line);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.rack.focused {
+  border-color: var(--accent);
+  border-style: solid;
+}
+
+.rack-empty {
+  color: var(--fg-dim);
+  font-size: 12px;
+  font-style: italic;
+}
+
+.tile-face {
+  position: relative;
+  background: var(--amber);
+  color: rgb(40, 30, 12);
+  font-weight: 800;
+  border-radius: 4px;
+  width: 26px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 15px;
+}
+
+.on-turn .tile-face {
+  background: rgb(150, 232, 174);
+  color: rgb(14, 36, 20);
+}
+
+.tile-face.blank {
+  color: var(--blank-fg);
+}
+
+.tile-face .pt {
+  position: absolute;
+  right: 2px;
+  bottom: 0;
+  font-size: 8px;
+  opacity: 0.75;
+}
+
+.rack-tools {
+  display: flex;
+  gap: 6px;
+  margin-top: 6px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.rack-input {
+  flex: 1;
+  min-width: 110px;
+  text-transform: uppercase;
+  font-size: 12px;
+}
+
+.mini {
+  padding: 4px 8px;
+  font-size: 12px;
+}
+
+.actions {
+  display: flex;
+  gap: 6px;
+  padding: 10px 12px;
+  flex-wrap: wrap;
+}
+
+.opts {
+  display: flex;
+  gap: 10px;
+  padding: 0 12px 10px;
+  flex-wrap: wrap;
+  color: var(--fg-dim);
+  font-size: 12px;
+}
+
+.opts label {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.moves-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+table.moves {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+table.moves th {
+  position: sticky;
+  top: 0;
+  background: var(--panel-2);
+  text-align: left;
+  padding: 5px 10px;
+  cursor: pointer;
+  color: var(--fg-dim);
+  font-weight: 600;
+  border-bottom: 1px solid var(--line);
+  white-space: nowrap;
+}
+
+table.moves th.num {
+  text-align: right;
+}
+
+table.moves td {
+  padding: 4px 10px;
+  border-bottom: 1px solid rgba(36, 48, 40, 0.6);
+}
+
+table.moves td.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+table.moves td.play {
+  font-weight: 600;
+}
+
+table.moves td.leave {
+  color: var(--amber);
+}
+
+table.moves td.empty {
+  color: var(--fg-dim);
+  font-style: italic;
+  text-align: center;
+  padding: 14px;
+}
+
+table.moves tbody tr:hover {
+  background: rgba(120, 220, 140, 0.09);
+}
+
+table.moves tbody tr.selected {
+  background: rgba(120, 220, 140, 0.18);
+}
+
+.out-panel {
+  flex: 0 0 auto;
+}
+
+.results {
+  margin: 0;
+  padding: 8px 12px;
+  height: 84px;
+  overflow: auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: var(--fg-dim);
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
## Web UI: browser analysis board over WASM

A mouse-oriented **analysis board** that runs MAGPIE entirely in the browser via WebAssembly. Intended as a common entry point for users and for embedding in the upcoming docs site. It follows the spirit of the notcurses TUI (green/amber palette, board + scoreboard + move list) but is mouse-first.

### What it does
- **Set up a position by clicking** — click a square to set the entry cursor (click again to flip across/down), then click letters in the on-screen palette; toggle **Blank** for a designated blank; right-click to erase. Keyboard entry also works.
- **Edit racks** — click a rack to focus it (palette / type / click-a-tile-to-remove / **Random**), **swap to move** to analyze the other side.
- **Analyze** — **Generate**, **Simulate** (adds win% + mean equity), **Endgame** (highlights the best move), **Infer**.
- **Plays list** — hover to preview on the board, click to pin, sort by any column, **Play** to advance the position.
- **Positions** — load a built-in sample, **Copy CGP**, inline **Load CGP**, **New** (empty board).

The board auto-sizes so the whole UI fits the window with no page scroll. Tiles render Woogles-style point-value subscripts; blanks are shown in red italic.

### How it works
The page drives the existing `wasmentry/wasm-worker.js`, extended with three JSON accessors exported from the engine:

| Export | C entry point | Returns |
| --- | --- | --- |
| `wasm_get_state_json` | `json_api_get_state` | board, premiums, racks, scores, turn, bag, lexicon, CGP |
| `wasm_get_moves_json` | `json_api_get_moves` | generated plays (+ sim win% / mean equity) |
| `wasm_get_endgame_json` | `json_api_get_endgame` | endgame value/depth + best move |

The board/racks/scores are edited client-side; before each analysis the UI serializes them to a CGP string, syncs it into the engine, and reads the structured JSON back to render. Schema lives in `src/impl/json_api.h`.

### Run it
```bash
make -f Makefile-wasm OBJ_DIR=obj-wasm magpie_wasm   # separate obj dir so native objects survive
python3 webui/serve.py                                # open http://localhost:8080/webui/
```
`serve.py` sends the `COOP: same-origin` / `COEP: require-corp` headers that `SharedArrayBuffer` (engine threads) requires.

### Testing
- `test/json_api_test.c` — unit test for the JSON serializers (registered, and added to an ASAN/UBSAN dev CI shard).
- `wasmentry/tests/webui.test.js` — three Playwright end-to-end tests: generate + preview + **viewport-fit**, **load-CGP**, and **play-through**.
- Verified locally: Playwright 3/3, existing `simulation.test.js` 2/2 (no regression), `magpie_test jsonapi` passes, and cppcheck / clang-tidy / clang-format / circular-deps all clean. An adversarial multi-agent review (24 found / 14 confirmed) was applied — notably a sim win% scaling fix and several worker-robustness fixes.

### Notes / follow-ups
- Ships the English lexica with data files (CSW21/24, NWL20/23, TWL06/14/98) on the standard 15×15 board; other distributions/layouts are future work.
- **Play advances the position locally** rather than via the engine's `commit` command: `commit` currently mis-validates plays that run through existing tiles (reproduced natively — opening plays commit fine, midgame/endgame through-plays fail with "not connected"). Advancing locally is also a better fit for analysis (you choose the next rack rather than a random draw). A separate engine fix would enable true through-play commits.
- Inference is exposed but minimal (shows the engine's text output).

Draft pending review of scope/approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Go8D8zTV4jSMNSX9dxGsXc
