### PR TITLE
endgame: fix zobrist rack double-count on outplays (heap-buffer-overflow)

### DIFF
--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -2503,6 +2503,22 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
       const bool is_outplay =
           small_move_get_tiles_played(small_move) == stm_rack_tiles;
 
+      // Outplays use play_move_endgame_outplay (below), which deliberately does
+      // NOT empty the rack, so stm_rack still holds the full pre-move rack.
+      // zobrist_add_move treats its rack arg as the post-move leftover, which
+      // for an outplay is empty; passing the stale full rack double-counts the
+      // played tiles (placeholder = placed + full = 2*placed) and can index the
+      // rack hash table out of bounds -- e.g. outplaying four S's yields
+      // placeholder[S] = 8 into an 8-slot (0..RACK_SIZE) row. Use an empty
+      // leftover for outplays.
+      Rack outplay_leftover;
+      if (is_outplay) {
+        rack_set_dist_size_and_reset(&outplay_leftover,
+                                     rack_get_dist_size(stm_rack));
+      }
+      const Rack *move_leftover_rack =
+          is_outplay ? &outplay_leftover : stm_rack;
+
       // Track whether thread 0 is inside root move #1's subtree
       if (is_root && worker->ordinal == 0 && pass == 0) {
         worker->in_first_root_move = (idx == 0);
@@ -2542,7 +2558,7 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
       if (worker->solver->transposition_table_optim) {
         child_key = zobrist_add_move(
             worker->solver->transposition_table->zobrist, node_key,
-            worker->move_list->spare_move, stm_rack,
+            worker->move_list->spare_move, move_leftover_rack,
             on_turn_idx == worker->solver->solving_player,
             game_get_consecutive_scoreless_turns(worker->game_copy),
             last_consecutive_scoreless_turns);

--- a/test/endgame_test.c
+++ b/test/endgame_test.c
@@ -1655,3 +1655,53 @@ void test_endgame_wasm(void) {
   test_pass_first();
   test_nonempty_bag();
 }
+
+// Regression: an endgame outplay that plays >= 4 of one letter (e.g. all four
+// S's from EOSSSS) must not overflow the zobrist rack-hash table.
+// play_move_endgame_outplay leaves the mover's rack full (it skips the update
+// because the game is ending), so the search's zobrist_add_move must treat the
+// post-outplay leftover as empty rather than double-counting the played tiles.
+// Otherwise the reconstructed pre-move rack is placed + full = 2*placed, and an
+// outplay of four S's makes placeholder[S] = 8, indexing rack_table[S] one past
+// its RACK_SIZE+1 row (heap-buffer-overflow under ASan; silent TT-key
+// corruption otherwise). Single-threaded and deterministic: the defect is not a
+// race and reproduces on the first solve.
+void test_endgame_outplay_zobrist_overflow(void) {
+  Config *config =
+      config_create_or_die("set -lex CSW24 -s1 score -s2 score -eplies 25");
+  load_and_exec_config_or_die(
+      config,
+      "cgp F6ENDEW2G/Y4AUA2TELCO/ROTARY8R/D2MEARING4I/2KITH3OW4/1QIN5XI4/"
+      "1U6B1V4/DA1DAUPhINE4/AL1H4Z6/EM1U3J7/3T3E7/APRICATE7/VOE4I7/ELEcTION7/"
+      "7G7 BFLNOOR/EOSSSS 442/356 0");
+
+  Game *game = config_get_game(config);
+  EndgameArgs endgame_args = {0};
+  endgame_args.thread_control = config_get_thread_control(config);
+  endgame_args.game = game;
+  endgame_args.plies = config_get_endgame_plies(config);
+  endgame_args.tt_fraction_of_mem = config_get_tt_fraction_of_mem(config);
+  endgame_args.initial_small_move_arena_size =
+      DEFAULT_INITIAL_SMALL_MOVE_ARENA_SIZE;
+  endgame_args.num_threads = 1;
+  endgame_args.use_heuristics = true;
+  endgame_args.forced_pass_bypass = true;
+  endgame_args.num_top_moves = 1;
+  endgame_args.seed = 42;
+
+  EndgameCtx *endgame_ctx = NULL;
+  EndgameResults *endgame_results = config_get_endgame_results(config);
+  ErrorStack *error_stack = error_stack_create();
+
+  endgame_solve(&endgame_ctx, &endgame_args, endgame_results, error_stack);
+
+  assert(error_stack_is_empty(error_stack));
+  const PVLine *pv =
+      endgame_results_get_pvline(endgame_results, ENDGAME_RESULT_BEST);
+  assert(pv != NULL);
+  assert(pv->num_moves > 0);
+
+  error_stack_destroy(error_stack);
+  endgame_ctx_destroy(endgame_ctx);
+  config_destroy(config);
+}

--- a/test/endgame_test.h
+++ b/test/endgame_test.h
@@ -3,6 +3,7 @@
 
 void test_endgame(void);
 void test_endgame_wasm(void);
+void test_endgame_outplay_zobrist_overflow(void);
 void test_multi_pv(void);
 void test_kue(void);
 void test_eldar_v_stick(void);

--- a/test/test.c
+++ b/test/test.c
@@ -127,6 +127,7 @@ static TestEntry test_table[] = {
     {"wmg", test_wmp_move_gen},
     {"winpct", test_win_pct},
     {"endgame", test_endgame},
+    {"endgameoutplay", test_endgame_outplay_zobrist_overflow},
     {"endgamefirstwin", test_endgame_first_win_sign},
     {"eldar_v", test_eldar_v_stick},
     {"zobrist", test_zobrist},


### PR DESCRIPTION
## Summary
The endgame solver has a heap-buffer-overflow (under ASan) / silent TT-key corruption (in production) when its search hashes an **outplay that plays ≥ 4 of one letter** (e.g. all four `S`s from a `EOSSSS` rack).

## Root cause
`play_move_endgame_outplay` deliberately does **not** empty the side-to-move rack — the game is ending, so it skips the update for speed. But the `abdada_negamax` move loop then passes that still-full rack to `zobrist_add_move` as the *post-move leftover*. `zobrist_add_move` reconstructs the pre-move rack as `placed_tiles + leftover`, so for an outplay it computes `placed + full = 2·placed`. The rack-hash row has `RACK_SIZE+1` (8) slots indexed by the per-letter count, so an outplay of four `S`s indexes `rack_table[S][8]` — one past the row.

- **Under ASan:** `heap-buffer-overflow` at `zobrist.h:181` → crash.
- **In production:** reads adjacent heap memory, silently corrupting the TT key for those outplay nodes.

## Fix
Pass an **empty** leftover rack to `zobrist_add_move` for outplays (the true post-move rack *is* empty), so `placeholder = placed` = the correct pre-move rack. Non-outplay moves are unaffected — `play_move_incremental` updates the rack in place, so `stm_rack` is already the correct leftover by the call. The pass-move call site is unaffected (`zobrist_add_move` skips the rack block for passes).

## Test
Adds `endgameoutplay`: solves a real position where the opponent can outplay four `S`s. It is single-threaded and **deterministic** (the defect is not a race) and reproduces on the first solve.

- **Before this change**, on unmodified `main`, the new test crashes with `AddressSanitizer: heap-buffer-overflow zobrist.h:181 in zobrist_add_move`.
- **After**, it passes; `endgame` / `zobrist` / `tt` regression tests remain green.

It's rare in normal play — it needs a ≥4-of-a-letter outplay to arise inside the search — which is why it took a deep endgame across many varied positions to surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKQniDvyWewhbMhuCrFKS2