### PR TITLE
config: set uspread=0.5 as the sim utility blend default

### DIFF
--- a/src/impl/config.c
+++ b/src/impl/config.c
@@ -1847,7 +1847,7 @@ void add_help_arg_to_string_builder(const Config *config, int token,
              "(uwin*wpct + uspread*spread_sigmoid) / (uwin + uspread), where "
              "spread_sigmoid = 1/(1+exp(-spread/uspreadscale)) is the "
              "logistic sigmoid of the rollout spread (strictly in (0, 1)). "
-             "Default 1.0 (pure win%).";
+             "Default 1.0, blended with the default uspread of 0.5.";
       break;
     case ARG_TOKEN_UTILITY_W_SPREAD:
       usages[0] = "<weight>";
@@ -1855,7 +1855,8 @@ void add_help_arg_to_string_builder(const Config *config, int token,
       examples[1] = "0.3";
       text = "Weight on (normalized) spread in the BAI sample utility. Default "
              "0.5. With non-zero uspread the simmer favors plays with higher "
-             "rollout spread in addition to higher win%.";
+             "rollout spread in addition to higher win%; set -uspread 0 to "
+             "restore the pure win% utility.";
       break;
     case ARG_TOKEN_UTILITY_SPREAD_SCALE:
       usages[0] = "<points>";

--- a/src/impl/config.c
+++ b/src/impl/config.c
@@ -1851,11 +1851,11 @@ void add_help_arg_to_string_builder(const Config *config, int token,
       break;
     case ARG_TOKEN_UTILITY_W_SPREAD:
       usages[0] = "<weight>";
-      examples[0] = "0.0";
+      examples[0] = "0.5";
       examples[1] = "0.3";
       text = "Weight on (normalized) spread in the BAI sample utility. Default "
-             "0.0 (pure win%). With non-zero uspread the simmer favors plays "
-             "with higher rollout spread in addition to higher win%.";
+             "0.5. With non-zero uspread the simmer favors plays with higher "
+             "rollout spread in addition to higher win%.";
       break;
     case ARG_TOKEN_UTILITY_SPREAD_SCALE:
       usages[0] = "<points>";
@@ -8405,7 +8405,7 @@ Config *config_create(const ConfigArgs *config_args, ErrorStack *error_stack) {
   config->stop_cond_pct = 99;
   config->cutoff = convert_user_cutoff_to_cutoff(0.005);
   config->utility_w_winpct = 1.0;
-  config->utility_w_spread = 0.0;
+  config->utility_w_spread = 0.5;
   config->utility_spread_scale = 100.0;
   config->time_limit_seconds = 60;
   config->num_threads = get_num_cores();

--- a/test/config_test.c
+++ b/test/config_test.c
@@ -2462,17 +2462,17 @@ void test_config_exchange_blank(void) {
 void test_config_utility_blend(void) {
   ErrorStack *error_stack = error_stack_create();
 
-  // Defaults: (1.0, 0.0, 100.0), fanned out identically to both players.
+  // Defaults: (1.0, 0.5, 100.0), fanned out identically to both players.
   {
     Config *config = config_create_default_test();
     assert(within_epsilon(config_get_utility_w_winpct(config), 1.0));
-    assert(within_epsilon(config_get_utility_w_spread(config), 0.0));
+    assert(within_epsilon(config_get_utility_w_spread(config), 0.5));
     assert(within_epsilon(config_get_utility_spread_scale(config), 100.0));
     assert(within_epsilon(config_get_p1_utility_w_winpct(config), 1.0));
-    assert(within_epsilon(config_get_p1_utility_w_spread(config), 0.0));
+    assert(within_epsilon(config_get_p1_utility_w_spread(config), 0.5));
     assert(within_epsilon(config_get_p1_utility_spread_scale(config), 100.0));
     assert(within_epsilon(config_get_p2_utility_w_winpct(config), 1.0));
-    assert(within_epsilon(config_get_p2_utility_w_spread(config), 0.0));
+    assert(within_epsilon(config_get_p2_utility_w_spread(config), 0.5));
     assert(within_epsilon(config_get_p2_utility_spread_scale(config), 100.0));
     config_destroy(config);
   }
@@ -2522,11 +2522,11 @@ void test_config_utility_blend(void) {
     Config *config = config_create_default_test();
     load_and_exec_config_or_die(config, "set -uwin1 0.4 -uspread1 0.6");
     assert(within_epsilon(config_get_utility_w_winpct(config), 1.0));
-    assert(within_epsilon(config_get_utility_w_spread(config), 0.0));
+    assert(within_epsilon(config_get_utility_w_spread(config), 0.5));
     assert(within_epsilon(config_get_p1_utility_w_winpct(config), 0.4));
     assert(within_epsilon(config_get_p1_utility_w_spread(config), 0.6));
     assert(within_epsilon(config_get_p2_utility_w_winpct(config), 1.0));
-    assert(within_epsilon(config_get_p2_utility_w_spread(config), 0.0));
+    assert(within_epsilon(config_get_p2_utility_w_spread(config), 0.5));
     config_destroy(config);
   }
 


### PR DESCRIPTION
## Summary

Changes the BAI sim sampler's spread-utility blend default from `uspread=0.0` (pure win%) to `uspread=0.5`. `uspreadscale` stays at `100.0`.

The blend mechanism (`uwin`/`uspread`/`uspreadscale`, from `31758629`) shipped with unit tests but no play-quality evaluation. This PR is the evaluation, and the result: a nonzero spread weight is a pure spread play — **+8–13 points of margin per game pair at no measurable win-rate cost** — which is worth having as the default in a game where spread breaks tournament ties.

**Depends on #585** (best-move selection fix) landing first: an early version of this evaluation was inflated by a selection defect in the `uspread=0` baseline that #585 fixes; all numbers below are measured against the fixed baseline.

## Evidence

All game-pair autoplay (`-gp true -wmp true`, CSW21, fixed seeds, control = `uspread=0`, treatment = `uspread=0.5` unless noted):

| Test | Sample | Spread/pair | Win% (treatment) |
|---|---|---|---|
| 2-ply, i=600, np=15 | 1,000 pairs | **+10.4** (p<0.0001) | 50.6% (ns) |
| 4-ply, i=1000, np=15 (realistic) | 1,660 pairs | **+12.9** (p<0.0001) | 51.1% (ns) |
| 2-ply wins-powered (np=10, no inference) | **16,560 pairs / 33,120 games** | **+7.9 ± 1.0** (p<0.0001) | **49.95%, 95% CI ±0.55%** |

The 33k-game run is the win-rate verdict: the effect on wins is zero to within about half a percent — the spread gain does not trade away games.

**Tuning** (all vs fixed control, 200 pairs/arm unless noted):
- 7-point curve over `uspread` ∈ {0.1, 0.25, 0.5, 0.75, 1.0, 1.5, 2.0}: soft onset below 0.5, then a flat plateau through 2.0 — no win% degradation even at 4× the proposed default.
- Direct heads-up `0.5` vs `1.0` (1,000 pairs): dead heat (+1.1/pair, p=0.52; win% 49.75, p=0.84). Nothing above 0.5 helps.
- `uspreadscale` ∈ {50, 100, 200} at `uspread=0.5`: not a sensitive knob; 100 is fine.
- A completed 15,000-pair / 30,000-game `uspread=0.75` run at a heavier per-game protocol (np=20, serial games): **+11.4/pair (p<0.0001), win% 49.94% (CI ±0.57%)** — the plateau and win-neutrality both hold at high precision. (Its modest numerical edge over the 0.5 mega-run's +7.9 is confounded with the protocol difference — np=10 vs np=20 — not evidence that 0.75 beats 0.5; the direct heads-up instrument for that comparison found 0.5 and 1.0 indistinguishable.)

So `0.5` is the smallest weight that captures the full effect, with the deepest evidence behind it.

## Why it works

Per-rollout win outcomes are coarse (0/0.5/1), so near-equal candidate plays often can't be separated by win% at a fixed sample budget — and in decided positions the win% signal goes completely flat. The sigmoid spread term keeps a smooth gradient in exactly those spots, letting the sim prefer the higher-scoring line (take the bingo, block for fewer points back) when win% is indifferent. Observed in real turns as trades like a 51-point play over a 40-point play at a 0.2% win% difference; measured in aggregate as ~+4–6 points/game with wins unchanged.

## Changes

- `src/impl/config.c`: `utility_w_spread` default `0.0` → `0.5`; `-uspread` help text updated.
- `test/config_test.c`: default-value assertions updated to match.

Validated: `config`/`sim`/`autoplay` suites pass; format/cppcheck/clang-tidy/circ-deps clean; full CI green on this branch.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_019SJ8s3CzxxYNbQpQvDAjrX
