### PR TITLE
sim: equity-tiebreak best-move selection under the pure-win% utility

### DIFF
--- a/src/ent/sim_results.c
+++ b/src/ent/sim_results.c
@@ -56,6 +56,10 @@ struct SimResults {
   BAIResult *bai_result;
   bool valid_for_current_game_state;
   double cutoff;
+  // Utility-blend spread weight the last sim ran with (the SimArgs value,
+  // recorded by simulate()). Selects the best-move path in
+  // sim_results_get_best_move; see the comment there.
+  double utility_w_spread;
   uint64_t num_infer_leaves;
 };
 
@@ -296,6 +300,7 @@ SimResults *sim_results_create(const double cutoff) {
   sim_results->bai_result = bai_result_create();
   sim_results->valid_for_current_game_state = false;
   sim_results->cutoff = cutoff;
+  sim_results->utility_w_spread = 0.0;
   sim_results->num_infer_leaves = 0;
   rack_set_dist_size_and_reset(&sim_results->rack, 0);
   rack_set_dist_size_and_reset(&sim_results->known_opp_rack, 0);
@@ -407,6 +412,11 @@ double sim_results_get_cutoff(const SimResults *sim_results) {
 
 void sim_results_set_cutoff(SimResults *sim_results, double cutoff) {
   sim_results->cutoff = cutoff;
+}
+
+void sim_results_set_utility_w_spread(SimResults *sim_results,
+                                      double utility_w_spread) {
+  sim_results->utility_w_spread = utility_w_spread;
 }
 
 uint64_t sim_results_get_num_infer_leaves(const SimResults *sim_results) {
@@ -650,14 +660,28 @@ int sim_results_get_best_move_index(const SimResults *sim_results) {
 
 // Not thread safe, assumes the sim is finished.
 const Move *sim_results_get_best_move(const SimResults *sim_results) {
-  // Prefer BAI's chosen arm: that's the one with highest mean *utility*
-  // (which the simmer blends from wpct + sigmoid(spread) when -uspread is
-  // non-zero). Falling through to sim_results_get_best_move_index would
-  // re-rank by raw win_pct_stat, ignoring the utility blend entirely.
-  int best_play_idx =
-      bai_result_get_best_arm(sim_results_get_bai_result(sim_results));
-  if (best_play_idx < 0) {
+  // With a nonzero spread weight, prefer BAI's chosen arm: that's the one
+  // with the highest mean *utility* (wpct blended with sigmoid(spread)).
+  // Falling through to sim_results_get_best_move_index would re-rank by raw
+  // win_pct_stat, ignoring the blend entirely.
+  //
+  // With a ZERO spread weight the sample utility is the raw 0/0.5/1 win
+  // outcome, which loses its gradient whenever win% saturates (decided
+  // games: every arm's mean is ~0 or ~1) or ties exactly. BAI's arm choice
+  // among tied arms is then effectively arbitrary, and measured game-pair
+  // autoplay showed it bleeding 5-60+ points per decided turn (playing
+  // rank-15 moves over same-win% higher-scoring ones). Use the win%
+  // comparator instead: it breaks win%-within-cutoff ties by mean equity,
+  // matching the displayed sort and recovering spread at no win% cost.
+  int best_play_idx;
+  if (sim_results->utility_w_spread == 0.0) {
     best_play_idx = sim_results_get_best_move_index(sim_results);
+  } else {
+    best_play_idx =
+        bai_result_get_best_arm(sim_results_get_bai_result(sim_results));
+    if (best_play_idx < 0) {
+      best_play_idx = sim_results_get_best_move_index(sim_results);
+    }
   }
   if (best_play_idx < 0) {
     return NULL;

--- a/src/ent/sim_results.h
+++ b/src/ent/sim_results.h
@@ -69,6 +69,10 @@ BAIResult *sim_results_get_bai_result(const SimResults *sim_results);
 
 double sim_results_get_cutoff(const SimResults *sim_results);
 void sim_results_set_cutoff(SimResults *sim_results, double cutoff);
+// Record the utility-blend spread weight the sim ran with; see
+// sim_results_get_best_move for how it affects best-move selection.
+void sim_results_set_utility_w_spread(SimResults *sim_results,
+                                      double utility_w_spread);
 uint64_t sim_results_get_num_infer_leaves(const SimResults *sim_results);
 void sim_results_set_num_infer_leaves(SimResults *sim_results,
                                       uint64_t num_infer_leaves);

--- a/src/impl/simmer.c
+++ b/src/impl/simmer.c
@@ -118,6 +118,7 @@ void simulate(SimArgs *sim_args, SimCtx **sim_ctx, SimResults *sim_results,
   sim_results_set_rack(sim_results, move_list_get_rack(sim_args->move_list));
   sim_results_set_known_opp_rack(sim_results, sim_args->known_opp_rack);
   sim_results_set_cutoff(sim_results, sim_args->bai_options.cutoff);
+  sim_results_set_utility_w_spread(sim_results, sim_args->utility_w_spread);
   sim_results_set_num_infer_leaves(sim_results, num_infer_leaves);
 
   bai(&sim_args->bai_options, (*sim_ctx)->rvs, (*sim_ctx)->rng,

--- a/test/sim_test.c
+++ b/test/sim_test.c
@@ -6,6 +6,7 @@
 #include "../src/def/thread_control_defs.h"
 #include "../src/ent/bag.h"
 #include "../src/ent/bai_result.h"
+#include "../src/ent/equity.h"
 #include "../src/ent/game.h"
 #include "../src/ent/letter_distribution.h"
 #include "../src/ent/move.h"
@@ -1140,6 +1141,44 @@ void test_snoprune_exchange_and_pass(void) {
   config_destroy(config);
 }
 
+void test_sim_best_move_equity_tiebreak(void) {
+  // Regression for best-move selection under the pure-win% utility default
+  // (uspread = 0). BAI's sample utility is then the raw 0/0.5/1 win outcome,
+  // which loses all gradient once win% saturates: in this fully-determined
+  // endgame (empty bag, both racks known) every candidate's rollout returns
+  // a loss, every arm's sample mean is identical, and BAI's "best arm" is
+  // effectively arbitrary. Game-pair autoplay measured this bleeding 5-60+
+  // points per decided turn (in this exact position it played the rank-7
+  // 28-point SKEIN over the 48-point E8 (A)KES). sim_results_get_best_move
+  // must fall back to the win%-with-equity-tiebreak comparator so the
+  // played move is the equity-best arm among the win%-tied field.
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -wmp true -s1 score -s2 score -r1 all -r2 all "
+      "-numplays 15 -plies 4 -threads 1 -iter 1000 -seed 42 "
+      "-uwin 1 -uspread 0 -uspreadscale 100");
+  load_and_exec_config_or_die(
+      config, "cgp IMSHI2F7/2A2B1I3PROG/2G2UPS5B1/2OU1TEC2MEAT1/2uN1AE1WRAXLED/"
+              "2IT1N4l2C1/2NO1O1OILIEST1/3WANTY2G1A2/2JA1E3AN1V2/1VAR5ZE1ORT/"
+              "1RID5OD1Y2/HI13/EL13/L14/E14 EFIKNRS/DEEOQUU 330/478 0");
+  load_and_exec_config_or_die(config, "gen");
+  SimResults *sim_results = config_get_sim_results(config);
+  const error_code_t status =
+      config_simulate_and_return_status(config, NULL, NULL, sim_results);
+  assert(status == ERROR_STATUS_SUCCESS);
+  const Move *best = sim_results_get_best_move(sim_results);
+  assert(best != NULL);
+  StringBuilder *move_string_builder = string_builder_create();
+  string_builder_add_move_description(move_string_builder, best,
+                                      config_get_ld(config));
+  printf("equity tiebreak best move: %s (score %d)\n",
+         string_builder_peek(move_string_builder),
+         equity_to_int(move_get_score(best)));
+  assert(strings_equal(string_builder_peek(move_string_builder), "E8 .KES"));
+  assert(equity_to_int(move_get_score(best)) == 48);
+  string_builder_destroy(move_string_builder);
+  config_destroy(config);
+}
+
 void test_sim(void) {
   const char *sim_perf_iters = getenv("SIM_PERF_ITERS");
   if (sim_perf_iters) {
@@ -1161,6 +1200,7 @@ void test_sim(void) {
     test_sim_one_ply();
     test_sim_ctx();
     test_sim_endgame();
+    test_sim_best_move_equity_tiebreak();
     test_sim_avoid_prune();
     test_sim_avoid_prune_multi();
     test_sim_avoid_prune_cmd();


### PR DESCRIPTION
## The bug

Since `31758629` (the sigmoid utility-blend commit), `sim_results_get_best_move` — the move autoplay actually plays — has preferred `bai_result_get_best_arm`, i.e. the arm with the highest mean *sample utility*. With the default `uspread=0`, that utility is the raw 0/0.5/1 win outcome, which **loses all gradient whenever win% saturates (decided games) or ties exactly**: every arm's mean is identical, BAI's argmax is arbitrary among the tied field, and the sim plays it as-is.

That commit's message said defaults were behavior-neutral — true for the *sample values*, but the *selection path* changed for everyone: the previous code selected via the win%-comparator, which breaks win%-within-cutoff ties by mean equity. That tiebreak was silently lost.

Note the displayed leaderboard still sorts with the equity tiebreak — so the played move could be rank 7/11/15 of the sim's own displayed table.

## Measured impact (game-pair autoplay, real games)

The pure-win% player played a move **other than the displayed win%-#1 on 16.1% of turns** (23/143 in a 6-pair 4-ply diagnostic), including −20 and −63 point picks at saturated win% (e.g. rank-7 `SKEIN` 28 over `(A)KES` 48 with every candidate at wp 0.00; rank-6 `(J)A` 9 over the 72-point bingo `AERIEST` with six arms tied at wp 57.40), declined bingos, and six-pass loops in decided endgames. Roughly **30+ points/game bled** in aggregate — this artifact was the bulk of an earlier sweep's apparent "+72 spread/pair from uspread=0.5" result (the spread term was masking the defect, not outplaying anyone).

## The fix

Record the sim's `utility_w_spread` in `SimResults` (set by `simulate()`, same pattern as `cutoff`). In `sim_results_get_best_move`:
- `uspread == 0`: select via the existing win%-with-equity-tiebreak comparator (`sim_results_get_best_move_index`) — restoring the pre-`31758629` selection semantics and matching the displayed sort.
- `uspread > 0`: BAI's blend-aware arm remains authoritative, unchanged.

## Validation

- **Regression test** (`test_sim_best_move_equity_tiebreak`, in the `sim` suite): the exact measured position — empty bag, every candidate's win% saturated at 0 — must play the 48-point equity-best `E8 (A)KES` (previously played the rank-7, 28-point `SKEIN`).
- **End-to-end**: re-running the same 6 diagnostic game pairs, the played-vs-win%-#1 mismatch rate drops **16.1% → 1.4%**, and both survivors are zero-cost anagram ties (`LUTE`/`TULE`). `uspread>0` behavior unchanged.
- **Game-pair measurement** (fixed vs unfixed control, identical seeds/settings vs an `uspread=0.5` opponent): control avg score 425.9 → 443.8 (**~+61 spread/pair recovered by this fix alone**); the residual true effect of `uspread=0.5` is +8-13/pair (measured at p<0.0001 across three protocols up to 33k games) with win% dead even (49.95%, CI ±0.55% at 33k games).
- cppcheck / clang-tidy / find_circ_deps clean; `sim` and `config` suites pass.

## Related

- Supersedes the rationale of #582 (uspread default change): that PR's motivating sweep was dominated by this artifact and should be re-judged on the corrected numbers (+8-13 spread/pair, no win% effect) after this fix lands.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_019SJ8s3CzxxYNbQpQvDAjrX