### PR TITLE
PEG opponent-leave inference: exact prior evaluation in peg_solve + ground-truth A/B benchmark

### DIFF
--- a/src/ent/alias_method.h
+++ b/src/ent/alias_method.h
@@ -159,4 +159,36 @@ static inline bool alias_method_sample(AliasMethod *am, XoshiroPRNG *prng,
   return true;
 }
 
+// If the distribution is a single point mass (exactly one distinct rack),
+// decode it into `out` and return true; otherwise return false. Lets a consumer
+// enumerate that leave's completions EXACTLY instead of sampling -- sampling a
+// degenerate prior with few draws mis-ranks candidates via a winner's curse.
+static inline bool alias_method_single_rack(const AliasMethod *am, Rack *out) {
+  if (am == NULL || am->num_items != 1 || am->total_item_count == 0) {
+    return false;
+  }
+  rack_decode(&am->items[0].rack, out);
+  return true;
+}
+
+// Number of distinct support points (leaves). item->count/rack are preserved by
+// alias_method_generate_tables, so the support can be enumerated exactly rather
+// than sampled (see the point-mass rationale above; this generalizes it).
+static inline int alias_method_num_items(const AliasMethod *am) {
+  return am == NULL ? 0 : (int)am->num_items;
+}
+
+// Decode support point `i` into `out` and return its (relative) weight count.
+static inline uint32_t alias_method_get_item(const AliasMethod *am, int i,
+                                             Rack *out) {
+  rack_decode(&am->items[i].rack, out);
+  return am->items[i].count;
+}
+
+// Support point `i`'s (relative) weight count, without decoding the rack -- for
+// selecting the highest-mass leaves before enumerating.
+static inline uint32_t alias_method_item_count(const AliasMethod *am, int i) {
+  return am->items[i].count;
+}
+
 #endif

--- a/src/ent/sim_args.h
+++ b/src/ent/sim_args.h
@@ -22,6 +22,10 @@ typedef struct SimArgs {
   WinPct *win_pcts;
   bool use_inference;
   bool use_heat_map;
+  // When set (with use_inference), inference_results already holds a leave
+  // distribution (e.g. from simmed inference) and simulate() must NOT
+  // overwrite it by running static inference itself.
+  bool inference_results_precomputed;
   InferenceResults *inference_results;
   InferenceArgs inference_args;
   int num_threads;
@@ -62,6 +66,9 @@ sim_args_fill(const int num_plies, const MoveList *move_list,
   sim_args->game = game;
   sim_args->use_inference = sim_with_inference;
   sim_args->use_heat_map = use_heat_map;
+  // Default: simulate() runs static inference itself. Callers that supply a
+  // precomputed distribution (simmed inference) set this after filling.
+  sim_args->inference_results_precomputed = false;
   sim_args->num_threads = num_threads;
   sim_args->print_interval = print_interval;
   sim_args->max_num_display_plays = max_num_display_plays;

--- a/src/ent/win_pct.c
+++ b/src/ent/win_pct.c
@@ -20,6 +20,10 @@ struct WinPct {
 
 const char *win_pct_get_name(const WinPct *wp) { return wp->name; }
 
+int win_pct_get_max_tiles_unseen(const WinPct *wp) {
+  return (int)wp->max_tiles_unseen;
+}
+
 float win_pct_get(const WinPct *wp, int spread_plus_leftover,
                   unsigned int game_unseen_tiles) {
   if (spread_plus_leftover > wp->max_spread) {

--- a/src/ent/win_pct.h
+++ b/src/ent/win_pct.h
@@ -10,6 +10,7 @@ WinPct *win_pct_create(const char *data_paths, const char *win_pct_name,
                        ErrorStack *error_stack);
 void win_pct_destroy(WinPct *wp);
 const char *win_pct_get_name(const WinPct *wp);
+int win_pct_get_max_tiles_unseen(const WinPct *wp);
 float win_pct_get(const WinPct *wp, int spread_plus_leftover,
                   unsigned int game_unseen_tiles);
 bool is_win_pct_within_cutoff(const double win_pct, const double cutoff);

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -2503,6 +2503,21 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
       const bool is_outplay =
           small_move_get_tiles_played(small_move) == stm_rack_tiles;
 
+      // Outplays use play_move_endgame_outplay (below), which deliberately does
+      // NOT empty the rack, so stm_rack still holds the full pre-move rack.
+      // zobrist_add_move treats its rack arg as the post-move leftover, which
+      // for an outplay is empty; passing the stale full rack double-counts the
+      // played tiles (placeholder = placed + full = 2*placed) and can index the
+      // rack hash table out of bounds -- e.g. outplaying four S's yields
+      // placeholder[S] = 8 into an 8-slot (0..RACK_SIZE) row. Use an empty
+      // leftover for outplays.
+      Rack outplay_leftover;
+      if (is_outplay) {
+        rack_set_dist_size_and_reset(&outplay_leftover,
+                                     rack_get_dist_size(stm_rack));
+      }
+      const Rack *move_leftover_rack = is_outplay ? &outplay_leftover : stm_rack;
+
       // Track whether thread 0 is inside root move #1's subtree
       if (is_root && worker->ordinal == 0 && pass == 0) {
         worker->in_first_root_move = (idx == 0);
@@ -2542,7 +2557,7 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
       if (worker->solver->transposition_table_optim) {
         child_key = zobrist_add_move(
             worker->solver->transposition_table->zobrist, node_key,
-            worker->move_list->spare_move, stm_rack,
+            worker->move_list->spare_move, move_leftover_rack,
             on_turn_idx == worker->solver->solving_player,
             game_get_consecutive_scoreless_turns(worker->game_copy),
             last_consecutive_scoreless_turns);

--- a/src/impl/inference.h
+++ b/src/impl/inference.h
@@ -10,6 +10,7 @@
 #include "../ent/rack.h"
 #include "../ent/thread_control.h"
 #include "../util/io_util.h"
+#include <stdint.h>
 
 typedef struct InferenceCtx InferenceCtx;
 
@@ -19,5 +20,14 @@ void infer(InferenceArgs *args, InferenceCtx **ctx, InferenceResults *results,
            ErrorStack *error_stack);
 void infer_without_ctx(InferenceArgs *args, InferenceResults *results,
                        ErrorStack *error_stack);
+
+// Shared with simmed_inference (simulation-based inference), which records
+// weighted candidate leaves through the same accounting as static inference.
+uint64_t get_number_of_draws_for_rack(const Rack *bag_as_rack,
+                                      const Rack *rack);
+void record_valid_leave(const Rack *rack, InferenceResults *results,
+                        inference_stat_t inference_stat_type,
+                        double current_leave_value,
+                        uint64_t number_of_draws_for_leave);
 
 #endif

--- a/src/impl/peg.c
+++ b/src/impl/peg.c
@@ -37,6 +37,7 @@
 #include "peg_combinatorics.h"
 #include "peg_pool.h"
 #include "word_prune.h"
+#include <assert.h>
 #include <limits.h>
 #include <stdatomic.h>
 #include <stdint.h>
@@ -1895,11 +1896,16 @@ static void peg_eval_inference_samples(PegEvalCtx *ctx,
     // Sample an opponent leave from the inference (empty prior => uniform rack).
     rack_reset(&leave);
     alias_method_sample(am, prng, &leave);
-    // Pool = the unseen tiles not pinned by the leave.
+    // Pool = the unseen tiles not pinned by the leave. The inference targets the
+    // opponent's immediately preceding move and only the opponent has acted
+    // since, so every sampled leave is a subset of the mover's unseen (leave <=
+    // opponent rack <= unseen) and rem is never negative -- the same invariant
+    // the simmer relies on when set_random_rack draws the leave strictly.
     MachineLetter pool[RACK_SIZE + PEG_MAX_BAG];
     int pool_n = 0;
     for (int ml = 0; ml < ctx->ld_size; ml++) {
       const int rem = (int)ctx->unseen[ml] - (int)rack_get_letter(&leave, ml);
+      assert(rem >= 0);
       for (int i = 0; i < rem; i++) {
         pool[pool_n++] = (MachineLetter)ml;
       }

--- a/src/impl/peg.c
+++ b/src/impl/peg.c
@@ -12,12 +12,14 @@
 #include "../def/peg_defs.h"
 #include "../def/rack_defs.h"
 #include "../def/thread_control_defs.h"
+#include "../ent/alias_method.h"
 #include "../ent/bag.h"
 #include "../ent/board.h"
 #include "../ent/dictionary_word.h"
 #include "../ent/endgame_results.h"
 #include "../ent/equity.h"
 #include "../ent/game.h"
+#include "../ent/inference_results.h"
 #include "../ent/kwg.h"
 #include "../ent/letter_distribution.h"
 #include "../ent/move.h"
@@ -25,6 +27,7 @@
 #include "../ent/rack.h"
 #include "../ent/thread_control.h"
 #include "../ent/transposition_table.h"
+#include "../ent/xoshiro.h"
 #include "../util/fnv.h"
 #include "../util/io_util.h"
 #include "endgame.h"
@@ -1820,6 +1823,12 @@ typedef struct PegCandJob {
   // of enumerating scenarios (see PegArgs.eval_bag_order).
   const MachineLetter *eval_bag_order;
   int eval_bag_order_len;
+  // When opp_leave_prior != NULL, sample inference_samples opponent racks from
+  // it instead of enumerating (see PegArgs.opp_leave_prior). Seeded per
+  // candidate from inference_seed for thread-safe reproducibility.
+  const InferenceResults *opp_leave_prior;
+  int inference_samples;
+  uint64_t inference_seed;
 } PegCandJob;
 
 // Evaluate exactly one bag ordering for the cand (no enumeration): the mover
@@ -1860,6 +1869,86 @@ static void peg_eval_fixed_ordering(PegEvalCtx *ctx,
   ctx->spread_weight = (double)value;
   ctx->weight_sum = 1;
   ctx->n_scenarios = 1;
+}
+
+// Inference-weighted scenario sampling (the pre-endgame analogue of the
+// simmer's inference-weighted opponent draws). Instead of enumerating the
+// uniform unseen splits, draw n_samples opponent racks from the leave-inference
+// prior: sample a leave from its AliasMethod, then complete it to a full rack
+// from the remaining unseen (mirroring set_random_rack). The leftover unseen is
+// the bag -- the mover draws its k_drawn tiles off the front and the rest is the
+// bag ordering. peg_make_post_cand_game derives the opponent rack as
+// unseen - (mover_drawn ++ bag_remaining), which equals the sampled rack by
+// construction. Each sample carries weight 1, so the caller reads win%/spread
+// exactly as for the enumerated path.
+static void peg_eval_inference_samples(PegEvalCtx *ctx,
+                                       const InferenceResults *prior,
+                                       int n_samples, XoshiroPRNG *prng) {
+  AliasMethod *am =
+      inference_results_get_alias_method((InferenceResults *)prior);
+  Rack leave;
+  rack_set_dist_size_and_reset(&leave, ctx->ld_size);
+  for (int s = 0; s < n_samples; s++) {
+    if (ctx->deadline_ns != 0 && ctimer_monotonic_ns() >= ctx->deadline_ns) {
+      break;
+    }
+    // Sample an opponent leave from the inference (empty prior => uniform rack).
+    rack_reset(&leave);
+    alias_method_sample(am, prng, &leave);
+    // Pool = the unseen tiles not pinned by the leave.
+    MachineLetter pool[RACK_SIZE + PEG_MAX_BAG];
+    int pool_n = 0;
+    for (int ml = 0; ml < ctx->ld_size; ml++) {
+      const int rem = (int)ctx->unseen[ml] - (int)rack_get_letter(&leave, ml);
+      for (int i = 0; i < rem; i++) {
+        pool[pool_n++] = (MachineLetter)ml;
+      }
+    }
+    // Shuffle: the front completes the opponent's rack (leave + draws); the
+    // remainder is the bag (the mover's k_drawn draws ++ the bag ordering).
+    for (int i = 0; i < pool_n; i++) {
+      const uint64_t j =
+          (uint64_t)i + prng_get_random_number(prng, (uint64_t)(pool_n - i));
+      const MachineLetter tmp = pool[i];
+      pool[i] = pool[j];
+      pool[j] = tmp;
+    }
+    int need = RACK_SIZE - rack_get_total_letters(&leave);
+    if (need < 0) {
+      need = 0;
+    }
+    int p = need < pool_n ? need : pool_n; // opp completion consumes pool[0..need)
+    MachineLetter mover_drawn[PEG_MAX_BAG + 1];
+    MachineLetter bag_remaining[PEG_MAX_BAG + 1];
+    int n_mover = 0;
+    for (; n_mover < ctx->k_drawn && p < pool_n; n_mover++, p++) {
+      mover_drawn[n_mover] = pool[p];
+    }
+    int n_bag_rem = 0;
+    for (; p < pool_n; p++) {
+      bag_remaining[n_bag_rem++] = pool[p];
+    }
+    Game *game = peg_make_post_cand_game(
+        ctx->worker, ctx->template_src, ctx->mover_idx, ctx->unseen,
+        ctx->ld_size, ctx->k_drawn, mover_drawn, n_bag_rem, bag_remaining);
+    const int32_t value = peg_eval_leaf(ctx, game);
+    if (ctx->progress != NULL && ctx->progress->on_scenario_done != NULL) {
+      ctx->progress->on_scenario_done(ctx->progress->stage_idx, ctx->cand_idx,
+                                      ctx->n_scenarios, value, 1,
+                                      ctx->progress->user_data);
+    }
+    ctx->total_weight += 1.0;
+    if (value > 0) {
+      ctx->win_weight += 1.0;
+      ctx->win_count++;
+    } else if (value == 0) {
+      ctx->win_weight += 0.5;
+      ctx->tie_count++;
+    }
+    ctx->spread_weight += (double)value;
+    ctx->weight_sum += 1;
+    ctx->n_scenarios++;
+  }
 }
 
 static void peg_cand_worker_fn(void *arg, int worker_idx) {
@@ -1908,6 +1997,15 @@ static void peg_cand_worker_fn(void *arg, int worker_idx) {
   if (job->eval_bag_order_len > 0) {
     // Pinned single scenario: evaluate exactly the caller's bag ordering.
     peg_eval_fixed_ordering(&ctx, job->eval_bag_order, job->eval_bag_order_len);
+  } else if (job->opp_leave_prior != NULL) {
+    // Inference-weighted sampling instead of uniform enumeration. Seed a
+    // per-candidate PRNG so the sample is reproducible and independent of how
+    // the pool schedules candidates across worker threads.
+    XoshiroPRNG *prng =
+        prng_create(job->inference_seed + (uint64_t)job->cand_rank + 1);
+    peg_eval_inference_samples(&ctx, job->opp_leave_prior,
+                               job->inference_samples, prng);
+    prng_destroy(prng);
   } else {
     MachineLetter mover_drawn[PEG_MAX_BAG + 1];
     MachineLetter bag_remaining[PEG_MAX_BAG + 1];
@@ -2009,7 +2107,8 @@ static void peg_eval_candidates(
     int scenario_stride, int64_t deadline_ns, ThreadControl *thread_control,
     PegPoll *poll, const PegProgress *progress,
     const MachineLetter *eval_bag_order, int eval_bag_order_len,
-    PegRankedCand *ranked) {
+    const InferenceResults *opp_leave_prior, int inference_samples,
+    uint64_t inference_seed, PegRankedCand *ranked) {
   PegCandJob *jobs = malloc_or_die((size_t)n * sizeof(PegCandJob));
   for (int i = 0; i < n; i++) {
     jobs[i].base_game = game;
@@ -2031,6 +2130,9 @@ static void peg_eval_candidates(
     jobs[i].cand_rank = i;
     jobs[i].eval_bag_order = eval_bag_order;
     jobs[i].eval_bag_order_len = eval_bag_order_len;
+    jobs[i].opp_leave_prior = opp_leave_prior;
+    jobs[i].inference_samples = inference_samples;
+    jobs[i].inference_seed = inference_seed;
   }
   if (pool) {
     void **ptrs = malloc_or_die((size_t)n * sizeof(void *));
@@ -2650,7 +2752,8 @@ void peg_solve(const PegArgs *args, PegResult *out, ErrorStack *error_stack) {
                         args->inner_top_k, /*fidelity_plies=*/0,
                         scenario_stride, deadline_ns, args->thread_control,
                         args->poll, &progress, args->eval_bag_order,
-                        args->eval_bag_order_len, ranked);
+                        args->eval_bag_order_len, args->opp_leave_prior,
+                        args->inference_samples, args->inference_seed, ranked);
     qsort(ranked, (size_t)n_cands, sizeof(PegRankedCand), peg_rank_cmp);
     // Drop budget-skipped sentinels (win_pct < 0) from the carried set: they
     // sort to the bottom, so the real candidates occupy [0, n_real).

--- a/src/impl/peg.c
+++ b/src/impl/peg.c
@@ -58,6 +58,16 @@
 // PegArgs.stage_top_k.
 static const int PEG_DEFAULT_HALVING_COUNTS[] = {32, 16, 8, 4, 2};
 
+// Narrowed schedule used automatically in inference mode (opp_leave_prior set,
+// no caller-supplied stage_top_k). The halving stages SAMPLE the opponent rack
+// (inference_samples scenarios per candidate), so with the full 32-wide field
+// the sampled endgame refinement cannot finish in a normal budget and the solve
+// falls back to the greedy seed -- evaluating the opponent info only at stage-0
+// fidelity. Keeping just the top few candidates (the greedy seed still ranks the
+// whole field first) lets the inference solve reach deep fidelity in the same
+// budget. This is the tail of the default schedule.
+static const int PEG_INFERENCE_HALVING_COUNTS[] = {8, 4, 2};
+
 // Solve-scoped cache mapping a post-candidate board signature to its
 // per-candidate pruned KWG. At an emptier (0-in-bag) endgame leaf the pruned
 // KWG depends only on the post-cand board and the union of both racks (all
@@ -877,6 +887,13 @@ typedef struct PegEvalCtx {
   const Game *template_src;
   int mover_idx;
   const uint8_t *unseen;
+  // Pinned opponent leave (per-letter counts, NULL = none). When set,
+  // peg_enum_splits reserves leave[ml] tiles of each letter for the opponent
+  // (avail = unseen[ml] - leave[ml]), so every enumerated split's opponent rack
+  // contains the leave -- an EXACT enumeration of a point-mass prior's
+  // completions, replacing the sampled path (which mis-ranks via a winner's
+  // curse). Lives only for the duration of the enumeration call.
+  const uint8_t *pinned_leave;
   int ld_size;
   const Move *cand;
   int bag_size;
@@ -1745,8 +1762,33 @@ static void peg_eval_split(PegEvalCtx *ctx, const MachineLetter *mover_drawn,
   }
 }
 
+// Detect a point-mass opponent-leave prior and extract its leave as per-letter
+// counts. A degenerate (single-support) prior sampled with few draws mis-ranks
+// candidates via a winner's curse; enumerating the pinned leave's completions
+// exactly (peg_enum_splits with ctx->pinned_leave set) removes that noise and,
+// unlike the sampled path, is applied at the deep stages too. Returns true and
+// fills leave_counts[0..ld_size) on a point mass, else false.
+static bool peg_prior_point_mass(const InferenceResults *prior, int ld_size,
+                                 uint8_t *leave_counts) {
+  if (prior == NULL) {
+    return false;
+  }
+  AliasMethod *am =
+      inference_results_get_alias_method((InferenceResults *)prior);
+  Rack leave;
+  rack_set_dist_size_and_reset(&leave, ld_size);
+  if (!alias_method_single_rack(am, &leave)) {
+    return false;
+  }
+  for (int ml = 0; ml < ld_size; ml++) {
+    leave_counts[ml] = (uint8_t)rack_get_letter(&leave, ml);
+  }
+  return true;
+}
+
 // Recursively choose, per machine letter, how many tiles go to the mover's
-// draw (m) and to the bag remainder (b), with m+b <= unseen[ml], mover total ==
+// draw (m) and to the bag remainder (b), with m+b <= unseen[ml] - leave[ml]
+// (the pinned leave, if any, is reserved for the opponent), mover total ==
 // k_drawn and bag-remainder total == n_bag_remaining. Opp gets the complement.
 static void peg_enum_splits(PegEvalCtx *ctx, int ml, int mover_left,
                             int bag_rem_left, int64_t weight,
@@ -1779,14 +1821,27 @@ static void peg_enum_splits(PegEvalCtx *ctx, int ml, int mover_left,
     }
     return;
   }
-  const int avail = ctx->unseen[ml];
+  // Reserve the pinned leave for the opponent: only (unseen - leave) tiles of
+  // this letter are eligible for the mover draw / bag, so `avail` BOUNDS the
+  // split and opp = complement always contains leave[ml]. The split WEIGHT,
+  // however, counts labeled deals over the FULL unseen[ml] pool: restricting the
+  // enumeration to opp >= leave does not change the relative multinomial count
+  // of an allowed split, so weighting over the reduced `avail` would bias win%
+  // (it under-weights splits where opp keeps spare copies of a leave letter).
+  // With no pinned leave, full == avail and this is the original enumeration.
+  const int full = ctx->unseen[ml];
+  const int avail =
+      full - (ctx->pinned_leave != NULL ? (int)ctx->pinned_leave[ml] : 0);
+  // A pinned leave must be a subset of the unseen pool (the same invariant the
+  // sampled path asserts); otherwise avail < 0 and the split is infeasible.
+  assert(avail >= 0);
   const int max_mover = mover_left < avail ? mover_left : avail;
   for (int to_mover = 0; to_mover <= max_mover; to_mover++) {
     const int max_bag =
         bag_rem_left < (avail - to_mover) ? bag_rem_left : (avail - to_mover);
     for (int to_bag = 0; to_bag <= max_bag; to_bag++) {
-      const int64_t add_weight = peg_binomial(avail, to_mover) *
-                                 peg_binomial(avail - to_mover, to_bag);
+      const int64_t add_weight = peg_binomial(full, to_mover) *
+                                 peg_binomial(full - to_mover, to_bag);
       for (int i = 0; i < to_mover; i++) {
         mover_drawn[n_mover + i] = (MachineLetter)ml;
       }
@@ -1798,6 +1853,45 @@ static void peg_enum_splits(PegEvalCtx *ctx, int ml, int mover_left,
                       bag_remaining, n_bag_rem + to_bag);
     }
   }
+}
+
+// Sum over all splits (for a pinned `leave`) of the per-split full_weight -- the
+// same quantity peg_enum_splits accumulates into ctx->total_weight when driven
+// with initial weight 1 -- computed WITHOUT any leaf evaluation. Mirrors
+// peg_enum_splits' avail bound + full-`unseen` multinomial weights + k_drawn!.
+// Lets the COLLECT-mode support enumeration (peg_collect_support) pre-scale each
+// leaf's initial weight to w_i / total_i so the emitted jobs carry the correct
+// prior-weighted conditional weight (the inline path reads total_i from the
+// accumulator instead; collect mode can't, so it needs this).
+static int64_t peg_enum_total(const uint8_t *unseen, const uint8_t *leave,
+                              int ld_size, int k_drawn, int ml, int mover_left,
+                              int bag_rem_left, int64_t weight) {
+  if (ml == ld_size) {
+    if (mover_left == 0 && bag_rem_left == 0) {
+      int64_t full = weight;
+      for (int f = 2; f <= k_drawn; f++) {
+        full *= f;
+      }
+      return full;
+    }
+    return 0;
+  }
+  const int full = unseen[ml];
+  const int avail = full - (leave != NULL ? (int)leave[ml] : 0);
+  const int max_mover = mover_left < avail ? mover_left : avail;
+  int64_t sum = 0;
+  for (int to_mover = 0; to_mover <= max_mover; to_mover++) {
+    const int max_bag =
+        bag_rem_left < (avail - to_mover) ? bag_rem_left : (avail - to_mover);
+    for (int to_bag = 0; to_bag <= max_bag; to_bag++) {
+      const int64_t add_weight = peg_binomial(full, to_mover) *
+                                 peg_binomial(full - to_mover, to_bag);
+      sum += peg_enum_total(unseen, leave, ld_size, k_drawn, ml + 1,
+                            mover_left - to_mover, bag_rem_left - to_bag,
+                            weight * add_weight);
+    }
+  }
+  return sum;
 }
 
 // One candidate-evaluation job (cand at a given fidelity), dispatched to a
@@ -1872,19 +1966,18 @@ static void peg_eval_fixed_ordering(PegEvalCtx *ctx,
   ctx->n_scenarios = 1;
 }
 
-// Inference-weighted scenario sampling (the pre-endgame analogue of the
-// simmer's inference-weighted opponent draws). Instead of enumerating the
-// uniform unseen splits, draw n_samples opponent racks from the leave-inference
-// prior: sample a leave from its AliasMethod, then complete it to a full rack
-// from the remaining unseen (mirroring set_random_rack). The leftover unseen is
-// the bag -- the mover draws its k_drawn tiles off the front and the rest is the
-// bag ordering. peg_make_post_cand_game derives the opponent rack as
-// unseen - (mover_drawn ++ bag_remaining), which equals the sampled rack by
-// construction. Each sample carries weight 1, so the caller reads win%/spread
-// exactly as for the enumerated path.
-static void peg_eval_inference_samples(PegEvalCtx *ctx,
-                                       const InferenceResults *prior,
-                                       int n_samples, XoshiroPRNG *prng) {
+// Collect/inline analog of peg_eval_inference_samples for MULTI-SUPPORT priors:
+// draw n_samples opponent racks from the prior and route each split through
+// peg_eval_split, which emits a scenario job in collect mode (so the DEEP stages
+// evaluate a multi-leave prior instead of ignoring it) or evaluates inline
+// otherwise. A point-mass prior is instead enumerated exactly (peg_enum_splits +
+// pinned_leave); a many-leave prior is sampled here because enumerating every
+// leave's completions is not generally affordable at the deep stages. The
+// sampling carries the usual few-draw variance -- a curse-free exact version
+// would enumerate the support weighted by prior mass (follow-on).
+static void peg_sample_splits_from_prior(PegEvalCtx *ctx,
+                                         const InferenceResults *prior,
+                                         int n_samples, XoshiroPRNG *prng) {
   AliasMethod *am =
       inference_results_get_alias_method((InferenceResults *)prior);
   Rack leave;
@@ -1893,14 +1986,8 @@ static void peg_eval_inference_samples(PegEvalCtx *ctx,
     if (ctx->deadline_ns != 0 && ctimer_monotonic_ns() >= ctx->deadline_ns) {
       break;
     }
-    // Sample an opponent leave from the inference (empty prior => uniform rack).
     rack_reset(&leave);
     alias_method_sample(am, prng, &leave);
-    // Pool = the unseen tiles not pinned by the leave. The inference targets the
-    // opponent's immediately preceding move and only the opponent has acted
-    // since, so every sampled leave is a subset of the mover's unseen (leave <=
-    // opponent rack <= unseen) and rem is never negative -- the same invariant
-    // the simmer relies on when set_random_rack draws the leave strictly.
     MachineLetter pool[RACK_SIZE + PEG_MAX_BAG];
     int pool_n = 0;
     for (int ml = 0; ml < ctx->ld_size; ml++) {
@@ -1910,8 +1997,6 @@ static void peg_eval_inference_samples(PegEvalCtx *ctx,
         pool[pool_n++] = (MachineLetter)ml;
       }
     }
-    // Shuffle: the front completes the opponent's rack (leave + draws); the
-    // remainder is the bag (the mover's k_drawn draws ++ the bag ordering).
     for (int i = 0; i < pool_n; i++) {
       const uint64_t j =
           (uint64_t)i + prng_get_random_number(prng, (uint64_t)(pool_n - i));
@@ -1934,27 +2019,211 @@ static void peg_eval_inference_samples(PegEvalCtx *ctx,
     for (; p < pool_n; p++) {
       bag_remaining[n_bag_rem++] = pool[p];
     }
-    Game *game = peg_make_post_cand_game(
-        ctx->worker, ctx->template_src, ctx->mover_idx, ctx->unseen,
-        ctx->ld_size, ctx->k_drawn, mover_drawn, n_bag_rem, bag_remaining);
-    const int32_t value = peg_eval_leaf(ctx, game);
-    if (ctx->progress != NULL && ctx->progress->on_scenario_done != NULL) {
-      ctx->progress->on_scenario_done(ctx->progress->stage_idx, ctx->cand_idx,
-                                      ctx->n_scenarios, value, 1,
-                                      ctx->progress->user_data);
-    }
-    ctx->total_weight += 1.0;
-    if (value > 0) {
-      ctx->win_weight += 1.0;
-      ctx->win_count++;
-    } else if (value == 0) {
-      ctx->win_weight += 0.5;
-      ctx->tie_count++;
-    }
-    ctx->spread_weight += (double)value;
-    ctx->weight_sum += 1;
-    ctx->n_scenarios++;
+    // Each sample carries weight 1 (peg_eval_split emits a job in collect mode
+    // or evaluates + accumulates inline).
+    peg_eval_split(ctx, mover_drawn, n_bag_rem, bag_remaining, /*weight=*/1);
   }
+}
+
+// Enumerate a MULTI-SUPPORT prior's support EXACTLY (the curse-free alternative
+// to sampling): for each support leaf L_i (prior weight w_i), pin L_i and
+// enumerate its completions, then combine per-leaf conditional results weighted
+// by prior mass:
+//   win% = (sum_i w_i * win_i/total_i) / (sum_i w_i),
+// where total_i = peg_enum_total(L_i) is that leaf's total enumeration weight
+// (so a leaf with a larger completion space is not over-counted). INLINE ONLY:
+// it drives peg_enum_splits per leaf into the ctx accumulators and diffs them,
+// so ctx must not be in collect mode (out_jobs must be NULL).
+static void peg_enumerate_support(PegEvalCtx *ctx,
+                                  const InferenceResults *prior,
+                                  int n_bag_remaining) {
+  AliasMethod *am =
+      inference_results_get_alias_method((InferenceResults *)prior);
+  const int n_items = alias_method_num_items(am);
+  // Above this support size, exact enumeration evaluates too many completions
+  // (every completion of every leaf, ~N x more scenarios than sampling) and
+  // starves the STAGED solve of depth -- empirically that leaves the candidate
+  // stuck at the weak greedy seed and does WORSE than uniform. So a many-leaf
+  // real-inference prior falls back to uniform enumeration here (safe, coherent,
+  // ignores the prior at this evaluation); only a SMALL support -- where exact
+  // enumeration is cheap and curse-free, the regime where it beats sampling --
+  // is enumerated. (A cheap-enough exact method for large multi-leaf priors, or
+  // deep-stage support enumeration for coherence, is future work.)
+  enum { PEG_SUPPORT_ENUM_MAX = 4 };
+  // Fall back to uniform for an EMPTY support (an inference that found nothing
+  // must not zero out every candidate's win% -- that ranks the field by
+  // garbage) and for a too-large support (cost; see below).
+  if (n_items == 0 || n_items > PEG_SUPPORT_ENUM_MAX) {
+    MachineLetter mover_drawn[PEG_MAX_BAG + 1];
+    MachineLetter bag_remaining[PEG_MAX_BAG + 1];
+    ctx->pinned_leave = NULL;
+    peg_enum_splits(ctx, /*ml=*/0, ctx->k_drawn, n_bag_remaining, /*weight=*/1,
+                    mover_drawn, 0, bag_remaining, 0);
+    return;
+  }
+  // Enumerate the highest-mass leaves first, capped: cost scales with the
+  // support size, so process the top PEG_SUPPORT_ENUM_CAP by weight (descending)
+  // -- a deterministic, mass-prioritized truncation. If the deadline then cuts
+  // the loop it drops the LOWEST-mass leaves (least biasing), and a support
+  // within the cap is enumerated in full. Selection is an insertion into a
+  // sorted top-k array (O(n_items * cap), cap small).
+  enum { PEG_SUPPORT_ENUM_CAP = 64 };
+  int top[PEG_SUPPORT_ENUM_CAP];
+  uint32_t top_w[PEG_SUPPORT_ENUM_CAP];
+  int n_top = 0;
+  for (int i = 0; i < n_items; i++) {
+    const uint32_t c = alias_method_item_count(am, i);
+    if (n_top < PEG_SUPPORT_ENUM_CAP) {
+      int pos = n_top++;
+      while (pos > 0 && top_w[pos - 1] < c) {
+        top[pos] = top[pos - 1];
+        top_w[pos] = top_w[pos - 1];
+        pos--;
+      }
+      top[pos] = i;
+      top_w[pos] = c;
+    } else if (c > top_w[PEG_SUPPORT_ENUM_CAP - 1]) {
+      int pos = PEG_SUPPORT_ENUM_CAP - 1;
+      while (pos > 0 && top_w[pos - 1] < c) {
+        top[pos] = top[pos - 1];
+        top_w[pos] = top_w[pos - 1];
+        pos--;
+      }
+      top[pos] = i;
+      top_w[pos] = c;
+    }
+  }
+  double comb_total = 0.0, comb_win = 0.0, comb_spread = 0.0;
+  int comb_nscen = 0;
+  Rack leaf_rack;
+  rack_set_dist_size_and_reset(&leaf_rack, ctx->ld_size);
+  uint8_t leaf_counts[MAX_ALPHABET_SIZE];
+  MachineLetter mover_drawn[PEG_MAX_BAG + 1];
+  MachineLetter bag_remaining[PEG_MAX_BAG + 1];
+  for (int t = 0; t < n_top; t++) {
+    if (ctx->deadline_ns != 0 && ctimer_monotonic_ns() >= ctx->deadline_ns) {
+      break;
+    }
+    rack_reset(&leaf_rack);
+    const uint32_t w_i = alias_method_get_item(am, top[t], &leaf_rack);
+    for (int ml = 0; ml < ctx->ld_size; ml++) {
+      leaf_counts[ml] = (uint8_t)rack_get_letter(&leaf_rack, ml);
+    }
+    // Fresh per-leaf accumulation into the ctx accumulators.
+    ctx->total_weight = 0.0;
+    ctx->win_weight = 0.0;
+    ctx->spread_weight = 0.0;
+    ctx->weight_sum = 0;
+    ctx->win_count = 0;
+    ctx->tie_count = 0;
+    ctx->n_scenarios = 0;
+    ctx->sampled_weight_seen = 0; // stride cursor is per-leaf
+    ctx->pinned_leave = leaf_counts;
+    peg_enum_splits(ctx, /*ml=*/0, ctx->k_drawn, n_bag_remaining, /*weight=*/1,
+                    mover_drawn, 0, bag_remaining, 0);
+    if (ctx->total_weight <= 0.0) {
+      continue;
+    }
+    const double norm = (double)w_i / ctx->total_weight; // w_i / total_i
+    comb_total += (double)w_i;
+    comb_win += norm * ctx->win_weight;       // w_i * (win_i / total_i)
+    comb_spread += norm * ctx->spread_weight; // w_i * (spread_i / total_i)
+    comb_nscen += ctx->n_scenarios;
+  }
+  // Publish the prior-weighted combination. Ranking reads the doubles; the
+  // integer tallies are set approximately (display only, not used at stage 0).
+  ctx->pinned_leave = NULL;
+  ctx->total_weight = comb_total;
+  ctx->win_weight = comb_win;
+  ctx->spread_weight = comb_spread;
+  ctx->n_scenarios = comb_nscen;
+  ctx->weight_sum = (int64_t)(comb_total + 0.5);
+  ctx->win_count = (int64_t)(comb_win + 0.5);
+  ctx->tie_count = 0;
+}
+
+// COLLECT-mode support enumeration: the analogue of peg_enumerate_support for
+// the deep halving stages, which run in collect mode (emit scenario jobs for a
+// barrier) and so cannot diff per-leaf ctx accumulators. Instead each leaf L_i
+// is enumerated with an INITIAL weight w_i * K / total_i, where total_i =
+// peg_enum_total(L_i); peg_enum_splits then scales that by the per-split
+// multinomial and peg_eval_split emits jobs carrying it. Summing over a leaf's
+// jobs gives total contribution w_i * K, and win contribution w_i * K *
+// (win_i / total_i), so the reduced win% = (sum_i w_i * win_i/total_i)/(sum_i
+// w_i) -- identical to the inline combine, with K cancelling. K is large enough
+// that w_i*K/total_i stays a precise positive integer; PEG_MAX_BAG bounds every
+// multinomial, so no int64 overflow. The deep stages have FEW candidates, so
+// enumerating the (capped, weight-ordered) support per candidate is affordable
+// even when it would be too costly over the whole stage-0 field.
+static void peg_collect_support(PegEvalCtx *ctx, const InferenceResults *prior,
+                                int n_bag_remaining) {
+  AliasMethod *am =
+      inference_results_get_alias_method((InferenceResults *)prior);
+  const int n_items = alias_method_num_items(am);
+  // Empty support: fall back to uniform (emitting no jobs would zero the
+  // candidate out of the ranking).
+  if (n_items == 0) {
+    MachineLetter mover_drawn[PEG_MAX_BAG + 1];
+    MachineLetter bag_remaining[PEG_MAX_BAG + 1];
+    ctx->pinned_leave = NULL;
+    peg_enum_splits(ctx, /*ml=*/0, ctx->k_drawn, n_bag_remaining, /*weight=*/1,
+                    mover_drawn, 0, bag_remaining, 0);
+    return;
+  }
+  // Weight-ordered top-k selection (see peg_enumerate_support).
+  enum { PEG_COLLECT_SUPPORT_CAP = 32 };
+  int top[PEG_COLLECT_SUPPORT_CAP];
+  uint32_t top_w[PEG_COLLECT_SUPPORT_CAP];
+  int n_top = 0;
+  for (int i = 0; i < n_items; i++) {
+    const uint32_t c = alias_method_item_count(am, i);
+    if (n_top < PEG_COLLECT_SUPPORT_CAP) {
+      int pos = n_top++;
+      while (pos > 0 && top_w[pos - 1] < c) {
+        top[pos] = top[pos - 1];
+        top_w[pos] = top_w[pos - 1];
+        pos--;
+      }
+      top[pos] = i;
+      top_w[pos] = c;
+    } else if (c > top_w[PEG_COLLECT_SUPPORT_CAP - 1]) {
+      int pos = PEG_COLLECT_SUPPORT_CAP - 1;
+      while (pos > 0 && top_w[pos - 1] < c) {
+        top[pos] = top[pos - 1];
+        top_w[pos] = top_w[pos - 1];
+        pos--;
+      }
+      top[pos] = i;
+      top_w[pos] = c;
+    }
+  }
+  const int64_t K = (int64_t)1 << 20; // weight scale (cancels in win%)
+  Rack leaf_rack;
+  rack_set_dist_size_and_reset(&leaf_rack, ctx->ld_size);
+  uint8_t leaf_counts[MAX_ALPHABET_SIZE];
+  MachineLetter mover_drawn[PEG_MAX_BAG + 1];
+  MachineLetter bag_remaining[PEG_MAX_BAG + 1];
+  for (int t = 0; t < n_top; t++) {
+    rack_reset(&leaf_rack);
+    const uint32_t w_i = alias_method_get_item(am, top[t], &leaf_rack);
+    for (int ml = 0; ml < ctx->ld_size; ml++) {
+      leaf_counts[ml] = (uint8_t)rack_get_letter(&leaf_rack, ml);
+    }
+    const int64_t total_i =
+        peg_enum_total(ctx->unseen, leaf_counts, ctx->ld_size, ctx->k_drawn,
+                       /*ml=*/0, ctx->k_drawn, n_bag_remaining, /*weight=*/1);
+    if (total_i <= 0) {
+      continue;
+    }
+    int64_t weight_i = (int64_t)((double)w_i * (double)K / (double)total_i + 0.5);
+    if (weight_i < 1) {
+      weight_i = 1;
+    }
+    ctx->pinned_leave = leaf_counts;
+    peg_enum_splits(ctx, /*ml=*/0, ctx->k_drawn, n_bag_remaining, weight_i,
+                    mover_drawn, 0, bag_remaining, 0);
+  }
+  ctx->pinned_leave = NULL;
 }
 
 static void peg_cand_worker_fn(void *arg, int worker_idx) {
@@ -2004,14 +2273,23 @@ static void peg_cand_worker_fn(void *arg, int worker_idx) {
     // Pinned single scenario: evaluate exactly the caller's bag ordering.
     peg_eval_fixed_ordering(&ctx, job->eval_bag_order, job->eval_bag_order_len);
   } else if (job->opp_leave_prior != NULL) {
-    // Inference-weighted sampling instead of uniform enumeration. Seed a
-    // per-candidate PRNG so the sample is reproducible and independent of how
-    // the pool schedules candidates across worker threads.
-    XoshiroPRNG *prng =
-        prng_create(job->inference_seed + (uint64_t)job->cand_rank + 1);
-    peg_eval_inference_samples(&ctx, job->opp_leave_prior,
-                               job->inference_samples, prng);
-    prng_destroy(prng);
+    uint8_t pinned_leave[MAX_ALPHABET_SIZE];
+    if (peg_prior_point_mass(job->opp_leave_prior, ctx.ld_size, pinned_leave)) {
+      // Point-mass prior (e.g. a pinned "psychic" leave): enumerate the leave's
+      // completions EXACTLY rather than sampling -- sampling a degenerate prior
+      // with few draws mis-ranks candidates via a winner's curse.
+      ctx.pinned_leave = pinned_leave;
+      MachineLetter mover_drawn[PEG_MAX_BAG + 1];
+      MachineLetter bag_remaining[PEG_MAX_BAG + 1];
+      peg_enum_splits(&ctx, /*ml=*/0, ctx.k_drawn, n_bag_remaining,
+                      /*weight=*/1, mover_drawn, 0, bag_remaining, 0);
+    } else {
+      // General (multi-support) prior: enumerate the support EXACTLY (each
+      // leaf's completions, weighted by prior mass) rather than sampling --
+      // sampling a many-leaf prior with few draws mis-ranks candidates via the
+      // same winner's curse the point-mass path avoids.
+      peg_enumerate_support(&ctx, job->opp_leave_prior, n_bag_remaining);
+    }
   } else {
     MachineLetter mover_drawn[PEG_MAX_BAG + 1];
     MachineLetter bag_remaining[PEG_MAX_BAG + 1];
@@ -2253,7 +2531,31 @@ static void peg_eval_candidates_scenario(
     int inner_top_k, int fidelity_plies, int scenario_stride,
     int64_t deadline_ns, ThreadControl *thread_control,
     const PegProgress *progress, PegPoll *poll, PegRankedCand *ranked,
-    PegCandOutcomes *out_outcomes) {
+    PegCandOutcomes *out_outcomes, const InferenceResults *opp_leave_prior,
+    int inference_samples, uint64_t inference_seed) {
+  // How the DEEP stages model the opponent, so they weight the inference too
+  // (not just the stage-0 filter): a POINT-MASS prior reserves its leave in
+  // every enumerated split (ctx.pinned_leave, exact); a MULTI-SUPPORT prior is
+  // sampled per candidate (peg_sample_splits_from_prior); no prior => uniform
+  // enumeration (unchanged).
+  uint8_t pinned_leave[MAX_ALPHABET_SIZE];
+  const bool has_pinned =
+      peg_prior_point_mass(opp_leave_prior, ld_size, pinned_leave);
+  // How the DEEP stages treat a MULTI-SUPPORT prior. Both non-uniform paths are
+  // OFF BY DEFAULT because, for the REAL pre-endgame inference, trusting the
+  // inferred opponent at the deep stages HURTS -- the inference is inaccurate,
+  // so the more faithfully the final move is optimized against it the worse the
+  // result (real-inference win% delta, seed 7: deep-uniform +0.005 -> deep-SAMPLE
+  // -0.071 -> deep-ENUM (coherent) -0.171). The machinery is not at fault: the
+  // SAME collect_support path scores POSITIVE on a point-mass psychic prior
+  // (+0.0125, PEGBENCH_PSYCHIC_MULTI), so exact deep enumeration is correct and
+  // would help once the inference is accurate enough. Until then the deep stages
+  // enumerate uniformly (ignore the multi-support prior). PEG_DEEP_ENUM /
+  // PEG_DEEP_SAMPLE re-enable the exact / sampled paths for experiments.
+  const bool multi_prior = opp_leave_prior != NULL && !has_pinned;
+  const bool sample_prior = multi_prior && getenv("PEG_DEEP_SAMPLE") != NULL;
+  const bool enum_prior = multi_prior && !sample_prior &&
+                          getenv("PEG_DEEP_ENUM") != NULL;
   // Shared per-cand templates: post-cand board + cross-sets + pruned override,
   // built once and read concurrently by the scenario workers.
   Game **templates = malloc_or_die((size_t)n * sizeof(Game *));
@@ -2273,6 +2575,7 @@ static void peg_eval_candidates_scenario(
     ctx.template_src = templates[i];
     ctx.mover_idx = mover_idx;
     ctx.unseen = unseen;
+    ctx.pinned_leave = has_pinned ? pinned_leave : NULL;
     ctx.ld_size = ld_size;
     ctx.opp_model = opp_model;
     ctx.inner_top_k = inner_top_k;
@@ -2290,8 +2593,24 @@ static void peg_eval_candidates_scenario(
     const int n_bag_remaining = bag_size - ctx.k_drawn;
     MachineLetter mover_drawn[PEG_MAX_BAG + 1];
     MachineLetter bag_remaining[PEG_MAX_BAG + 1];
-    peg_enum_splits(&ctx, /*ml=*/0, ctx.k_drawn, n_bag_remaining, /*weight=*/1,
-                    mover_drawn, 0, bag_remaining, 0);
+    if (sample_prior) {
+      // Experiment only (PEG_DEEP_SAMPLE): sample opponent racks.
+      XoshiroPRNG *prng = prng_create(inference_seed + (uint64_t)i + 1);
+      peg_sample_splits_from_prior(&ctx, opp_leave_prior, inference_samples,
+                                   prng);
+      prng_destroy(prng);
+    } else if (enum_prior) {
+      // Experiment only (PEG_DEEP_ENUM): enumerate the support exactly at the
+      // deep stages (coherent, curse-free -- correct, but hurts because the real
+      // inference is inaccurate; see the comment above).
+      peg_collect_support(&ctx, opp_leave_prior, n_bag_remaining);
+    } else {
+      // Default: point-mass (ctx.pinned_leave set) uses its pinned enumeration;
+      // a multi-support prior falls through to uniform (ignored) here; no prior
+      // is uniform. All are a single peg_enum_splits.
+      peg_enum_splits(&ctx, /*ml=*/0, ctx.k_drawn, n_bag_remaining, /*weight=*/1,
+                      mover_drawn, 0, bag_remaining, 0);
+    }
   }
 
   // Enable per-ordering capture on every job when the caller asked for it.
@@ -2589,12 +2908,34 @@ void peg_solve(const PegArgs *args, PegResult *out, ErrorStack *error_stack) {
   // fixed cap, so a caller may pass a longer stage_top_k.
   const int default_num_stages = (int)(sizeof(PEG_DEFAULT_HALVING_COUNTS) /
                                        sizeof(PEG_DEFAULT_HALVING_COUNTS[0]));
-  const int *counts = (args->stage_top_k && args->num_stages > 0)
-                          ? args->stage_top_k
-                          : PEG_DEFAULT_HALVING_COUNTS;
-  int num_stages = (args->stage_top_k && args->num_stages > 0)
-                       ? args->num_stages
-                       : default_num_stages;
+  const int *counts;
+  int num_stages;
+  if (args->stage_top_k && args->num_stages > 0) {
+    // Caller-supplied schedule always wins (an explicit override opts out of the
+    // inference-mode narrowing below).
+    counts = args->stage_top_k;
+    num_stages = args->num_stages;
+  } else if (args->opp_leave_prior != NULL &&
+             alias_method_num_items(inference_results_get_alias_method(
+                 (InferenceResults *)args->opp_leave_prior)) > 0 &&
+             !peg_prior_point_mass(args->opp_leave_prior,
+                                   ld_get_size(game_get_ld(prepared_base)),
+                                   (uint8_t[MAX_ALPHABET_SIZE]){0})) {
+    // Multi-support prior with no explicit schedule: the deep stages SAMPLE the
+    // opponent rack per candidate (costly), so narrow the field to reach deep
+    // fidelity in budget (see PEG_INFERENCE_HALVING_COUNTS). A point-mass prior
+    // is instead enumerated exactly -- cheaper than the uniform full-field
+    // enumeration -- so it keeps the full-width default schedule below. An
+    // EMPTY-support prior (an inference that found nothing) is treated as no
+    // prior: its evaluation falls back to uniform, so it must keep the uniform
+    // schedule too or the prior's mere presence would change the solve.
+    counts = PEG_INFERENCE_HALVING_COUNTS;
+    num_stages = (int)(sizeof(PEG_INFERENCE_HALVING_COUNTS) /
+                       sizeof(PEG_INFERENCE_HALVING_COUNTS[0]));
+  } else {
+    counts = PEG_DEFAULT_HALVING_COUNTS;
+    num_stages = default_num_stages;
+  }
   if (args->max_stage > 0 && args->max_stage < num_stages) {
     num_stages = args->max_stage;
   }
@@ -2608,6 +2949,7 @@ void peg_solve(const PegArgs *args, PegResult *out, ErrorStack *error_stack) {
     // deterministic (full enumeration, deterministic playout, no deep solves).
     num_stages = 0;
   }
+  out->planned_num_stages = num_stages;
 
   // Exhaustive mode: a single uncapped stage (-pegtopk all / 0). With no
   // narrowing the per-stage fidelity ramp is pointless — re-evaluating the
@@ -2885,7 +3227,9 @@ void peg_solve(const PegArgs *args, PegResult *out, ErrorStack *error_stack) {
               bag_size, &moves[cand_idx], 1, args->opp_model, args->inner_top_k,
               stage_fidelity, scenario_stride, deadline_ns,
               args->thread_control, &inner, /*poll=*/NULL, &restaged[cand_idx],
-              args->include_per_scenario ? &cand_oc : NULL);
+              args->include_per_scenario ? &cand_oc : NULL,
+              args->opp_leave_prior, args->inference_samples,
+              args->inference_seed);
           restaged[cand_idx].eval_seconds = ctimer_elapsed_seconds(&cand_timer);
           peg_poll_set_evaluating(args->poll, -1, 0);
           // If the deadline passed while this candidate was evaluating, some of
@@ -2929,7 +3273,8 @@ void peg_solve(const PegArgs *args, PegResult *out, ErrorStack *error_stack) {
             pool, workers, prepared_base, mover_idx, unseen, ld_size, ld,
             bag_size, moves, eval_count, args->opp_model, args->inner_top_k,
             stage_fidelity, scenario_stride, deadline_ns, args->thread_control,
-            &progress, args->poll, restaged, stage_oc);
+            &progress, args->poll, restaged, stage_oc, args->opp_leave_prior,
+            args->inference_samples, args->inference_seed);
         // A deadline can cut the stage mid-flight: a candidate whose scenario
         // jobs bailed has a short weight_sum, so keep only the fully-scored
         // ones (as the live path does) instead of ranking partial scores.
@@ -2939,6 +3284,13 @@ void peg_solve(const PegArgs *args, PegResult *out, ErrorStack *error_stack) {
         // complete weight_sum is ranked[0].weight_sum: carried candidates were
         // fully scored at the previous stage and weight_sum (= perm(unseen,
         // bag_size)) is constant across plays.
+        // CAVEAT (multi-support sampled prior only): the deep sampled path routes
+        // each weight-1 sample through peg_eval_split's per-multiset factorial
+        // scaling, so its weight_sum is a sum-of-(n_bag!)'s (N..24*N), not a flat
+        // constant. This completeness gate can then mis-classify a deadline-cut
+        // sampled candidate. It never affects win%/spread ranking (those divide
+        // by total_weight); PEG_MAX_BAG bounds the distortion; and the live poll
+        // path uses whole-candidate done_count, not this gate.
         const int64_t full_weight = ranked[0].weight_sum;
         PegRankedCand *part_new =
             malloc_or_die((size_t)eval_count * sizeof(PegRankedCand));

--- a/src/impl/peg.c
+++ b/src/impl/peg.c
@@ -2494,6 +2494,12 @@ void peg_solve(const PegArgs *args, PegResult *out, ErrorStack *error_stack) {
     // A pinned single scenario has nothing for the halving stages to re-rank.
     num_stages = 0;
   }
+  if (args->greedy_seed_only) {
+    // Greedy seed only: rank the full field by the stage-0 greedy-playout
+    // win%, skipping the halving stages' exact endgame refinement. Bounded and
+    // deterministic (full enumeration, deterministic playout, no deep solves).
+    num_stages = 0;
+  }
 
   // Exhaustive mode: a single uncapped stage (-pegtopk all / 0). With no
   // narrowing the per-stage fidelity ramp is pointless — re-evaluating the

--- a/src/impl/peg.h
+++ b/src/impl/peg.h
@@ -121,6 +121,14 @@ typedef struct PegArgs {
   // all stages".
   int max_stage;
 
+  // Run only the greedy seed (stage 0): rank the full candidate field by the
+  // greedy-playout win% and skip the halving stages' exact endgame refinement.
+  // A fast, bounded, deterministic evaluation -- full scenario enumeration and
+  // a deterministic playout, with no open-ended deep endgame solves -- at the
+  // cost of the endgame-exact fidelity the halving stages add. Overrides
+  // max_stage and stage_top_k. Default false.
+  bool greedy_seed_only;
+
   // Optional per-stage candidate counts for the halving stages (stage 1
   // onward), overriding the built-in default schedule. NULL = use the default.
   // When set, num_stages is the array length and defines how many halving

--- a/src/impl/peg.h
+++ b/src/impl/peg.h
@@ -5,6 +5,7 @@
 #include "../def/letter_distribution_defs.h"
 #include "../def/peg_defs.h"
 #include "../ent/game.h"
+#include "../ent/inference_results.h"
 #include "../ent/move.h"
 #include "../ent/thread_control.h"
 #include "../util/io_util.h"
@@ -153,6 +154,18 @@ typedef struct PegArgs {
   // k > 1 = sample one multiset per k weight-units, scaled accordingly.
   // 0 = use the bag-size default (the solver picks a sane stride per bag size).
   int scenario_stride;
+
+  // Optional opponent-leave prior for inference-weighted scenario sampling.
+  // When non-NULL, PEG samples the opponent's COMPLETE rack per scenario from
+  // this leave distribution -- sample a leave via its AliasMethod, then draw to
+  // a full rack from the remaining unseen -- instead of enumerating the uniform
+  // unseen, the pre-endgame analogue of the simmer's inference-weighted
+  // opponent draws. inference_samples scenarios are drawn per candidate;
+  // inference_seed seeds a per-candidate, thread-independent sampler. NULL =
+  // uniform enumeration (default). Honored in the greedy seed stage.
+  const InferenceResults *opp_leave_prior;
+  int inference_samples;
+  uint64_t inference_seed;
 
   // Nested pre-endgame lookahead for NON-EMPTIER leaves. When nested_enabled,
   // a leaf that still has bag tiles is evaluated by recursively solving the

--- a/src/impl/peg.h
+++ b/src/impl/peg.h
@@ -296,6 +296,13 @@ typedef struct PegResult {
   // stage = the deepest stage actually run). -1 while running or uninitialized.
   int last_completed_stage;
 
+  // Number of halving stages the solve was SCHEDULED to run (the resolved
+  // schedule length after all adjustments): the default 5-wide ramp, the
+  // narrowed inference ramp when opp_leave_prior is set, a caller stage_top_k,
+  // or 0 for greedy-seed-only / pinned-scenario. Distinct from
+  // last_completed_stage (how many actually ran within budget). 0 until set.
+  int planned_num_stages;
+
   // True when the deepest stage was cut off by the budget/interrupt after
   // scoring only some of its candidates (a partial tier), so it was reached but
   // not completed. False when every stage shown ran to completion.

--- a/src/impl/peg_inference.c
+++ b/src/impl/peg_inference.c
@@ -1,0 +1,646 @@
+// Pre-endgame (PEG) inference: evaluates candidate opponent racks by running,
+// for each candidate leave, one pre-endgame solve over the target's top moves
+// to decide whether a PEG player with that rack would have made the observed
+// play.
+//
+// This is the pre-endgame analogue of simmed_inference.c. The leave
+// enumeration (exhaustive for small leaves, Monte Carlo for large), the static
+// pre-filter, the logistic weight, and the result recording are all the same;
+// only the inner "would they play this?" test differs: instead of an inner
+// Monte Carlo sim it runs peg_solve over the candidate move set (only_moves)
+// and compares the score+win utilities (sim_utility_blend of PEG win% and mean
+// spread) of the best move and the observed move.
+
+#include "peg_inference.h"
+
+#include "../compat/ctime.h"
+#include "../def/equity_defs.h"
+#include "../def/letter_distribution_defs.h"
+#include "../def/move_defs.h"
+#include "../def/rack_defs.h"
+#include "../def/thread_control_defs.h"
+#include "../ent/alias_method.h"
+#include "../ent/bag.h"
+#include "../ent/equity.h"
+#include "../ent/game.h"
+#include "../ent/inference_args.h"
+#include "../ent/inference_results.h"
+#include "../ent/klv.h"
+#include "../ent/leave_rack.h"
+#include "../ent/letter_distribution.h"
+#include "../ent/move.h"
+#include "../ent/player.h"
+#include "../ent/rack.h"
+#include "../ent/sim_args.h"
+#include "../ent/thread_control.h"
+#include "../ent/xoshiro.h"
+#include "../impl/gameplay.h"
+#include "../impl/inference.h"
+#include "../impl/move_gen.h"
+#include "../impl/peg.h"
+#include "../util/io_util.h"
+#include "../util/string_util.h"
+#include <math.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MAX_SAMPLE_POOL 200
+#define PEG_INFER_DEFAULT_CANDIDATE_PLAYS 7
+// Utility-space margin. Pre-endgame utility gaps (win% blended with a sigmoid
+// of spread, in [0, 1]) run well above the simmed inference's few-display-point
+// margins, so the borderline point sits near a third of the scale. This is the
+// primary weighting knob; tune it via the benchmark.
+#define PEG_INFER_DEFAULT_UTILITY_MARGIN 0.3
+#define PEG_INFER_DEFAULT_STATIC_PREFILTER 20.0
+
+// ── Internal context ────────────────────────────────────────────────────────
+
+typedef struct {
+  // Base game: target has target_played+target_known tiles; nontarget has
+  // nontarget_known tiles; bag = all_tiles - all known. game_copy'd into
+  // inner_game for each candidate.
+  Game *base_inner_game;
+  Game *inner_game;
+
+  Rack bag_as_rack;          // pool for candidate leave draws
+  Rack current_leave;        // candidate leave being evaluated
+  Rack target_known_combined; // target_played + target_known
+
+  // Move / solver infrastructure reused across candidates.
+  MoveList *inner_move_list;
+  const Move **only_move_ptrs; // scratch: pointers into inner_move_list
+  ThreadControl *inner_thread_control; // owned; for the inner peg_solve
+  ErrorStack *inner_error_stack;       // owned
+
+  // Observed move, extracted once.
+  game_event_t observed_move_type;
+  int observed_num_exch;
+  Move observed_move_copy;
+
+  int target_index;
+  int ld_size;
+  int leave_size;
+
+  // Tuning.
+  int num_candidate_plays;
+  double util_w_winpct;
+  double util_w_spread;
+  double util_spread_scale;
+  bool greedy_seed_only;
+  int peg_max_stage;
+  int peg_scenario_stride;
+  PegOppModel peg_opp_model;
+  double peg_time_budget_s;
+  double time_budget_s;
+  double peg_utility_margin;
+  double static_prefilter_margin;
+
+  // Not owned.
+  ThreadControl *thread_control; // outer interrupt
+  InferenceResults *results;
+  int num_threads;
+
+  XoshiroPRNG *prng;
+  uint64_t eval_count;
+
+  PegInferLeaveCallback leave_callback;
+  void *leave_callback_data;
+} PegInferCtx;
+
+// ── Weight ──────────────────────────────────────────────────────────────────
+//
+// Smooth logistic on the utility gap, centred at the margin. gap <= 0 -> ~1.0,
+// gap == margin -> 0.5, gap >> margin -> ~0.0. Same shape as simmed inference's
+// compute_weight (gap and margin are both in [0, 1] utility units here).
+static double compute_weight(double gap, double margin) {
+  const double x = (gap - margin) / margin;
+  return 1.0 / (1.0 + exp(3.0 * x));
+}
+
+// Score+win utility of one ranked candidate, on the simmer's [0, 1] scale.
+static double peg_cand_utility(const PegInferCtx *ctx,
+                               const PegRankedCand *cand) {
+  return sim_utility_blend(cand->win_pct, double_to_equity(cand->mean_spread),
+                           ctx->util_w_winpct, ctx->util_w_spread,
+                           ctx->util_spread_scale);
+}
+
+// True when a ranked candidate is the observed move (exact tiles for a
+// placement; matching exchange count for an exchange).
+static bool cand_is_observed(const PegInferCtx *ctx, const Move *cand) {
+  if (ctx->observed_move_type == GAME_EVENT_EXCHANGE) {
+    return move_get_type(cand) == GAME_EVENT_EXCHANGE &&
+           move_get_tiles_played(cand) == ctx->observed_num_exch;
+  }
+  return compare_moves_without_equity(cand, &ctx->observed_move_copy,
+                                      /*allow_duplicates=*/true) == -1;
+}
+
+// ── Observed-move matching in the generated list ─────────────────────────────
+static int find_observed_move_idx(const MoveList *ml, const PegInferCtx *ctx) {
+  const int n = move_list_get_count(ml);
+  if (ctx->observed_move_type == GAME_EVENT_EXCHANGE) {
+    for (int i = 0; i < n; i++) {
+      const Move *m = move_list_get_move(ml, i);
+      if (move_get_type(m) == GAME_EVENT_EXCHANGE &&
+          move_get_tiles_played(m) == ctx->observed_num_exch) {
+        return i;
+      }
+    }
+  } else {
+    for (int i = 0; i < n; i++) {
+      if (compare_moves_without_equity(move_list_get_move(ml, i),
+                                       &ctx->observed_move_copy,
+                                       /*allow_duplicates=*/true) == -1) {
+        return i;
+      }
+    }
+  }
+  return -1;
+}
+
+// ── KLV-optimal exchange builder (verbatim from simmed inference) ────────────
+static void make_best_exchange_move(const Rack *rack, int exch_count,
+                                    const KLV *klv, int ld_size,
+                                    Move *out_move) {
+  MachineLetter flat[RACK_SIZE];
+  int total = 0;
+  for (int ml = 0; ml < ld_size && total < RACK_SIZE; ml++) {
+    int cnt = (int)rack_get_letter(rack, ml);
+    for (int k = 0; k < cnt && total < RACK_SIZE; k++) {
+      flat[total++] = (MachineLetter)ml;
+    }
+  }
+
+  move_set_type(out_move, GAME_EVENT_EXCHANGE);
+  move_set_tiles_played(out_move, exch_count);
+  move_set_tiles_length(out_move, exch_count);
+  move_set_score(out_move, int_to_equity(0));
+
+  const int keep_count = total - exch_count;
+  if (keep_count <= 0) {
+    for (int i = 0; i < total; i++) {
+      move_set_tile(out_move, flat[i], i);
+    }
+    move_set_equity(out_move, int_to_equity(0));
+    return;
+  }
+
+  int cur_idx[RACK_SIZE];
+  int best_idx[RACK_SIZE];
+  for (int i = 0; i < keep_count; i++) {
+    cur_idx[i] = i;
+    best_idx[i] = i;
+  }
+  Equity best_equity = 0;
+  bool first = true;
+  Rack leave_rack;
+  rack_set_dist_size_and_reset(&leave_rack, ld_size);
+
+  while (true) {
+    rack_reset(&leave_rack);
+    for (int i = 0; i < keep_count; i++) {
+      rack_add_letter(&leave_rack, flat[cur_idx[i]]);
+    }
+    Equity eq = klv_get_leave_value(klv, &leave_rack);
+    if (first || eq > best_equity) {
+      best_equity = eq;
+      for (int i = 0; i < keep_count; i++) {
+        best_idx[i] = cur_idx[i];
+      }
+      first = false;
+    }
+    int pos = keep_count - 1;
+    while (pos >= 0 && cur_idx[pos] == total - keep_count + pos) {
+      pos--;
+    }
+    if (pos < 0) {
+      break;
+    }
+    cur_idx[pos]++;
+    for (int i = pos + 1; i < keep_count; i++) {
+      cur_idx[i] = cur_idx[i - 1] + 1;
+    }
+  }
+
+  bool kept[RACK_SIZE] = {false};
+  for (int i = 0; i < keep_count; i++) {
+    kept[best_idx[i]] = true;
+  }
+  int tile_idx = 0;
+  for (int i = 0; i < total; i++) {
+    if (!kept[i]) {
+      move_set_tile(out_move, flat[i], tile_idx++);
+    }
+  }
+  move_set_equity(out_move, best_equity);
+}
+
+// ── Core candidate evaluation ────────────────────────────────────────────────
+//
+// Rebuilds the target's pre-move rack (target_known_combined + current_leave),
+// generates the top candidate moves, runs one peg_solve over them, and returns
+// a weight in [0, 1] from the score+win utility gap.
+static double peg_evaluate_candidate_leave(PegInferCtx *ctx) {
+  // 1. Set up inner_game: copy base, add the candidate leave to the target's
+  //    rack on top of the known tiles already drawn.
+  game_copy(ctx->inner_game, ctx->base_inner_game);
+  {
+    Rack *target_rack =
+        player_get_rack(game_get_player(ctx->inner_game, ctx->target_index));
+    const int draw_idx =
+        game_get_player_draw_index(ctx->inner_game, ctx->target_index);
+    Bag *bag = game_get_bag(ctx->inner_game);
+    for (int i = 0; i < ctx->ld_size; i++) {
+      const uint16_t n = rack_get_letter(&ctx->current_leave, i);
+      for (uint16_t j = 0; j < n; j++) {
+        if (!bag_draw_letter(bag, i, draw_idx)) {
+          return 0.0;
+        }
+        rack_add_letter(target_rack, i);
+      }
+    }
+  }
+
+  // 2. Generate top num_candidate_plays moves by static equity.
+  move_list_reset(ctx->inner_move_list);
+  const MoveGenArgs gen_args = {
+      .game = ctx->inner_game,
+      .move_list = ctx->inner_move_list,
+      .move_record_type = MOVE_RECORD_ALL,
+      .move_sort_type = MOVE_SORT_EQUITY,
+      .override_kwg = NULL,
+      .eq_margin_movegen = 0,
+      .target_equity = EQUITY_MAX_VALUE,
+      .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+      .tiles_played_bv = NULL,
+  };
+  generate_moves(&gen_args);
+
+  move_list_sort_moves(ctx->inner_move_list);
+  if (move_list_get_count(ctx->inner_move_list) > ctx->num_candidate_plays) {
+    ctx->inner_move_list->count = ctx->num_candidate_plays;
+  }
+  const int num_static = move_list_get_count(ctx->inner_move_list);
+  if (num_static == 0) {
+    return 0.0;
+  }
+
+  // 3. Find (or build) the observed move's slot in the candidate list.
+  int obs_idx = -1;
+  if (ctx->observed_move_type == GAME_EVENT_EXCHANGE) {
+    const Rack *target_rack =
+        player_get_rack(game_get_player(ctx->inner_game, ctx->target_index));
+    const int rack_total = rack_get_total_letters(target_rack);
+    if (rack_total < ctx->observed_num_exch) {
+      return 0.0;
+    }
+    const KLV *klv =
+        player_get_klv(game_get_player(ctx->inner_game, ctx->target_index));
+    // Exchanging is legal only when the bag holds at least a full rack
+    // (RACK_SIZE) -- you must be able to draw a replacement for every tile you
+    // could return. In the PEG bag range [PEG_MIN_BAG, PEG_MAX_BAG] this never
+    // holds, so no exchange arms are built; the branch is kept correct for a
+    // boundary reconstruction whose bag is >= RACK_SIZE. An exchange observed
+    // in a sub-full-rack position is impossible, so obs_idx stays -1 and the
+    // leave scores 0.
+    int n_arms = 0;
+    if (bag_get_letters(game_get_bag(ctx->inner_game)) >= RACK_SIZE) {
+      for (int k = 1; k <= rack_total; k++) {
+        Move *slot = ctx->inner_move_list->moves[num_static + n_arms];
+        make_best_exchange_move(target_rack, k, klv, ctx->ld_size, slot);
+        if (k == ctx->observed_num_exch) {
+          obs_idx = num_static + n_arms;
+        }
+        n_arms++;
+      }
+    }
+    ctx->inner_move_list->count = num_static + n_arms;
+  } else {
+    obs_idx = find_observed_move_idx(ctx->inner_move_list, ctx);
+    if (obs_idx < 0) {
+      Move *extra = ctx->inner_move_list->moves[num_static];
+      move_copy(extra, &ctx->observed_move_copy);
+      ctx->inner_move_list->count = num_static + 1;
+      obs_idx = num_static;
+    }
+  }
+  if (obs_idx < 0) {
+    return 0.0;
+  }
+  if (ctx->inner_move_list->count == 1) {
+    return 1.0; // only one legal move; trivially consistent
+  }
+
+  const int inner_arms = ctx->inner_move_list->count;
+  double gap = 0.0;
+  double result = 0.0;
+
+  // 4. Static pre-filter: skip the (expensive) PEG solve when the observed move
+  //    already trails the static best by a wide margin. Kept generous, since a
+  //    low-static setup can still be the pre-endgame win% best.
+  if (ctx->leave_size > 1) {
+    const double best_static = equity_to_double(
+        move_get_equity(move_list_get_move(ctx->inner_move_list, 0)));
+    const double obs_static = equity_to_double(
+        move_get_equity(move_list_get_move(ctx->inner_move_list, obs_idx)));
+    if (best_static - obs_static > ctx->static_prefilter_margin * 4.0) {
+      result = 0.0;
+      goto invoke_callback;
+    }
+  }
+
+  // 5. Run one PEG solve over the candidate set and read each move's utility.
+  for (int i = 0; i < inner_arms; i++) {
+    ctx->only_move_ptrs[i] = move_list_get_move(ctx->inner_move_list, i);
+  }
+  const Move *protect_arr[1] = {
+      move_list_get_move(ctx->inner_move_list, obs_idx)};
+
+  ctx->eval_count++;
+  thread_control_set_status(ctx->inner_thread_control,
+                            THREAD_CONTROL_STATUS_STARTED);
+  PegArgs peg_args = {0};
+  peg_args.game = ctx->inner_game;
+  peg_args.thread_control = ctx->inner_thread_control;
+  peg_args.num_threads = ctx->num_threads;
+  peg_args.time_budget_seconds = ctx->peg_time_budget_s;
+  peg_args.greedy_seed_only = ctx->greedy_seed_only;
+  peg_args.max_stage = ctx->peg_max_stage;
+  peg_args.scenario_stride = ctx->peg_scenario_stride;
+  peg_args.opp_model = ctx->peg_opp_model;
+  peg_args.only_moves = ctx->only_move_ptrs;
+  peg_args.n_only_moves = inner_arms;
+  peg_args.protect_moves = protect_arr;
+  peg_args.n_protect_moves = 1;
+
+  PegResult peg_result = {0};
+  error_stack_reset(ctx->inner_error_stack);
+  peg_solve(&peg_args, &peg_result, ctx->inner_error_stack);
+
+  if (error_stack_is_empty(ctx->inner_error_stack) &&
+      peg_result.n_top_cands > 0 && peg_result.best_win >= 0.0) {
+    double best_util = -1.0;
+    double obs_util = -1.0;
+    for (int i = 0; i < peg_result.n_top_cands; i++) {
+      const double u = peg_cand_utility(ctx, &peg_result.top_cands[i]);
+      if (u > best_util) {
+        best_util = u;
+      }
+      if (obs_util < 0.0 && cand_is_observed(ctx, &peg_result.top_cands[i].move)) {
+        obs_util = u;
+      }
+    }
+    if (obs_util >= 0.0) {
+      gap = best_util - obs_util;
+      result = compute_weight(gap, ctx->peg_utility_margin);
+    } else {
+      // Observed move not in the ranked set (should not happen with
+      // protect_moves): no usable signal, skip this leave.
+      result = 0.0;
+    }
+  } else {
+    // Solve produced no usable ranking (e.g. cut off before any candidate
+    // finished): skip this leave rather than guess.
+    result = 0.0;
+  }
+  peg_result_destroy(&peg_result);
+
+invoke_callback:
+  if (ctx->leave_callback) {
+    ctx->leave_callback(&ctx->current_leave, ctx->inner_move_list, obs_idx, gap,
+                        result, ctx->inner_game, ctx->leave_callback_data);
+  }
+  return result;
+}
+
+// ── Recording (verbatim from simmed inference) ───────────────────────────────
+static void record_candidate_leave(PegInferCtx *ctx, double weight) {
+  if (weight <= 0.0) {
+    return;
+  }
+  uint64_t raw_draws =
+      get_number_of_draws_for_rack(&ctx->bag_as_rack, &ctx->current_leave);
+  if (raw_draws == 0) {
+    return;
+  }
+  uint64_t weighted = (uint64_t)(raw_draws * weight + 0.5);
+  if (weighted == 0) {
+    return;
+  }
+  const KLV *klv =
+      player_get_klv(game_get_player(ctx->base_inner_game, ctx->target_index));
+  Equity leave_equity = klv_get_leave_value(klv, &ctx->current_leave);
+
+  record_valid_leave(&ctx->current_leave, ctx->results, INFERENCE_TYPE_LEAVE,
+                     equity_to_double(leave_equity), weighted);
+  alias_method_add_rack(inference_results_get_alias_method(ctx->results),
+                        &ctx->current_leave, (int)weighted);
+  leave_rack_list_insert_rack(
+      &ctx->current_leave, /*exchanged=*/NULL, (int)weighted, leave_equity,
+      inference_results_get_leave_rack_list(ctx->results));
+}
+
+static void evaluate_and_record(PegInferCtx *ctx) {
+  if (thread_control_get_status(ctx->thread_control) ==
+      THREAD_CONTROL_STATUS_USER_INTERRUPT) {
+    return;
+  }
+  const double weight = peg_evaluate_candidate_leave(ctx);
+  record_candidate_leave(ctx, weight);
+}
+
+// ── Exhaustive enumeration (verbatim from simmed inference) ──────────────────
+static void exhaust_leaves(PegInferCtx *ctx, int tiles_to_place,
+                           int start_letter) {
+  if (thread_control_get_status(ctx->thread_control) ==
+      THREAD_CONTROL_STATUS_USER_INTERRUPT) {
+    return;
+  }
+  if (tiles_to_place == 0) {
+    evaluate_and_record(ctx);
+    return;
+  }
+  for (int letter = start_letter; letter < ctx->ld_size; letter++) {
+    if (rack_get_letter(&ctx->bag_as_rack, letter) > 0) {
+      rack_take_letter(&ctx->bag_as_rack, letter);
+      rack_add_letter(&ctx->current_leave, letter);
+      exhaust_leaves(ctx, tiles_to_place - 1, letter);
+      rack_take_letter(&ctx->current_leave, letter);
+      rack_add_letter(&ctx->bag_as_rack, letter);
+    }
+  }
+}
+
+// ── Monte Carlo leave sampling (verbatim from simmed inference) ──────────────
+static void sample_leave_mc(PegInferCtx *ctx) {
+  MachineLetter pool[MAX_SAMPLE_POOL];
+  int total = 0;
+  for (int i = 0; i < ctx->ld_size && total < MAX_SAMPLE_POOL; i++) {
+    int cnt = rack_get_letter(&ctx->bag_as_rack, i);
+    for (int j = 0; j < cnt && total < MAX_SAMPLE_POOL; j++) {
+      pool[total++] = (MachineLetter)i;
+    }
+  }
+  rack_reset(&ctx->current_leave);
+  const int n = ctx->leave_size < total ? ctx->leave_size : total;
+  for (int i = 0; i < n; i++) {
+    uint64_t j =
+        (uint64_t)i + prng_get_random_number(ctx->prng, (uint64_t)(total - i));
+    MachineLetter tmp = pool[i];
+    pool[i] = pool[j];
+    pool[j] = tmp;
+    rack_add_letter(&ctx->current_leave, pool[i]);
+  }
+}
+
+// ── Base game setup (verbatim from simmed inference) ─────────────────────────
+static bool setup_base_inner_game(PegInferCtx *ctx,
+                                  const PegInferenceArgs *args,
+                                  ErrorStack *error_stack) {
+  const InferenceArgs *base = args->base;
+  ctx->base_inner_game = game_duplicate(base->game);
+  return_rack_to_bag(ctx->base_inner_game, 0);
+  return_rack_to_bag(ctx->base_inner_game, 1);
+
+  rack_set_dist_size_and_reset(&ctx->target_known_combined, ctx->ld_size);
+  rack_union(&ctx->target_known_combined, base->target_played_tiles);
+  rack_union(&ctx->target_known_combined, base->target_known_rack);
+
+  if (!draw_rack_from_bag(ctx->base_inner_game, ctx->target_index,
+                          &ctx->target_known_combined)) {
+    error_stack_push(
+        error_stack, ERROR_STATUS_INFERENCE_TARGET_LETTERS_NOT_IN_BAG,
+        string_duplicate(
+            "peg inference: failed to draw combined target tiles from bag"));
+    return false;
+  }
+  if (!draw_rack_from_bag(ctx->base_inner_game, 1 - ctx->target_index,
+                          base->nontarget_known_rack)) {
+    log_fatal("peg inference: failed to draw nontarget known rack from bag");
+  }
+
+  const Bag *bag = game_get_bag(ctx->base_inner_game);
+  int bag_counts[MAX_ALPHABET_SIZE];
+  memset(bag_counts, 0, sizeof(bag_counts));
+  bag_increment_unseen_count(bag, bag_counts);
+  rack_set_dist_size_and_reset(&ctx->bag_as_rack, ctx->ld_size);
+  for (int i = 0; i < MAX_ALPHABET_SIZE; i++) {
+    rack_add_letters(&ctx->bag_as_rack, i, bag_counts[i]);
+  }
+  return true;
+}
+
+// ── Entry point ──────────────────────────────────────────────────────────────
+void peg_infer(const PegInferenceArgs *args, InferenceResults *results,
+               ErrorStack *error_stack) {
+  const InferenceArgs *base = args->base;
+
+  if (!args->observed_move) {
+    error_stack_push(error_stack, ERROR_STATUS_INFERENCE_NO_TILES_PLAYED,
+                     string_duplicate("peg_infer: no observed move provided"));
+    return;
+  }
+
+  const int known_target_tiles =
+      rack_get_total_letters(base->target_played_tiles) +
+      rack_get_total_letters(base->target_known_rack);
+  const int leave_size = RACK_SIZE - known_target_tiles;
+  if (leave_size < 0) {
+    error_stack_push(
+        error_stack, ERROR_STATUS_INFERENCE_RACK_OVERFLOW,
+        string_duplicate("peg_infer: more known target tiles than rack size"));
+    return;
+  }
+
+  PegInferCtx ctx;
+  memset(&ctx, 0, sizeof(ctx));
+
+  ctx.target_index = base->target_index;
+  ctx.ld_size = ld_get_size(game_get_ld(base->game));
+  ctx.leave_size = leave_size;
+  ctx.num_candidate_plays = args->num_candidate_plays > 0
+                                ? args->num_candidate_plays
+                                : PEG_INFER_DEFAULT_CANDIDATE_PLAYS;
+  ctx.util_w_winpct =
+      args->utility_w_winpct > 0.0 ? args->utility_w_winpct : 1.0;
+  ctx.util_w_spread = args->utility_w_spread; // 0.0 default = pure win%
+  ctx.util_spread_scale =
+      args->utility_spread_scale > 0.0 ? args->utility_spread_scale : 100.0;
+  ctx.greedy_seed_only = args->greedy_seed_only;
+  ctx.peg_max_stage = args->peg_max_stage;
+  ctx.peg_scenario_stride = args->peg_scenario_stride;
+  ctx.peg_opp_model = args->peg_opp_model;
+  ctx.peg_time_budget_s = args->peg_time_budget_s;
+  ctx.time_budget_s = args->time_budget_s;
+  ctx.peg_utility_margin = args->peg_utility_margin > 0.0
+                               ? args->peg_utility_margin
+                               : PEG_INFER_DEFAULT_UTILITY_MARGIN;
+  ctx.static_prefilter_margin = args->static_prefilter_margin > 0.0
+                                    ? args->static_prefilter_margin
+                                    : PEG_INFER_DEFAULT_STATIC_PREFILTER;
+  ctx.thread_control = base->thread_control;
+  ctx.results = results;
+  ctx.num_threads = base->num_threads;
+  ctx.eval_count = 0;
+
+  ctx.observed_move_type = move_get_type(args->observed_move);
+  ctx.observed_num_exch = base->target_num_exch;
+  move_copy(&ctx.observed_move_copy, args->observed_move);
+  ctx.leave_callback = args->leave_callback;
+  ctx.leave_callback_data = args->leave_callback_data;
+
+  rack_set_dist_size_and_reset(&ctx.bag_as_rack, ctx.ld_size);
+  rack_set_dist_size_and_reset(&ctx.current_leave, ctx.ld_size);
+  rack_set_dist_size_and_reset(&ctx.target_known_combined, ctx.ld_size);
+
+  if (!setup_base_inner_game(&ctx, args, error_stack)) {
+    return;
+  }
+
+  inference_results_reset(results, base->leave_list_capacity, ctx.ld_size);
+
+  const int move_cap = ctx.num_candidate_plays + RACK_SIZE;
+  ctx.inner_move_list = move_list_create(move_cap);
+  ctx.only_move_ptrs = malloc_or_die((size_t)move_cap * sizeof(const Move *));
+  ctx.inner_thread_control = thread_control_create();
+  ctx.inner_error_stack = error_stack_create();
+  ctx.inner_game = game_duplicate(ctx.base_inner_game);
+  ctx.prng = prng_create(42);
+
+  const int exhaustive_max = args->exhaustive_max_leave > 0
+                                 ? args->exhaustive_max_leave
+                                 : PEG_INFER_EXHAUSTIVE_MAX_DEFAULT;
+
+  if (leave_size == 0) {
+    rack_reset(&ctx.current_leave);
+    evaluate_and_record(&ctx);
+  } else if (leave_size <= exhaustive_max) {
+    exhaust_leaves(&ctx, leave_size, BLANK_MACHINE_LETTER);
+  } else {
+    Timer mc_timer;
+    ctimer_reset(&mc_timer);
+    ctimer_start(&mc_timer);
+    while (thread_control_get_status(ctx.thread_control) !=
+               THREAD_CONTROL_STATUS_USER_INTERRUPT &&
+           ctimer_elapsed_seconds(&mc_timer) < ctx.time_budget_s) {
+      sample_leave_mc(&ctx);
+      evaluate_and_record(&ctx);
+    }
+  }
+
+  inference_results_finalize(base->target_played_tiles, base->target_known_rack,
+                             &ctx.bag_as_rack, results, base->target_score,
+                             base->target_num_exch, base->equity_margin,
+                             thread_control_get_status(ctx.thread_control) ==
+                                 THREAD_CONTROL_STATUS_USER_INTERRUPT);
+
+  prng_destroy(ctx.prng);
+  error_stack_destroy(ctx.inner_error_stack);
+  thread_control_destroy(ctx.inner_thread_control);
+  free(ctx.only_move_ptrs);
+  move_list_destroy(ctx.inner_move_list);
+  game_destroy(ctx.inner_game);
+  game_destroy(ctx.base_inner_game);
+}

--- a/src/impl/peg_inference.c
+++ b/src/impl/peg_inference.c
@@ -289,6 +289,7 @@ static double peg_evaluate_candidate_leave(PegInferCtx *ctx) {
 
   // 3. Find (or build) the observed move's slot in the candidate list.
   int obs_idx = -1;
+  bool obs_force_inserted = false;
   if (ctx->observed_move_type == GAME_EVENT_EXCHANGE) {
     const Rack *target_rack =
         player_get_rack(game_get_player(ctx->inner_game, ctx->target_index));
@@ -324,6 +325,7 @@ static double peg_evaluate_candidate_leave(PegInferCtx *ctx) {
       move_copy(extra, &ctx->observed_move_copy);
       ctx->inner_move_list->count = num_static + 1;
       obs_idx = num_static;
+      obs_force_inserted = true;
     }
   }
   if (obs_idx < 0) {
@@ -340,12 +342,20 @@ static double peg_evaluate_candidate_leave(PegInferCtx *ctx) {
   // 4. Static pre-filter: skip the (expensive) PEG solve when the observed move
   //    already trails the static best by a wide margin. Kept generous, since a
   //    low-static setup can still be the pre-endgame win% best.
-  if (ctx->leave_size > 1) {
+  //
+  //    Only applied when the observed move was found in the generated field, so
+  //    its equity is fresh and comparable. A force-inserted observed move
+  //    carries the caller's stale equity (never recomputed for this leave), is
+  //    by construction a low-static play we must not prune, and -- for a pass --
+  //    an EQUITY_PASS_VALUE that equity_to_double cannot convert; skipping the
+  //    filter for it keeps the comparison honest and avoids that crash.
+  if (ctx->leave_size > 1 && !obs_force_inserted) {
     const double best_static = equity_to_double(
         move_get_equity(move_list_get_move(ctx->inner_move_list, 0)));
     const double obs_static = equity_to_double(
         move_get_equity(move_list_get_move(ctx->inner_move_list, obs_idx)));
-    if (best_static - obs_static > ctx->static_prefilter_margin * 4.0) {
+    gap = best_static - obs_static;
+    if (gap > ctx->static_prefilter_margin * 4.0) {
       result = 0.0;
       goto invoke_callback;
     }
@@ -388,8 +398,21 @@ static double peg_evaluate_candidate_leave(PegInferCtx *ctx) {
       if (u > best_util) {
         best_util = u;
       }
-      if (obs_util < 0.0 && cand_is_observed(ctx, &peg_result.top_cands[i].move)) {
+      if (obs_util < 0.0 &&
+          cand_is_observed(ctx, &peg_result.top_cands[i].move)) {
         obs_util = u;
+      }
+    }
+    // top_cands is only the last completed stage's survivors; under the halving
+    // cascade a higher-utility candidate can be cut before the final stage (PEG
+    // ranks by win% + a tiny spread term, not by this utility). graded_cands
+    // holds every candidate that entered a halving stage, so scan it too for
+    // the true best (empty in greedy-seed mode, where top_cands is already the
+    // full field). The observed move is protected, so it stays in top_cands.
+    for (int i = 0; i < peg_result.n_graded; i++) {
+      const double u = peg_cand_utility(ctx, &peg_result.graded_cands[i]);
+      if (u > best_util) {
+        best_util = u;
       }
     }
     if (obs_util >= 0.0) {
@@ -425,9 +448,13 @@ static void record_candidate_leave(PegInferCtx *ctx, double weight) {
   if (raw_draws == 0) {
     return;
   }
+  // A leave that earned a strictly positive weight should not vanish to a zero
+  // draw count just because it has a single draw-combination (raw_draws == 1)
+  // and a sub-0.5 weight; floor it to 1 so low-multiplicity leaves are
+  // down-weighted, not dropped.
   uint64_t weighted = (uint64_t)(raw_draws * weight + 0.5);
   if (weighted == 0) {
-    return;
+    weighted = 1;
   }
   const KLV *klv =
       player_get_klv(game_get_player(ctx->base_inner_game, ctx->target_index));
@@ -514,6 +541,8 @@ static bool setup_base_inner_game(PegInferCtx *ctx,
         error_stack, ERROR_STATUS_INFERENCE_TARGET_LETTERS_NOT_IN_BAG,
         string_duplicate(
             "peg inference: failed to draw combined target tiles from bag"));
+    game_destroy(ctx->base_inner_game);
+    ctx->base_inner_game = NULL;
     return false;
   }
   if (!draw_rack_from_bag(ctx->base_inner_game, 1 - ctx->target_index,
@@ -565,10 +594,19 @@ void peg_infer(const PegInferenceArgs *args, InferenceResults *results,
                                 : PEG_INFER_DEFAULT_CANDIDATE_PLAYS;
   ctx.util_w_winpct =
       args->utility_w_winpct > 0.0 ? args->utility_w_winpct : 1.0;
-  ctx.util_w_spread = args->utility_w_spread; // 0.0 default = pure win%
+  // The pre-endgame inference unifies on the score+win blended utility, so the
+  // spread term is on by default (unlike the simmer's pure-win% default). The
+  // 0.3 utility margin is calibrated for this blend; a pure-win% gap (a few
+  // points) would be far too small for it.
+  ctx.util_w_spread =
+      args->utility_w_spread > 0.0 ? args->utility_w_spread : 1.0;
   ctx.util_spread_scale =
       args->utility_spread_scale > 0.0 ? args->utility_spread_scale : 100.0;
-  ctx.greedy_seed_only = args->greedy_seed_only;
+  // Inner-solve depth defaults per bag: the wider big-bag scenario space gets
+  // the cheap, deterministic greedy seed; 1-2 tiles in the bag can afford the
+  // halving cascade's deeper refinement.
+  const int peg_bag = bag_get_letters(game_get_bag(base->game));
+  ctx.greedy_seed_only = args->greedy_seed_only || (peg_bag >= 3);
   ctx.peg_max_stage = args->peg_max_stage;
   ctx.peg_scenario_stride = args->peg_scenario_stride;
   ctx.peg_opp_model = args->peg_opp_model;

--- a/src/impl/peg_inference.h
+++ b/src/impl/peg_inference.h
@@ -1,0 +1,121 @@
+#ifndef PEG_INFERENCE_H
+#define PEG_INFERENCE_H
+
+#include "../ent/inference_args.h"
+#include "../ent/inference_results.h"
+#include "../ent/move.h"
+#include "../impl/peg.h"
+#include "../util/io_util.h"
+
+// Pre-endgame (PEG) inference: evaluates candidate opponent racks by asking,
+// for each candidate leave, whether a PEG player holding that rack would have
+// made the observed play. It is the pre-endgame analogue of simmed inference
+// (simmed_inference.c) -- same leave enumeration, weighting, and result
+// recording -- but the inner "would they play this?" test runs one pre-endgame
+// solve over the candidate's top moves and compares their score+win utilities,
+// rather than an inner Monte Carlo sim.
+//
+// Applies only when the bag is in the PEG range [PEG_MIN_BAG, PEG_MAX_BAG]; the
+// caller is responsible for gating on bag size.
+//
+// The per-move value is the simmer's score+win utility (sim_utility_blend):
+// win% blended with a sigmoid of the mean spread, in [0, 1]. The whole codebase
+// is unifying on this metric, so inference uses it too: the acceptance gap is
+// best_utility - observed_utility, in the same [0, 1] units as the margin, and
+// no win_pct table is needed.
+
+// Maximum leave size evaluated by exhaustive enumeration; larger leaves are
+// Monte Carlo sampled within the time budget. Smaller than simmed inference's
+// because each inner evaluation is a full PEG solve (far more expensive than a
+// short sim), so exhaustive enumeration saturates sooner. Overridable per call
+// via PegInferenceArgs.exhaustive_max_leave.
+#define PEG_INFER_EXHAUSTIVE_MAX_DEFAULT 1
+
+// Callback invoked after each candidate leave is fully evaluated (debugging /
+// inspection). gap and the utilities are in [0, 1] utility units.
+typedef void (*PegInferLeaveCallback)(const Rack *candidate_leave,
+                                      const MoveList *move_list, int obs_idx,
+                                      double gap, double weight,
+                                      const Game *inner_game, void *user_data);
+
+// Arguments for pre-endgame inference. Wraps InferenceArgs and adds the
+// parameters needed for the inner PEG evaluation of candidate racks.
+typedef struct PegInferenceArgs {
+  // Standard inference parameters: game state, target player index, known
+  // tiles, equity margin, thread count, etc.
+  const InferenceArgs *base;
+
+  // The exact Move the target was observed to play.
+  //   - Tile placement: position/tiles/score used for matching.
+  //   - Exchange: only the tile count is matched.
+  const Move *observed_move;
+
+  // Candidate moves generated per leave -- the "top-N by equity" field the
+  // inner PEG solve ranks. The observed move is force-included even if it falls
+  // outside the top N (a low-static-equity setup can still be the pre-endgame
+  // best). Small (single digits) keeps each PEG solve affordable. 0 = default.
+  int num_candidate_plays;
+
+  // Score+win utility weights (sim_utility_blend, sim_args.h). The per-move
+  // value is (w_winpct*win% + w_spread*sigmoid(spread/spread_scale)) /
+  // (w_winpct + w_spread), in [0, 1]. Zero/unset uses w_winpct 1.0, w_spread
+  // 0.0 (pure win%), spread_scale 100.0. Set w_spread > 0 to weight margin.
+  double utility_w_winpct;
+  double utility_w_spread;
+  double utility_spread_scale;
+
+  // Inner PEG-solver configuration. The cost/depth levers that scale the
+  // inference from 1peg (afford a deeper solve per leave) to 4peg (cheap greedy
+  // solve, fewer candidates, sampled scenarios). Optional; 0/false uses a
+  // per-bag default chosen by peg_infer.
+  //   greedy_seed_only    : rank the field by the stage-0 greedy win% only
+  //                         (bounded, deterministic; the default for big bags).
+  //   peg_max_stage       : cap on PEG halving stages when not greedy-only.
+  //   peg_scenario_stride : PEG scenario sampling (1 = full, k > 1 = sampled).
+  //   peg_opp_model       : opponent model for the inner solve (default rational).
+  bool greedy_seed_only;
+  int peg_max_stage;
+  int peg_scenario_stride;
+  PegOppModel peg_opp_model;
+
+  // Per-leave wall-clock budget (seconds) for the inner PEG solve. 0 = the
+  // solver's own default. Scaled down as the outer leave count grows.
+  double peg_time_budget_s;
+
+  // Leave enumeration: exhaustive when leave_size <= exhaustive_max_leave, else
+  // Monte Carlo sampling. 0 = PEG_INFER_EXHAUSTIVE_MAX_DEFAULT.
+  int exhaustive_max_leave;
+
+  // Wall-clock budget (seconds) for the whole Monte Carlo sampling loop.
+  // Sampling stops when the budget is spent or an external interrupt arrives.
+  double time_budget_s;
+
+  // Logistic weight margin in utility units [0, 1]:
+  //   gap    = best_utility - observed_utility
+  //   weight = logistic centred at peg_utility_margin:
+  //     gap <= 0                 -> ~1.0  (observed is the PEG best)
+  //     gap = peg_utility_margin -> 0.5   (borderline)
+  //     gap >> peg_utility_margin -> ~0.0 (clearly not the best)
+  // Must be > 0; <= 0 uses a default of 0.3 (pre-endgame utility gaps run much
+  // larger than the simmer's few-point margins).
+  double peg_utility_margin;
+
+  // Static pre-filter margin, in equity points. For leaves larger than one
+  // tile, a candidate whose observed move trails the top static move by more
+  // than 4x this is skipped before any PEG solve. Kept generous in the
+  // pre-endgame, where a low-static setup can still be the win%-best move.
+  // <= 0 uses a default of 20.0.
+  double static_prefilter_margin;
+
+  // Optional per-leave callback; NULL to disable.
+  PegInferLeaveCallback leave_callback;
+  void *leave_callback_data;
+} PegInferenceArgs;
+
+// Runs pre-endgame inference, populating results with a weighted distribution
+// over likely opponent leaves. Threading: the outer candidate loop is
+// single-threaded; all base->num_threads are used for each inner PEG solve.
+void peg_infer(const PegInferenceArgs *args, InferenceResults *results,
+               ErrorStack *error_stack);
+
+#endif

--- a/src/impl/peg_inference.h
+++ b/src/impl/peg_inference.h
@@ -58,20 +58,25 @@ typedef struct PegInferenceArgs {
 
   // Score+win utility weights (sim_utility_blend, sim_args.h). The per-move
   // value is (w_winpct*win% + w_spread*sigmoid(spread/spread_scale)) /
-  // (w_winpct + w_spread), in [0, 1]. Zero/unset uses w_winpct 1.0, w_spread
-  // 0.0 (pure win%), spread_scale 100.0. Set w_spread > 0 to weight margin.
+  // (w_winpct + w_spread), in [0, 1]. Unlike the simmer (which defaults to pure
+  // win%), pre-endgame inference unifies on the blended utility: zero/unset
+  // uses w_winpct 1.0, w_spread 1.0 (blended), spread_scale 100.0, which the
+  // 0.3 utility margin is calibrated for.
   double utility_w_winpct;
   double utility_w_spread;
   double utility_spread_scale;
 
   // Inner PEG-solver configuration. The cost/depth levers that scale the
   // inference from 1peg (afford a deeper solve per leave) to 4peg (cheap greedy
-  // solve, fewer candidates, sampled scenarios). Optional; 0/false uses a
-  // per-bag default chosen by peg_infer.
+  // solve, fewer candidates, sampled scenarios).
   //   greedy_seed_only    : rank the field by the stage-0 greedy win% only
-  //                         (bounded, deterministic; the default for big bags).
-  //   peg_max_stage       : cap on PEG halving stages when not greedy-only.
-  //   peg_scenario_stride : PEG scenario sampling (1 = full, k > 1 = sampled).
+  //                         (bounded, deterministic). peg_infer forces this on
+  //                         for bag >= 3 regardless; for bag 1-2 it defaults off
+  //                         (the halving cascade), and setting it true overrides.
+  //   peg_max_stage       : cap on PEG halving stages when not greedy-only
+  //                         (0 = run the full cascade; only used for bag 1-2).
+  //   peg_scenario_stride : PEG scenario sampling (1 = full, k > 1 = sampled;
+  //                         0 = the solver's per-bag default). Passed through.
   //   peg_opp_model       : opponent model for the inner solve (default rational).
   bool greedy_seed_only;
   int peg_max_stage;

--- a/src/impl/random_variable.c
+++ b/src/impl/random_variable.c
@@ -683,6 +683,10 @@ void rv_sim_reset(RandomVariables *rvs, const SimArgs *sim_args) {
   simmer->use_alias_method =
       simmer->use_inference &&
       (!simmer->known_opp_rack || rack_is_empty(simmer->known_opp_rack));
+  // Refresh the inference results along with use_alias_method: a reused sim
+  // context whose previous solve ran without inference would otherwise sample
+  // racks through a stale (possibly NULL) pointer.
+  simmer->inference_results = sim_args->inference_results;
 
   simmer->utility_w_winpct = sim_args->utility_w_winpct;
   simmer->utility_w_spread = sim_args->utility_w_spread;

--- a/src/impl/simmed_inference.c
+++ b/src/impl/simmed_inference.c
@@ -1,0 +1,801 @@
+// Simulation-based inference: evaluates candidate opponent racks by running
+// short inner sims to determine whether a sim player with that rack would
+// have made the observed play.
+//
+// Compared to static inference (which uses KLV leave values), simmed inference
+// correctly handles setup plays whose sim equity exceeds their static equity.
+//
+// Architecture:
+//   - Outer loop: exhaustive enumeration (leave_size <=
+//   SIMMED_INFER_EXHAUSTIVE_MAX)
+//     or Monte Carlo sampling (larger leaves).
+//   - Inner evaluation: two-stage probe + full sim with early stopping.
+//   - Weight: smooth logistic on (best_sim_equity - obs_sim_equity); hedges
+//     uncertain cases with a midlevel weight rather than binary accept/reject.
+//   - Threading: all num_threads are devoted to each inner sim; the outer loop
+//     is single-threaded.
+
+#include "simmed_inference.h"
+
+#include "../compat/ctime.h"
+#include "../def/equity_defs.h"
+#include "../def/game_history_defs.h"
+#include "../def/letter_distribution_defs.h"
+#include "../def/move_defs.h"
+#include "../def/rack_defs.h"
+#include "../def/thread_control_defs.h"
+#include "../ent/alias_method.h"
+#include "../ent/bag.h"
+#include "../ent/equity.h"
+#include "../ent/game.h"
+#include "../ent/inference_args.h"
+#include "../ent/inference_results.h"
+#include "../ent/klv.h"
+#include "../ent/leave_rack.h"
+#include "../ent/letter_distribution.h"
+#include "../ent/move.h"
+#include "../ent/player.h"
+#include "../ent/rack.h"
+#include "../ent/sim_args.h"
+#include "../ent/sim_results.h"
+#include "../ent/stats.h"
+#include "../ent/thread_control.h"
+#include "../ent/win_pct.h"
+#include "../ent/xoshiro.h"
+#include "../impl/gameplay.h"
+#include "../impl/inference.h"
+#include "../impl/move_gen.h"
+#include "../impl/simmer.h"
+#include "../util/io_util.h"
+#include "../util/string_util.h"
+#include <math.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Conservative upper bound on tiles that could be in the leave pool.
+// Standard Scrabble has 100 tiles; even with small racks and bags this fits.
+#define MAX_SAMPLE_POOL 200
+
+// ── Internal context
+// ──────────────────────────────────────────────────────────
+
+typedef struct {
+  // Base game: target has target_played+target_known tiles; nontarget has
+  // nontarget_known tiles; bag = all_tiles - target_played - target_known
+  // - nontarget_known. game_copy'd into inner_game for each candidate.
+  Game *base_inner_game;
+
+  // Working copy reset for each candidate evaluation.
+  Game *inner_game;
+
+  // Pool of tiles available for leave draws
+  // (= all tiles minus target's known tiles and nontarget's known tiles).
+  Rack bag_as_rack;
+
+  // The candidate leave being evaluated (mutated during recursion / MC).
+  Rack current_leave;
+
+  // Combined known target tiles = target_played + target_known.
+  Rack target_known_combined;
+
+  // Sim infrastructure (reused across candidates).
+  MoveList *inner_move_list;
+  SimResults *inner_sim_results;
+  SimCtx *inner_sim_ctx;
+  ErrorStack *inner_error_stack;
+
+  // Observed move fields, extracted once at setup.
+  game_event_t observed_move_type;
+  int observed_num_exch;
+  Move observed_move_copy; // for exact tile-placement matching
+
+  int target_index;
+  int ld_size;
+  int leave_size;
+
+  // Tuning parameters.
+  int num_candidate_plays;
+  int num_inner_sim_plies;
+  int probe_iterations;
+  int full_iterations;
+  double time_budget_s;
+  double sim_equity_margin;
+
+  // Not owned.
+  ThreadControl *thread_control;
+  WinPct *win_pcts;
+  InferenceResults *results;
+  int num_threads;
+
+  // PRNG for Monte Carlo leave sampling.
+  XoshiroPRNG *prng;
+
+  // Monotonically increasing counter used as inner-sim seed.
+  uint64_t eval_count;
+
+  // Optional callback invoked after each candidate leave evaluation.
+  SimmedInferLeaveCallback leave_callback;
+  void *leave_callback_data;
+} SimmedInferCtx;
+
+// ── Bogopoints
+// ────────────────────────────────────────────────────────────────
+//
+// Converts a win-percentage gap to "bogopoints": the integer number of display
+// points X such that win_pct_get(wp, X, avg_unseen) − win_pct_get(wp, 0,
+// avg_unseen) ≈ wp_gap.  Uses equity_gap_pts as a fallback when both plays are
+// pinned at the same win% extreme (100%/0%) and the gap cannot be expressed in
+// the win_pct table.
+static double win_pct_gap_to_bogopoints(double wp_gap, int avg_unseen,
+                                        const WinPct *wp,
+                                        double equity_gap_pts) {
+  if (wp_gap <= 0.0) {
+    return 0.0;
+  }
+  // Clamp avg_unseen to the table's range.
+  const int max_unseen = win_pct_get_max_tiles_unseen(wp);
+  if (avg_unseen < 1) {
+    avg_unseen = 1;
+  }
+  if (avg_unseen > max_unseen) {
+    avg_unseen = max_unseen;
+  }
+
+  const double base_wp = (double)win_pct_get(wp, 0, (unsigned int)avg_unseen);
+  // win_pct_get clamps to max_spread, so 9999 gives the maximum win%.
+  const double max_wp = (double)win_pct_get(wp, 9999, (unsigned int)avg_unseen);
+  const double target_wp = base_wp + wp_gap;
+
+  // If target_wp is at or above the achievable maximum, fall back to equity.
+  if (target_wp >= max_wp) {
+    return equity_gap_pts;
+  }
+
+  // Binary search on integer display points.
+  int lo = 0, hi = 9999;
+  while (lo < hi) {
+    const int mid = lo + (hi - lo) / 2;
+    if ((double)win_pct_get(wp, mid, (unsigned int)avg_unseen) < target_wp) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  return (double)lo;
+}
+
+// ── Weight function
+// ───────────────────────────────────────────────────────────
+//
+// gap = bogopoints (display points derived from win% gap, may be negative)
+//
+// Returns weight in [0, 1]:
+//   gap <= 0              → ~1.0  (observed is the sim best)
+//   gap = sim_margin      →  0.5  (at the margin)
+//   gap = 2 * sim_margin  → ~0.05 (nearly rejected)
+//   gap >> sim_margin     → ~0.0
+//
+// Logistic centred at sim_margin with scale = sim_margin.
+static double compute_weight(double gap, double sim_margin) {
+  double x = (gap - sim_margin) / sim_margin;
+  return 1.0 / (1.0 + exp(3.0 * x));
+}
+
+// ── Observed-move matching
+// ────────────────────────────────────────────────────
+//
+// For tile placements: finds the index of the exact position+tile match.
+// For exchanges:       finds the first (highest-equity) exchange of the
+//                      observed count.
+// Returns -1 if no match exists (play impossible with this rack).
+static int find_observed_move_idx(const MoveList *ml,
+                                  const SimmedInferCtx *ctx) {
+  const int n = move_list_get_count(ml);
+  if (ctx->observed_move_type == GAME_EVENT_EXCHANGE) {
+    for (int i = 0; i < n; i++) {
+      const Move *m = move_list_get_move(ml, i);
+      if (move_get_type(m) == GAME_EVENT_EXCHANGE &&
+          move_get_tiles_played(m) == ctx->observed_num_exch) {
+        return i; // list is sorted descending; first match is best exchange
+      }
+    }
+  } else {
+    for (int i = 0; i < n; i++) {
+      // compare_moves_without_equity returns -1 when moves are identical
+      if (compare_moves_without_equity(move_list_get_move(ml, i),
+                                       &ctx->observed_move_copy,
+                                       /*allow_duplicates=*/true) == -1) {
+        return i;
+      }
+    }
+  }
+  return -1;
+}
+
+// ── KLV-optimal exchange builder
+// ──────────────────────────────────────────────
+//
+// Enumerates all C(total, exch_count) ways to split the rack and keeps the
+// split that maximises the KLV value of the leave (kept tiles).  The exchanged
+// tiles — the complement — are stored in out_move.
+//
+// For 7 tiles this is at most C(7,3)=C(7,4)=35 iterations; each iteration
+// costs one KLV lookup (fast hash).  Total cost is negligible.
+static void make_best_exchange_move(const Rack *rack, int exch_count,
+                                    const KLV *klv, int ld_size,
+                                    Move *out_move) {
+  // Flatten rack to an array of machine letters.
+  MachineLetter flat[RACK_SIZE];
+  int total = 0;
+  for (int ml = 0; ml < ld_size && total < RACK_SIZE; ml++) {
+    int cnt = (int)rack_get_letter(rack, ml);
+    for (int k = 0; k < cnt && total < RACK_SIZE; k++) {
+      flat[total++] = (MachineLetter)ml;
+    }
+  }
+
+  move_set_type(out_move, GAME_EVENT_EXCHANGE);
+  move_set_tiles_played(out_move, exch_count);
+  move_set_tiles_length(out_move, exch_count);
+  move_set_score(out_move, int_to_equity(0));
+
+  const int keep_count = total - exch_count;
+  if (keep_count <= 0) {
+    // Exchange everything — no leave to optimise.
+    for (int i = 0; i < total; i++) {
+      move_set_tile(out_move, flat[i], i);
+    }
+    move_set_equity(out_move, int_to_equity(0));
+    return;
+  }
+
+  // Enumerate all C(total, keep_count) index combinations.
+  int cur_idx[RACK_SIZE];
+  int best_idx[RACK_SIZE];
+  for (int i = 0; i < keep_count; i++) {
+    cur_idx[i] = i;
+    best_idx[i] = i;
+  }
+  Equity best_equity = 0;
+  bool first = true;
+  Rack leave_rack;
+  rack_set_dist_size_and_reset(&leave_rack, ld_size);
+
+  while (true) {
+    rack_reset(&leave_rack);
+    for (int i = 0; i < keep_count; i++) {
+      rack_add_letter(&leave_rack, flat[cur_idx[i]]);
+    }
+    Equity eq = klv_get_leave_value(klv, &leave_rack);
+    if (first || eq > best_equity) {
+      best_equity = eq;
+      for (int i = 0; i < keep_count; i++) {
+        best_idx[i] = cur_idx[i];
+      }
+      first = false;
+    }
+    // Advance to the next combination (standard algorithm).
+    int pos = keep_count - 1;
+    while (pos >= 0 && cur_idx[pos] == total - keep_count + pos) {
+      pos--;
+    }
+    if (pos < 0) {
+      break;
+    }
+    cur_idx[pos]++;
+    for (int i = pos + 1; i < keep_count; i++) {
+      cur_idx[i] = cur_idx[i - 1] + 1;
+    }
+  }
+
+  // Exchange tiles = everything in flat[] NOT at a best_idx position.
+  bool kept[RACK_SIZE] = {false};
+  for (int i = 0; i < keep_count; i++) {
+    kept[best_idx[i]] = true;
+  }
+  int tile_idx = 0;
+  for (int i = 0; i < total; i++) {
+    if (!kept[i]) {
+      move_set_tile(out_move, flat[i], tile_idx++);
+    }
+  }
+  move_set_equity(out_move, best_equity);
+}
+
+// ── Core candidate evaluation
+// ─────────────────────────────────────────────────
+//
+// Adds current_leave to the target's rack in inner_game (on top of the
+// target_known_combined tiles already drawn), generates moves, and runs a
+// two-stage probe/full sim. Returns a weight in [0, 1] representing how
+// consistent this candidate rack is with the observed play.
+static double sim_evaluate_candidate_leave(SimmedInferCtx *ctx) {
+  // 1. Set up inner_game: copy base, then add the candidate leave to the
+  //    target's rack. base_inner_game already has target_known_combined
+  //    (played + known tiles) drawn for the target; we ADD current_leave on
+  //    top so the target has their full rack (target_known_combined +
+  //    current_leave) and the observed move's tiles are always present.
+  //    draw_rack_from_bag would wrongly REPLACE the rack with only the leave,
+  //    causing rack_take_letter underflows when the observed move is played.
+  game_copy(ctx->inner_game, ctx->base_inner_game);
+  {
+    Rack *target_rack =
+        player_get_rack(game_get_player(ctx->inner_game, ctx->target_index));
+    const int draw_idx =
+        game_get_player_draw_index(ctx->inner_game, ctx->target_index);
+    Bag *bag = game_get_bag(ctx->inner_game);
+    for (int i = 0; i < ctx->ld_size; i++) {
+      const uint16_t n = rack_get_letter(&ctx->current_leave, i);
+      for (uint16_t j = 0; j < n; j++) {
+        if (!bag_draw_letter(bag, i, draw_idx)) {
+          return 0.0; // shouldn't happen if current_leave sampled from
+                      // bag_as_rack
+        }
+        rack_add_letter(target_rack, i);
+      }
+    }
+  }
+
+  // 2. Generate top num_candidate_plays moves by static equity.
+  //    The inner_move_list has capacity num_candidate_plays+RACK_SIZE so there
+  //    is always room to add the observed move and exchange arms.
+  move_list_reset(ctx->inner_move_list);
+  const MoveGenArgs gen_args = {
+      .game = ctx->inner_game,
+      .move_list = ctx->inner_move_list,
+      .move_record_type = MOVE_RECORD_ALL,
+      .move_sort_type = MOVE_SORT_EQUITY,
+      .override_kwg = NULL,
+      .eq_margin_movegen = 0,
+      .target_equity = EQUITY_MAX_VALUE,
+      .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+      .tiles_played_bv = NULL,
+  };
+  generate_moves(&gen_args);
+
+  // Sort first (heap → descending equity), then trim to top
+  // num_candidate_plays. Sorting before trimming is critical: the heap does not
+  // store elements in equity order, so trimming first would keep an arbitrary 5
+  // rather than the actual top 5.
+  move_list_sort_moves(ctx->inner_move_list);
+  if (move_list_get_count(ctx->inner_move_list) > ctx->num_candidate_plays) {
+    ctx->inner_move_list->count = ctx->num_candidate_plays;
+  }
+  const int num_static = move_list_get_count(ctx->inner_move_list);
+  if (num_static == 0) {
+    return 0.0;
+  }
+
+  // 3. Find (or build) the observed move's slot in the candidate list.
+  //
+  // For exchanges: always append one KLV-optimal exchange arm for every
+  // possible leave size (exchange counts 1..rack_total), so the inner sim
+  // compares the observed N-tile exchange against all other exchanges AND
+  // all scoring plays.  obs_idx is set to the arm whose count matches.
+  //
+  // For tile placements: try to find the exact observed move in the top-N;
+  // if absent (e.g. a setup play with low static equity), force-insert it
+  // into the reserved extra slot.
+  int obs_idx = -1;
+  if (ctx->observed_move_type == GAME_EVENT_EXCHANGE) {
+    const Rack *target_rack =
+        player_get_rack(game_get_player(ctx->inner_game, ctx->target_index));
+    const int rack_total = rack_get_total_letters(target_rack);
+    if (rack_total < ctx->observed_num_exch) {
+      return 0.0;
+    }
+    const KLV *klv =
+        player_get_klv(game_get_player(ctx->inner_game, ctx->target_index));
+    for (int k = 1; k <= rack_total; k++) {
+      Move *slot = ctx->inner_move_list->moves[num_static + k - 1];
+      make_best_exchange_move(target_rack, k, klv, ctx->ld_size, slot);
+      if (k == ctx->observed_num_exch) {
+        obs_idx = num_static + k - 1;
+      }
+    }
+    ctx->inner_move_list->count = num_static + rack_total;
+  } else {
+    // For tile placements, the observed move IS playable (target tiles include
+    // all played tiles), so the only thing missing is its ranking.
+    obs_idx = find_observed_move_idx(ctx->inner_move_list, ctx);
+    if (obs_idx < 0) {
+      Move *extra = ctx->inner_move_list->moves[num_static];
+      move_copy(extra, &ctx->observed_move_copy);
+      ctx->inner_move_list->count = num_static + 1;
+      obs_idx = num_static;
+    }
+  }
+  if (obs_idx < 0) {
+    return 0.0; // observed move not playable with this rack
+  }
+  if (ctx->inner_move_list->count == 1) {
+    return 1.0; // only one legal move; trivially consistent
+  }
+
+  // Declare here so all paths below see them (required before any goto).
+  const int inner_arms = ctx->inner_move_list->count;
+  double gap = 0.0;
+  double result = 0.0;
+
+  // 4. Static pre-filter: for leaves larger than 1 tile, skip the inner sim
+  //    when the observed move is already well behind the static best. 1-tile
+  //    leaves have at most ~33 candidates so they always sim. Larger leaves
+  //    can have thousands of candidates and this avoids most probe sims.
+  if (ctx->leave_size > 1) {
+    const double best_static = equity_to_double(
+        move_get_equity(move_list_get_move(ctx->inner_move_list, 0)));
+    const double obs_static = equity_to_double(
+        move_get_equity(move_list_get_move(ctx->inner_move_list, obs_idx)));
+    gap = best_static - obs_static;
+    if (gap > ctx->sim_equity_margin * 4.0) {
+      result = 0.0;
+      // Reset sim results so the callback sees iters=0 (no sim ran).
+      // Without this, inner_sim_results may hold stale data from a previous
+      // candidate with a different move-list size, causing out-of-bounds
+      // access.
+      sim_results_reset(ctx->inner_move_list, ctx->inner_sim_results,
+                        ctx->num_inner_sim_plies, ctx->eval_count,
+                        /*use_heat_map=*/false);
+      goto invoke_callback;
+    }
+  }
+
+  // 5. Run inner sim in two stages. Uses a local macro to avoid repeating the
+  //    sim setup. The inner sim always uses known_opp_rack=NULL so the target's
+  //    simulated opponent is sampled uniformly from available tiles.
+#define RUN_INNER_SIM(max_iters, gap_out)                                      \
+  do {                                                                         \
+    ctx->eval_count++;                                                         \
+    thread_control_set_status(ctx->thread_control,                             \
+                              THREAD_CONTROL_STATUS_STARTED);                  \
+    SimArgs _sa;                                                               \
+    sim_args_fill(                                                             \
+        ctx->num_inner_sim_plies, ctx->inner_move_list,                        \
+        /*num_plays=*/inner_arms, /*known_opp_rack=*/NULL, ctx->win_pcts,      \
+        /*inference_results=*/NULL, ctx->thread_control, ctx->inner_game,      \
+        /*use_inference=*/false, /*use_heat_map=*/false, ctx->num_threads,     \
+        /*print_interval=*/0, /*max_display_plays=*/inner_arms,                \
+        /*max_display_plies=*/ctx->num_inner_sim_plies,                        \
+        /*seed=*/ctx->eval_count, /*max_iterations=*/(uint64_t)(max_iters),    \
+        /*min_play_iterations=*/1, /*scond=*/101.0, BAI_THRESHOLD_NONE,        \
+        /*time_limit_seconds=*/9999, BAI_SAMPLING_RULE_ROUND_ROBIN,            \
+        /*cutoff=*/0.0, /*inference_args=*/NULL, &_sa);                        \
+    error_stack_reset(ctx->inner_error_stack);                                 \
+    simulate(&_sa, &ctx->inner_sim_ctx, ctx->inner_sim_results,                \
+             ctx->inner_error_stack);                                          \
+    /* Find best arm by win% (not equity) */                                   \
+    int _best_arm = 0;                                                         \
+    double _best_wp_val = -1.0;                                                \
+    for (int _i = 0; _i < inner_arms; _i++) {                                  \
+      const double _wp = stat_get_mean(simmed_play_get_win_pct_stat(           \
+          sim_results_get_simmed_play(ctx->inner_sim_results, _i)));           \
+      if (_wp > _best_wp_val) {                                                \
+        _best_wp_val = _wp;                                                    \
+        _best_arm = _i;                                                        \
+      }                                                                        \
+    }                                                                          \
+    const double _obs_wp = stat_get_mean(simmed_play_get_win_pct_stat(         \
+        sim_results_get_simmed_play(ctx->inner_sim_results, obs_idx)));        \
+    const double _wp_gap = _best_wp_val - _obs_wp;                             \
+    /* Equity gap used as fallback for bogopoints when both plays are pinned   \
+     */                                                                        \
+    const double _best_eq = stat_get_mean(simmed_play_get_equity_stat(         \
+        sim_results_get_simmed_play(ctx->inner_sim_results, _best_arm)));      \
+    const double _obs_eq = stat_get_mean(simmed_play_get_equity_stat(          \
+        sim_results_get_simmed_play(ctx->inner_sim_results, obs_idx)));        \
+    /* Avg unseen tiles: bag + opponent rack before any move is executed */    \
+    const int _bag_sz = bag_get_letters(game_get_bag(ctx->inner_game));        \
+    const int _opp_sz = rack_get_total_letters(player_get_rack(                \
+        game_get_player(ctx->inner_game, 1 - ctx->target_index)));             \
+    int _avg_unseen = _bag_sz + _opp_sz;                                       \
+    if (_avg_unseen < 1)                                                       \
+      _avg_unseen = 1;                                                         \
+    (gap_out) = win_pct_gap_to_bogopoints(_wp_gap, _avg_unseen, ctx->win_pcts, \
+                                          _best_eq - _obs_eq);                 \
+  } while (0)
+
+  RUN_INNER_SIM(ctx->probe_iterations, gap);
+
+  // Respect outer interrupt (e.g. total inference time budget exhausted).
+  if (thread_control_get_status(ctx->thread_control) ==
+      THREAD_CONTROL_STATUS_USER_INTERRUPT) {
+    result = compute_weight(gap, ctx->sim_equity_margin);
+    goto invoke_callback;
+  }
+
+  // Early reject: gap far above margin even after a rough probe.
+  if (gap > ctx->sim_equity_margin * 4.0) {
+    result = 0.0;
+    goto invoke_callback;
+  }
+
+  // Early accept: observed play is the sim best (or better).
+  if (gap <= 0.0) {
+    result = 1.0;
+    goto invoke_callback;
+  }
+
+  // Uncertain: run the full evaluation for a more reliable estimate.
+  RUN_INNER_SIM(ctx->full_iterations, gap);
+
+#undef RUN_INNER_SIM
+
+  result = compute_weight(gap, ctx->sim_equity_margin);
+  if (thread_control_get_status(ctx->thread_control) ==
+      THREAD_CONTROL_STATUS_USER_INTERRUPT) {
+    goto invoke_callback; // result already set above
+  }
+
+invoke_callback:
+  if (ctx->leave_callback) {
+    ctx->leave_callback(&ctx->current_leave, ctx->inner_move_list,
+                        ctx->inner_sim_results, obs_idx, gap, result,
+                        ctx->inner_game, ctx->leave_callback_data);
+  }
+  return result;
+}
+
+// ── Recording a candidate leave
+// ───────────────────────────────────────────────
+//
+// Weights the leave's combinatorial draw count by the sim acceptance weight
+// and records it into InferenceResults.
+static void record_candidate_leave(SimmedInferCtx *ctx, double weight) {
+  if (weight <= 0.0) {
+    return;
+  }
+
+  uint64_t raw_draws =
+      get_number_of_draws_for_rack(&ctx->bag_as_rack, &ctx->current_leave);
+  if (raw_draws == 0) {
+    return;
+  }
+
+  // Scale draw count by sim acceptance weight.
+  // Rounding 0.5 * 1 → 1 is acceptable: uncertain single-draw leaves are
+  // included at full weight, matching the "hedge" intent.
+  uint64_t weighted = (uint64_t)(raw_draws * weight + 0.5);
+  if (weighted == 0) {
+    return;
+  }
+
+  const KLV *klv =
+      player_get_klv(game_get_player(ctx->base_inner_game, ctx->target_index));
+  Equity leave_equity = klv_get_leave_value(klv, &ctx->current_leave);
+
+  record_valid_leave(&ctx->current_leave, ctx->results, INFERENCE_TYPE_LEAVE,
+                     equity_to_double(leave_equity), weighted);
+  alias_method_add_rack(inference_results_get_alias_method(ctx->results),
+                        &ctx->current_leave, (int)weighted);
+  leave_rack_list_insert_rack(
+      &ctx->current_leave, /*exchanged=*/NULL, (int)weighted, leave_equity,
+      inference_results_get_leave_rack_list(ctx->results));
+}
+
+// ── Evaluate + record
+// ─────────────────────────────────────────────────────────
+
+static void evaluate_and_record(SimmedInferCtx *ctx) {
+  if (thread_control_get_status(ctx->thread_control) ==
+      THREAD_CONTROL_STATUS_USER_INTERRUPT) {
+    return;
+  }
+  double weight = sim_evaluate_candidate_leave(ctx);
+  record_candidate_leave(ctx, weight);
+}
+
+// ── Exhaustive enumeration
+// ─────────────────────────────────────────────────────
+//
+// Recursively enumerates all combinations of `tiles_to_place` tiles from
+// bag_as_rack (multiset combinations, no duplicates). Mirrors the recursion
+// in the static inference's iterate_through_all_possible_leaves.
+static void exhaust_leaves(SimmedInferCtx *ctx, int tiles_to_place,
+                           int start_letter) {
+  if (thread_control_get_status(ctx->thread_control) ==
+      THREAD_CONTROL_STATUS_USER_INTERRUPT) {
+    return;
+  }
+  if (tiles_to_place == 0) {
+    evaluate_and_record(ctx);
+    return;
+  }
+  for (int letter = start_letter; letter < ctx->ld_size; letter++) {
+    if (rack_get_letter(&ctx->bag_as_rack, letter) > 0) {
+      rack_take_letter(&ctx->bag_as_rack, letter);
+      rack_add_letter(&ctx->current_leave, letter);
+      exhaust_leaves(ctx, tiles_to_place - 1, letter);
+      rack_take_letter(&ctx->current_leave, letter);
+      rack_add_letter(&ctx->bag_as_rack, letter);
+    }
+  }
+}
+
+// ── Monte Carlo leave sampling
+// ────────────────────────────────────────────────
+//
+// Samples leave_size tiles without replacement from bag_as_rack using a
+// Fisher-Yates partial shuffle. Writes the result into ctx->current_leave.
+static void sample_leave_mc(SimmedInferCtx *ctx) {
+  MachineLetter pool[MAX_SAMPLE_POOL];
+  int total = 0;
+  for (int i = 0; i < ctx->ld_size && total < MAX_SAMPLE_POOL; i++) {
+    int cnt = rack_get_letter(&ctx->bag_as_rack, i);
+    for (int j = 0; j < cnt && total < MAX_SAMPLE_POOL; j++) {
+      pool[total++] = (MachineLetter)i;
+    }
+  }
+
+  rack_reset(&ctx->current_leave);
+  const int n = ctx->leave_size < total ? ctx->leave_size : total;
+  for (int i = 0; i < n; i++) {
+    uint64_t j =
+        (uint64_t)i + prng_get_random_number(ctx->prng, (uint64_t)(total - i));
+    MachineLetter tmp = pool[i];
+    pool[i] = pool[j];
+    pool[j] = tmp;
+    rack_add_letter(&ctx->current_leave, pool[i]);
+  }
+}
+
+// ── Base game setup
+// ───────────────────────────────────────────────────────────
+//
+// Prepares base_inner_game with:
+//   - target player: target_played + target_known tiles
+//   - nontarget player: nontarget_known tiles
+//   - bag: all_tiles - target_played - target_known - nontarget_known
+//
+// Also populates bag_as_rack (the pool for candidate leave sampling).
+// The nontarget's known tiles ARE drawn into base_inner_game so they are
+// excluded from the leave pool. However, the inner sim's set_random_rack(NULL)
+// will return them to the bag and draw a fresh random rack each iteration,
+// ensuring the target player never has knowledge of the nontarget's rack.
+static bool setup_base_inner_game(SimmedInferCtx *ctx,
+                                  const SimmedInferenceArgs *args,
+                                  ErrorStack *error_stack) {
+  const InferenceArgs *base = args->base;
+
+  ctx->base_inner_game = game_duplicate(base->game);
+
+  // Start from a clean pool: return both racks to the bag.
+  return_rack_to_bag(ctx->base_inner_game, 0);
+  return_rack_to_bag(ctx->base_inner_game, 1);
+
+  // Build combined known target tiles = target_played + target_known.
+  rack_set_dist_size_and_reset(&ctx->target_known_combined, ctx->ld_size);
+  rack_union(&ctx->target_known_combined, base->target_played_tiles);
+  rack_union(&ctx->target_known_combined, base->target_known_rack);
+
+  if (!draw_rack_from_bag(ctx->base_inner_game, ctx->target_index,
+                          &ctx->target_known_combined)) {
+    error_stack_push(
+        error_stack, ERROR_STATUS_INFERENCE_TARGET_LETTERS_NOT_IN_BAG,
+        string_duplicate(
+            "simmed inference: failed to draw combined target tiles from bag"));
+    return false;
+  }
+
+  if (!draw_rack_from_bag(ctx->base_inner_game, 1 - ctx->target_index,
+                          base->nontarget_known_rack)) {
+    // This mirrors the log_fatal in static inference for the same condition.
+    log_fatal("simmed inference: failed to draw nontarget known rack from bag");
+  }
+
+  // bag_as_rack = tiles remaining after both known racks are drawn.
+  // This is the pool from which candidate leaves will be sampled.
+  const Bag *bag = game_get_bag(ctx->base_inner_game);
+  int bag_counts[MAX_ALPHABET_SIZE];
+  memset(bag_counts, 0, sizeof(bag_counts));
+  bag_increment_unseen_count(bag, bag_counts);
+  rack_set_dist_size_and_reset(&ctx->bag_as_rack, ctx->ld_size);
+  for (int i = 0; i < MAX_ALPHABET_SIZE; i++) {
+    rack_add_letters(&ctx->bag_as_rack, i, bag_counts[i]);
+  }
+
+  return true;
+}
+
+// ── Entry point
+// ───────────────────────────────────────────────────────────────
+
+void simmed_infer(const SimmedInferenceArgs *args, InferenceResults *results,
+                  ErrorStack *error_stack) {
+  const InferenceArgs *base = args->base;
+
+  if (!args->observed_move) {
+    error_stack_push(
+        error_stack, ERROR_STATUS_INFERENCE_NO_TILES_PLAYED,
+        string_duplicate("simmed_infer: no observed move provided"));
+    return;
+  }
+
+  const int known_target_tiles =
+      rack_get_total_letters(base->target_played_tiles) +
+      rack_get_total_letters(base->target_known_rack);
+  const int leave_size = RACK_SIZE - known_target_tiles;
+  if (leave_size < 0) {
+    error_stack_push(
+        error_stack, ERROR_STATUS_INFERENCE_RACK_OVERFLOW,
+        string_duplicate(
+            "simmed_infer: more known target tiles than rack size"));
+    return;
+  }
+
+  SimmedInferCtx ctx;
+  memset(&ctx, 0, sizeof(ctx));
+
+  ctx.target_index = base->target_index;
+  ctx.ld_size = ld_get_size(game_get_ld(base->game));
+  ctx.leave_size = leave_size;
+  ctx.num_candidate_plays = args->num_candidate_plays;
+  ctx.num_inner_sim_plies = args->num_inner_sim_plies;
+  ctx.probe_iterations = args->probe_iterations;
+  ctx.full_iterations = args->full_iterations;
+  ctx.time_budget_s = args->time_budget_s;
+  ctx.sim_equity_margin =
+      (args->sim_equity_margin > 0.0) ? args->sim_equity_margin : 3.0;
+  ctx.thread_control = base->thread_control;
+  ctx.win_pcts = args->win_pcts;
+  ctx.results = results;
+  ctx.num_threads = base->num_threads;
+  ctx.eval_count = 0;
+
+  ctx.observed_move_type = move_get_type(args->observed_move);
+  ctx.observed_num_exch = base->target_num_exch;
+  move_copy(&ctx.observed_move_copy, args->observed_move);
+  ctx.leave_callback = args->leave_callback;
+  ctx.leave_callback_data = args->leave_callback_data;
+
+  rack_set_dist_size_and_reset(&ctx.bag_as_rack, ctx.ld_size);
+  rack_set_dist_size_and_reset(&ctx.current_leave, ctx.ld_size);
+  rack_set_dist_size_and_reset(&ctx.target_known_combined, ctx.ld_size);
+
+  if (!setup_base_inner_game(&ctx, args, error_stack)) {
+    return;
+  }
+
+  inference_results_reset(results, base->leave_list_capacity, ctx.ld_size);
+
+  // RACK_SIZE extra slots: for exchanges, we add one best-exchange arm per
+  // possible leave size (0..RACK_SIZE-1), i.e. exchange counts 1..RACK_SIZE.
+  ctx.inner_move_list = move_list_create(args->num_candidate_plays + RACK_SIZE);
+  ctx.inner_sim_results = sim_results_create(0.0);
+  ctx.inner_sim_ctx = NULL;
+  ctx.inner_error_stack = error_stack_create();
+  ctx.inner_game = game_duplicate(ctx.base_inner_game);
+  ctx.prng = prng_create(42);
+
+  if (leave_size == 0) {
+    // Bingo or full exchange: leave is empty, only one candidate.
+    rack_reset(&ctx.current_leave);
+    evaluate_and_record(&ctx);
+  } else if (leave_size <= SIMMED_INFER_EXHAUSTIVE_MAX) {
+    exhaust_leaves(&ctx, leave_size, BLANK_MACHINE_LETTER);
+  } else {
+    Timer mc_timer;
+    ctimer_reset(&mc_timer);
+    ctimer_start(&mc_timer);
+    while (thread_control_get_status(ctx.thread_control) !=
+               THREAD_CONTROL_STATUS_USER_INTERRUPT &&
+           ctimer_elapsed_seconds(&mc_timer) < ctx.time_budget_s) {
+      sample_leave_mc(&ctx);
+      evaluate_and_record(&ctx);
+    }
+  }
+
+  inference_results_finalize(base->target_played_tiles, base->target_known_rack,
+                             &ctx.bag_as_rack, results, base->target_score,
+                             base->target_num_exch, base->equity_margin,
+                             thread_control_get_status(ctx.thread_control) ==
+                                 THREAD_CONTROL_STATUS_USER_INTERRUPT);
+
+  prng_destroy(ctx.prng);
+  error_stack_destroy(ctx.inner_error_stack);
+  sim_ctx_destroy(ctx.inner_sim_ctx);
+  sim_results_destroy(ctx.inner_sim_results);
+  move_list_destroy(ctx.inner_move_list);
+  game_destroy(ctx.inner_game);
+  game_destroy(ctx.base_inner_game);
+}

--- a/src/impl/simmed_inference.h
+++ b/src/impl/simmed_inference.h
@@ -1,0 +1,97 @@
+#ifndef SIMMED_INFERENCE_H
+#define SIMMED_INFERENCE_H
+
+#include "../ent/inference_args.h"
+#include "../ent/inference_results.h"
+#include "../ent/move.h"
+#include "../ent/sim_results.h"
+#include "../ent/win_pct.h"
+#include "../util/io_util.h"
+
+// Maximum leave size for which exhaustive enumeration is used.
+// For leave_size > this value, Monte Carlo sampling is used instead.
+#define SIMMED_INFER_EXHAUSTIVE_MAX 2
+
+// Callback invoked after each candidate leave is fully evaluated.
+//
+// Parameters:
+//   candidate_leave  — the leave rack being evaluated
+//   move_list        — candidate moves with sim equities populated
+//                      (static equities if statically rejected before any sim)
+//   sim_results      — inner sim results from the last sim stage run;
+//                      may have 0 iterations if statically pre-filtered
+//   obs_idx          — index of the observed move in move_list
+//   gap              — best_sim_equity - obs_sim_equity (or static gap if
+//                      rejected before sim)
+//   weight           — final acceptance weight in [0, 1]
+//   inner_game       — the inner game used for evaluation (for board/LD access)
+//   user_data        — caller-supplied context pointer
+typedef void (*SimmedInferLeaveCallback)(const Rack *candidate_leave,
+                                         const MoveList *move_list,
+                                         const SimResults *sim_results,
+                                         int obs_idx, double gap, double weight,
+                                         const Game *inner_game,
+                                         void *user_data);
+
+// Arguments for simulation-based inference. Wraps InferenceArgs and adds
+// the parameters needed for inner-sim evaluation of candidate racks.
+typedef struct SimmedInferenceArgs {
+  // Standard inference parameters: game state, target player index, known
+  // tiles, equity margin, thread count, etc.
+  const InferenceArgs *base;
+
+  // The exact Move that was observed by the inferring player.
+  //   - Tile placement: all fields (position, tiles, score) used for matching.
+  //   - Exchange: only tiles_played (count) is matched; position/tiles ignored.
+  const Move *observed_move;
+
+  // Win-percentage table required by the inner simulator.
+  WinPct *win_pcts;
+
+  // Number of candidate plays to generate per rack evaluation.
+  int num_candidate_plays;
+
+  // Sim plies for each inner evaluation (1 or 2 recommended).
+  int num_inner_sim_plies;
+
+  // Quick probe: total sim iterations run first to detect obvious cases.
+  // If gap is clearly above or below the accept threshold, stops here.
+  int probe_iterations;
+
+  // Full evaluation: additional iterations run when the probe result is
+  // uncertain (gap is within the midrange). The total in the uncertain case
+  // is probe_iterations + full_iterations.
+  int full_iterations;
+
+  // Wall-clock budget (seconds) for the Monte Carlo loop when
+  // leave_size > SIMMED_INFER_EXHAUSTIVE_MAX. Sampling stops when either
+  // the budget is exhausted or an external interrupt arrives.
+  double time_budget_s;
+
+  // Optional per-leave callback for debugging/inspection. Called after every
+  // candidate leave evaluation with the inner move list and sim results.
+  // Set to NULL to disable (default behaviour).
+  SimmedInferLeaveCallback leave_callback;
+  void *leave_callback_data;
+
+  // Sim equity margin in display points (e.g. 3.0) used by the weight function.
+  //   gap  = best_sim_equity - observed_sim_equity
+  //   weight = logistic centred at sim_equity_margin:
+  //     gap <= 0             → ~1.0  (observed is the sim best)
+  //     gap = sim_equity_margin → 0.5  (borderline)
+  //     gap >> sim_equity_margin → ~0.0  (clearly not the best)
+  // Must be > 0; if <= 0 a default of 3.0 is used.
+  double sim_equity_margin;
+} SimmedInferenceArgs;
+
+// Runs simulation-based inference, populating results with a weighted
+// distribution over likely opponent leaves. Compared to static inference,
+// this evaluates whether a candidate rack would produce the observed play
+// under sim (not static-equity) play, making it sensitive to setup plays.
+//
+// Threading: the outer candidate loop is single-threaded; all threads in
+// base->num_threads are used for each inner sim evaluation.
+void simmed_infer(const SimmedInferenceArgs *args, InferenceResults *results,
+                  ErrorStack *error_stack);
+
+#endif

--- a/src/impl/simmer.c
+++ b/src/impl/simmer.c
@@ -84,12 +84,16 @@ void simulate(SimArgs *sim_args, SimCtx **sim_ctx, SimResults *sim_results,
 
   uint64_t num_infer_leaves = 0;
   if (sim_args->use_inference) {
-    infer(&sim_args->inference_args, &((*sim_ctx)->inference_ctx),
-          sim_args->inference_results, error_stack);
-    if (!error_stack_is_empty(error_stack) ||
-        thread_control_get_status(sim_args->thread_control) !=
-            THREAD_CONTROL_STATUS_STARTED) {
-      return;
+    // A caller that already computed the leave distribution (e.g. simmed
+    // inference) passes it through untouched; otherwise run static inference.
+    if (!sim_args->inference_results_precomputed) {
+      infer(&sim_args->inference_args, &((*sim_ctx)->inference_ctx),
+            sim_args->inference_results, error_stack);
+      if (!error_stack_is_empty(error_stack) ||
+          thread_control_get_status(sim_args->thread_control) !=
+              THREAD_CONTROL_STATUS_STARTED) {
+        return;
+      }
     }
     num_infer_leaves =
         stat_get_num_unique_samples(inference_results_get_equity_values(

--- a/test/peginf_benchmark.c
+++ b/test/peginf_benchmark.c
@@ -1,36 +1,49 @@
-// A/B benchmark for pre-endgame (PEG) inference. The end goal: from PEG
-// positions, play the game out with Player A (uniform PEG) vs Player B
-// (inference-weighted PEG), equal per-turn budget, and tally the win%/spread
-// difference, logging per-turn wall time to confirm neither arm overruns.
+// A/B benchmark for pre-endgame (PEG) inference. From a PEG position, play the
+// game out with the inferring player using uniform PEG (arm A) vs
+// inference-weighted PEG (arm B), an equal per-turn budget, and the d25 endgame
+// once the bag empties. Logs per-turn wall time (inference + solve) to confirm
+// neither arm overruns, and reports each arm's final spread.
 //
-// This is built incrementally. THIS increment lands the playout core: from a
-// position, choose and play each move -- PEG (greedy seed) while the bag holds
-// [PEG_MIN_BAG, PEG_MAX_BAG] tiles, a static best otherwise (a placeholder for
-// the d25 time-limited endgame) -- until the game ends, logging per-turn time
-// against the budget. The inference variant (Player B), position generation
-// (static -> sim -> <=4, and PEG -> PEG), and the A/B aggregation build on top.
+// The inferring player's PEG turns weight peg_solve's scenarios by an inference
+// of the opponent's leave from the opponent's previous move: simmed inference
+// when the opponent moved with a bag >= 5, peg inference when <= 4 (they were in
+// a PEG situation themselves). The opponent plays uniform PEG in both arms.
+//
+// Built incrementally: increment 3 adds the inference variant on top of the
+// playout core (PEG + d25 endgame). Position generation and multi-position
+// aggregation follow.
 
+#include "../src/compat/ctime.h"
 #include "../src/def/equity_defs.h"
+#include "../src/def/game_history_defs.h"
+#include "../src/def/letter_distribution_defs.h"
 #include "../src/def/move_defs.h"
 #include "../src/def/peg_defs.h"
 #include "../src/def/thread_control_defs.h"
-#include "../src/compat/ctime.h"
 #include "../src/ent/bag.h"
 #include "../src/ent/endgame_results.h"
 #include "../src/ent/equity.h"
 #include "../src/ent/game.h"
+#include "../src/ent/inference_args.h"
+#include "../src/ent/inference_results.h"
+#include "../src/ent/letter_distribution.h"
 #include "../src/ent/move.h"
 #include "../src/ent/player.h"
+#include "../src/ent/rack.h"
 #include "../src/ent/thread_control.h"
+#include "../src/ent/win_pct.h"
 #include "../src/impl/config.h"
 #include "../src/impl/endgame.h"
 #include "../src/impl/gameplay.h"
 #include "../src/impl/move_gen.h"
 #include "../src/impl/peg.h"
+#include "../src/impl/peg_inference.h"
+#include "../src/impl/simmed_inference.h"
 #include "../src/util/io_util.h"
 #include "test_util.h"
 #include <assert.h>
 #include <stdio.h>
+#include <string.h>
 #include <time.h>
 
 // A real 4-in-bag CSW24 pre-endgame: player 0 (ACEINOP) on turn, bag = 4.
@@ -42,6 +55,13 @@
 #define PEG_BENCH_TURN_BUDGET_S 3.0
 #define PEG_BENCH_MAX_CANDIDATES 20
 #define PEG_BENCH_ENDGAME_PLIES 25
+#define PEG_BENCH_INFERENCE_SAMPLES 200
+// Fraction of the per-turn budget the inference step may use; the rest goes to
+// the PEG solve so the whole turn stays within budget.
+#define PEG_BENCH_INFER_BUDGET_FRAC 0.4
+// Opponent's-turn bag >= this uses simmed inference; below uses peg inference.
+#define PEG_BENCH_SIM_INFER_BAG 5
+#define PEG_BENCH_INFER_CANDIDATES 7
 
 static double peg_bench_now_s(void) {
   struct timespec t;
@@ -49,11 +69,114 @@ static double peg_bench_now_s(void) {
   return (double)t.tv_sec + (double)t.tv_nsec * 1e-9;
 }
 
-// Solve and play the endgame (bag empty), capped to the same per-turn budget as
-// the pre-endgame turns: a depth-25 solve with soft/hard IDS limits and a hard
-// wall-clock deadline all set to budget_s. Returns true if a move was played.
+// ── Inference setup (mirrors simmedinf_benchmark) ────────────────────────────
+
+static void peg_bench_extract_played_tiles(const Move *move, int ld_size,
+                                           Rack *played) {
+  rack_set_dist_size_and_reset(played, ld_size);
+  const int n = move_get_tiles_length(move);
+  for (int i = 0; i < n; i++) {
+    const MachineLetter ml = move_get_tile(move, i);
+    if (ml != PLAYED_THROUGH_MARKER) {
+      rack_add_letter(played, get_is_blanked(ml) ? BLANK_MACHINE_LETTER : ml);
+    }
+  }
+}
+
+typedef struct {
+  Rack target_played_tiles;
+  Rack target_known_rack;
+  Rack nontarget_known_rack;
+  InferenceArgs args;
+} PegBenchInferSetup;
+
+static void peg_bench_fill_infer_args(PegBenchInferSetup *setup,
+                                      const Game *game_before_prev,
+                                      const Move *prev_move,
+                                      int prev_player_index,
+                                      ThreadControl *thread_control) {
+  const int ld_size = ld_get_size(game_get_ld(game_before_prev));
+  rack_set_dist_size_and_reset(&setup->target_known_rack, ld_size);
+  rack_set_dist_size_and_reset(&setup->nontarget_known_rack, ld_size);
+
+  int target_num_exch = 0;
+  if (move_get_type(prev_move) == GAME_EVENT_EXCHANGE) {
+    target_num_exch = move_get_tiles_played(prev_move);
+    rack_set_dist_size_and_reset(&setup->target_played_tiles, ld_size);
+  } else {
+    peg_bench_extract_played_tiles(prev_move, ld_size,
+                                   &setup->target_played_tiles);
+  }
+  rack_copy(&setup->nontarget_known_rack,
+            player_get_rack(
+                game_get_player(game_before_prev, 1 - prev_player_index)));
+
+  infer_args_fill(&setup->args, /*leave_list_capacity=*/PEG_BENCH_INFER_CANDIDATES,
+                  int_to_equity(0), NULL, game_before_prev, /*num_threads=*/1,
+                  /*parent_worker_thread_index=*/0, /*print_interval=*/0,
+                  thread_control, /*use_game_history=*/false,
+                  /*use_inference_cutoff_optimization=*/false, prev_player_index,
+                  move_get_score(prev_move), target_num_exch,
+                  &setup->target_played_tiles, &setup->target_known_rack,
+                  &setup->nontarget_known_rack);
+}
+
+// Infer the opponent's leave distribution from their previous move: simmed
+// inference when they moved with a bag >= PEG_BENCH_SIM_INFER_BAG, peg inference
+// when they were themselves in the PEG range. Returns true on success.
+static bool peg_bench_run_inference(const Game *game_before_prev,
+                                    const Move *prev_move,
+                                    int prev_player_index, int prev_turn_bag,
+                                    WinPct *win_pcts,
+                                    ThreadControl *thread_control,
+                                    InferenceResults *results, double budget_s,
+                                    ErrorStack *error_stack) {
+  PegBenchInferSetup setup;
+  peg_bench_fill_infer_args(&setup, game_before_prev, prev_move,
+                            prev_player_index, thread_control);
+  thread_control_set_status(thread_control, THREAD_CONTROL_STATUS_STARTED);
+  if (prev_turn_bag >= PEG_BENCH_SIM_INFER_BAG) {
+    const SimmedInferenceArgs si_args = {
+        .base = &setup.args,
+        .observed_move = prev_move,
+        .win_pcts = win_pcts,
+        .num_candidate_plays = PEG_BENCH_INFER_CANDIDATES,
+        .num_inner_sim_plies = 2,
+        .probe_iterations = 20,
+        .full_iterations = 40,
+        .time_budget_s = budget_s,
+        .sim_equity_margin = 3.0,
+    };
+    simmed_infer(&si_args, results, error_stack);
+  } else {
+    // Keep the inference inside its slice of the turn budget: bound each inner
+    // PEG solve (peg_time_budget_s) and push leaves of size > 1 onto the
+    // time-bounded Monte-Carlo path (only leaves of size <= exhaustive_max_leave
+    // take peg_infer's unbounded exhaustive path).
+    const PegInferenceArgs peg_args = {
+        .base = &setup.args,
+        .observed_move = prev_move,
+        .num_candidate_plays = PEG_BENCH_INFER_CANDIDATES,
+        .exhaustive_max_leave = 1,
+        .peg_time_budget_s = 0.1,
+        .time_budget_s = budget_s,
+    };
+    peg_infer(&peg_args, results, error_stack);
+  }
+  if (!error_stack_is_empty(error_stack)) {
+    error_stack_reset(error_stack);
+    return false;
+  }
+  return true;
+}
+
+// ── Move selection ───────────────────────────────────────────────────────────
+
+// Solve and play the endgame (bag empty), capped to budget_s. Copies the played
+// move to *out_move. Returns true if a move was played.
 static bool peg_bench_play_endgame(Game *game, ThreadControl *thread_control,
-                                   double budget_s, ErrorStack *error_stack) {
+                                   double budget_s, Move *out_move,
+                                   ErrorStack *error_stack) {
   EndgameArgs endgame_args = {0};
   endgame_args.thread_control = thread_control;
   endgame_args.game = game;
@@ -67,9 +190,6 @@ static bool peg_bench_play_endgame(Game *game, ThreadControl *thread_control,
   endgame_args.enable_pv_display = true;
   endgame_args.num_top_moves = 1;
   endgame_args.seed = 0;
-  // Same time budget as a pre-endgame turn: stop IDS at the soft limit, don't
-  // start a depth that would blow the hard limit, and bail mid-search at the
-  // wall-clock deadline.
   endgame_args.soft_time_limit = budget_s;
   endgame_args.hard_time_limit = budget_s;
   endgame_args.external_deadline_ns =
@@ -84,9 +204,8 @@ static bool peg_bench_play_endgame(Game *game, ThreadControl *thread_control,
   if (error_stack_is_empty(error_stack)) {
     const PVLine *pv = endgame_results_get_pvline(results, ENDGAME_RESULT_BEST);
     if (pv != NULL && pv->num_moves > 0) {
-      Move move;
-      small_move_to_move(&move, &pv->moves[0], game_get_board(game));
-      play_move(&move, game, NULL);
+      small_move_to_move(out_move, &pv->moves[0], game_get_board(game));
+      play_move(out_move, game, NULL);
       played = true;
     }
   }
@@ -95,22 +214,23 @@ static bool peg_bench_play_endgame(Game *game, ThreadControl *thread_control,
   return played;
 }
 
-// Choose and play one move for the player on turn. While the bag is in the PEG
-// range, solve it with the greedy pre-endgame seed within budget_s; at bag 0
-// solve the endgame under the same budget. *elapsed_out is the wall time spent.
+// Choose and play one move: greedy PEG while the bag is in range (with the
+// inference prior when non-NULL), the d25 endgame at bag 0. Copies the played
+// move to *out_move; *elapsed_out is the solve wall time.
 static void peg_bench_play_turn(Game *game, MoveList *move_list,
                                 ThreadControl *thread_control, double budget_s,
-                                double *elapsed_out, ErrorStack *error_stack) {
+                                const InferenceResults *prior, uint64_t seed,
+                                Move *out_move, double *elapsed_out,
+                                ErrorStack *error_stack) {
   const double t0 = peg_bench_now_s();
   const int bag = bag_get_letters(game_get_bag(game));
   bool played = false;
   if (bag == 0) {
-    played = peg_bench_play_endgame(game, thread_control, budget_s, error_stack);
+    played = peg_bench_play_endgame(game, thread_control, budget_s, out_move,
+                                    error_stack);
   } else if (bag >= PEG_MIN_BAG && bag <= PEG_MAX_BAG) {
-    // Supply the candidate field explicitly: peg_solve's own root move
-    // generation is unused by every caller (all pass only_moves) and currently
-    // returns just a pass here. Top-N by static equity is a sound field, and
-    // capping it keeps each greedy solve fast.
+    // Supply the candidate field explicitly (peg_solve's own root move gen is
+    // unused by callers and returns only a pass); top-N by static equity.
     move_list_reset(move_list);
     const MoveGenArgs gen_args = {
         .game = game,
@@ -126,8 +246,8 @@ static void peg_bench_play_turn(Game *game, MoveList *move_list,
     generate_moves(&gen_args);
     move_list_sort_moves(move_list);
     const int total = move_list_get_count(move_list);
-    const int n_cand = total < PEG_BENCH_MAX_CANDIDATES ? total
-                                                        : PEG_BENCH_MAX_CANDIDATES;
+    const int n_cand =
+        total < PEG_BENCH_MAX_CANDIDATES ? total : PEG_BENCH_MAX_CANDIDATES;
     const Move *cands[PEG_BENCH_MAX_CANDIDATES];
     for (int i = 0; i < n_cand; i++) {
       cands[i] = move_list_get_move(move_list, i);
@@ -141,57 +261,111 @@ static void peg_bench_play_turn(Game *game, MoveList *move_list,
       peg_args.time_budget_seconds = budget_s;
       peg_args.only_moves = cands;
       peg_args.n_only_moves = n_cand;
+      peg_args.opp_leave_prior = prior;
+      peg_args.inference_samples = prior ? PEG_BENCH_INFERENCE_SAMPLES : 0;
+      peg_args.inference_seed = seed;
       thread_control_set_status(thread_control, THREAD_CONTROL_STATUS_STARTED);
       PegResult peg_result = {0};
       peg_solve(&peg_args, &peg_result, error_stack);
       if (error_stack_is_empty(error_stack) && peg_result.n_top_cands > 0 &&
           peg_result.best_win >= 0.0) {
-        play_move(&peg_result.best_move, game, NULL);
+        move_copy(out_move, &peg_result.best_move);
+        play_move(out_move, game, NULL);
         played = true;
       }
       peg_result_destroy(&peg_result);
     }
   }
   if (!played) {
-    // A solve produced nothing (e.g. a severe budget, or a bag outside the PEG
-    // range that should not occur mid-playout): fall back to the static best.
     const Move *move = get_top_equity_move(game, move_list);
-    play_move(move, game, NULL);
+    move_copy(out_move, move);
+    play_move(out_move, game, NULL);
   }
   *elapsed_out = peg_bench_now_s() - t0;
 }
 
-// Play the game to the end from its current state, logging per-turn wall time
-// against the budget. Returns player 0's final spread (score0 - score1).
+// ── Playout ──────────────────────────────────────────────────────────────────
+
+// Play the game to the end. The inferring player weights its PEG scenarios by
+// an inference of the opponent's previous move when use_inference is set; the
+// opponent always plays uniform PEG. Returns player 0's final spread.
 static int peg_bench_play_out(Game *game, MoveList *move_list,
-                              ThreadControl *thread_control,
+                              ThreadControl *thread_control, WinPct *win_pcts,
+                              int inferring_player, bool use_inference,
                               ErrorStack *error_stack) {
+  Game *game_before_prev = game_duplicate(game);
+  InferenceResults *inf_results = inference_results_create(NULL);
+  Move prev_move;
+  memset(&prev_move, 0, sizeof(prev_move));
+  bool have_prev = false;
+  int prev_player = -1;
+  int prev_turn_bag = 0;
+
   int turn = 0;
-  double total = 0.0;
   double worst = 0.0;
   while (!game_over(game)) {
-    const int player_idx = game_get_player_on_turn_index(game);
-    const int bag = bag_get_letters(game_get_bag(game));
-    double elapsed = 0.0;
-    peg_bench_play_turn(game, move_list, thread_control, PEG_BENCH_TURN_BUDGET_S,
-                        &elapsed, error_stack);
-    total += elapsed;
-    if (elapsed > worst) {
-      worst = elapsed;
+    const int on_turn = game_get_player_on_turn_index(game);
+    const int turn_bag = bag_get_letters(game_get_bag(game));
+    Game *snapshot = game_duplicate(game);
+
+    const InferenceResults *prior = NULL;
+    double infer_elapsed = 0.0;
+    const bool prev_inferable =
+        have_prev && (move_get_type(&prev_move) == GAME_EVENT_TILE_PLACEMENT_MOVE ||
+                      move_get_type(&prev_move) == GAME_EVENT_EXCHANGE);
+    if (use_inference && on_turn == inferring_player && prev_inferable &&
+        turn_bag >= PEG_MIN_BAG && turn_bag <= PEG_MAX_BAG) {
+      const double t0 = peg_bench_now_s();
+      const double infer_budget =
+          PEG_BENCH_TURN_BUDGET_S * PEG_BENCH_INFER_BUDGET_FRAC;
+      if (peg_bench_run_inference(game_before_prev, &prev_move, prev_player,
+                                  prev_turn_bag, win_pcts, thread_control,
+                                  inf_results, infer_budget, error_stack)) {
+        prior = inf_results;
+      }
+      infer_elapsed = peg_bench_now_s() - t0;
     }
-    printf("    turn %2d  p%d  bag=%d  %.2fs%s\n", ++turn, player_idx, bag,
-           elapsed,
-           elapsed > PEG_BENCH_TURN_BUDGET_S * 1.5 ? "  *** OVER BUDGET" : "");
+
+    double solve_budget = PEG_BENCH_TURN_BUDGET_S - infer_elapsed;
+    if (solve_budget < 0.5) {
+      solve_budget = 0.5;
+    }
+    Move played;
+    double solve_elapsed = 0.0;
+    peg_bench_play_turn(game, move_list, thread_control, solve_budget, prior,
+                        /*seed=*/42 + (uint64_t)turn, &played, &solve_elapsed,
+                        error_stack);
+
+    const double turn_total = infer_elapsed + solve_elapsed;
+    if (turn_total > worst) {
+      worst = turn_total;
+    }
+    printf("    turn %2d  p%d  bag=%d  infer=%.2fs solve=%.2fs total=%.2fs%s%s\n",
+           ++turn, on_turn, turn_bag, infer_elapsed, solve_elapsed, turn_total,
+           prior != NULL ? "  [inf]" : "",
+           turn_total > PEG_BENCH_TURN_BUDGET_S * 1.5 ? "  *** OVER" : "");
+
+    game_copy(game_before_prev, snapshot);
+    game_destroy(snapshot);
+    prev_move = played;
+    have_prev = true;
+    prev_player = on_turn;
+    prev_turn_bag = turn_bag;
+
     if (!error_stack_is_empty(error_stack)) {
-      printf("    ERROR on turn %d: ", turn);
       error_stack_print_and_reset(error_stack);
       break;
     }
   }
-  printf("    (%d turns, %.2fs total, worst turn %.2fs vs %.2fs budget)\n", turn,
-         total, worst, PEG_BENCH_TURN_BUDGET_S);
-  return equity_to_int(player_get_score(game_get_player(game, 0))) -
-         equity_to_int(player_get_score(game_get_player(game, 1)));
+  printf("    (%d turns, worst turn %.2fs vs %.2fs budget)\n", turn, worst,
+         PEG_BENCH_TURN_BUDGET_S);
+
+  inference_results_destroy(inf_results);
+  game_destroy(game_before_prev);
+  const int p0_spread =
+      equity_to_int(player_get_score(game_get_player(game, 0))) -
+      equity_to_int(player_get_score(game_get_player(game, 1)));
+  return inferring_player == 0 ? p0_spread : -p0_spread;
 }
 
 void test_peginf_benchmark(void) {
@@ -203,16 +377,48 @@ void test_peginf_benchmark(void) {
   ThreadControl *thread_control = config_get_thread_control(config);
   MoveList *move_list = move_list_create(64);
   ErrorStack *error_stack = error_stack_create();
-
-  printf("  PEG benchmark playout (4-in-bag CSW24, budget %.1fs/turn):\n",
-         PEG_BENCH_TURN_BUDGET_S);
-  const int spread =
-      peg_bench_play_out(game, move_list, thread_control, error_stack);
-  printf("  final spread (p0 - p1): %+d\n", spread);
-
-  assert(game_over(game));
+  WinPct *win_pcts =
+      win_pct_create(config_get_data_paths(config), DEFAULT_WIN_PCT,
+                     error_stack);
   assert(error_stack_is_empty(error_stack));
 
+  printf("  PEG A/B benchmark (4-in-bag CSW24, budget %.1fs/turn):\n",
+         PEG_BENCH_TURN_BUDGET_S);
+
+  // Run the A/B for each player as the inferring player. In this position p0
+  // moves first (no opponent prior move -> inference is a no-op on its only PEG
+  // turn), while p1 gets a PEG turn right after p0's move -> its peg-inference
+  // path fires. Position generation (a later increment) yields positions where
+  // the on-turn player always has the opponent's prior move to infer from.
+  for (int inferring_player = 0; inferring_player < 2; inferring_player++) {
+    printf("  === inferring player p%d ===\n", inferring_player);
+
+    printf("  Arm A (uniform PEG):\n");
+    Game *game_a = game_duplicate(game);
+    const int spread_a =
+        peg_bench_play_out(game_a, move_list, thread_control, win_pcts,
+                           inferring_player, /*use_inference=*/false,
+                           error_stack);
+
+    printf("  Arm B (inference-weighted PEG):\n");
+    Game *game_b = game_duplicate(game);
+    const int spread_b =
+        peg_bench_play_out(game_b, move_list, thread_control, win_pcts,
+                           inferring_player, /*use_inference=*/true,
+                           error_stack);
+
+    printf("  RESULT p%d spread: A (uniform) %+d  vs  B (inference) %+d  "
+           "(delta %+d)\n",
+           inferring_player, spread_a, spread_b, spread_b - spread_a);
+
+    assert(game_over(game_a));
+    assert(game_over(game_b));
+    assert(error_stack_is_empty(error_stack));
+    game_destroy(game_a);
+    game_destroy(game_b);
+  }
+
+  win_pct_destroy(win_pcts);
   move_list_destroy(move_list);
   error_stack_destroy(error_stack);
   config_destroy(config);

--- a/test/peginf_benchmark.c
+++ b/test/peginf_benchmark.c
@@ -39,6 +39,7 @@
 #include "../src/impl/peg.h"
 #include "../src/impl/peg_inference.h"
 #include "../src/impl/simmed_inference.h"
+#include "../src/compat/memory_info.h"
 #include "../src/util/io_util.h"
 #include "test_constants.h"
 #include "test_util.h"
@@ -69,6 +70,20 @@
 #define PEG_BENCH_MAX_SIM 6
 #define PEG_BENCH_MAX_PEG 4
 #define PEG_BENCH_GAME_CAP 300
+
+// Hardware threads each PEG solve / endgame / inference runs on (all cores, like
+// a real peg run); set once per test from config_get_num_threads.
+static int g_bench_num_threads = 1;
+
+// Read a positive integer environment override, or fall back to def.
+static int peg_bench_env_int(const char *name, int def) {
+  const char *v = getenv(name);
+  if (v == NULL) {
+    return def;
+  }
+  const int parsed = atoi(v);
+  return parsed > 0 ? parsed : def;
+}
 
 static double peg_bench_now_s(void) {
   struct timespec t;
@@ -119,7 +134,8 @@ static void peg_bench_fill_infer_args(PegBenchInferSetup *setup,
                 game_get_player(game_before_prev, 1 - prev_player_index)));
 
   infer_args_fill(&setup->args, /*leave_list_capacity=*/PEG_BENCH_INFER_CANDIDATES,
-                  int_to_equity(0), NULL, game_before_prev, /*num_threads=*/1,
+                  int_to_equity(0), NULL, game_before_prev,
+                  /*num_threads=*/g_bench_num_threads,
                   /*parent_worker_thread_index=*/0, /*print_interval=*/0,
                   thread_control, /*use_game_history=*/false,
                   /*use_inference_cutoff_optimization=*/false, prev_player_index,
@@ -191,7 +207,7 @@ static bool peg_bench_play_endgame(Game *game, ThreadControl *thread_control,
   endgame_args.tt_fraction_of_mem = 0.05;
   endgame_args.initial_small_move_arena_size =
       DEFAULT_INITIAL_SMALL_MOVE_ARENA_SIZE;
-  endgame_args.num_threads = 1;
+  endgame_args.num_threads = g_bench_num_threads;
   endgame_args.use_heuristics = true;
   endgame_args.forced_pass_bypass = true;
   endgame_args.enable_pv_display = true;
@@ -263,7 +279,7 @@ static void peg_bench_play_turn(Game *game, MoveList *move_list,
       PegArgs peg_args = {0};
       peg_args.game = game;
       peg_args.thread_control = thread_control;
-      peg_args.num_threads = 1;
+      peg_args.num_threads = g_bench_num_threads;
       peg_args.greedy_seed_only = true;
       peg_args.time_budget_seconds = budget_s;
       peg_args.only_moves = cands;
@@ -483,9 +499,12 @@ static int peg_bench_generate(Game *proto, MoveList *move_list,
 }
 
 void test_peginf_benchmark(void) {
-  Config *config = config_create_or_die(
-      "set -lex CSW24 -s1 equity -s2 equity -r1 all -r2 all -numplays 15 "
-      "-threads 1");
+  char config_cmd[256];
+  snprintf(config_cmd, sizeof(config_cmd),
+           "set -lex CSW24 -s1 equity -s2 equity -r1 all -r2 all -numplays 15 "
+           "-threads %d",
+           get_num_cores());
+  Config *config = config_create_or_die(config_cmd);
   load_and_exec_config_or_die(config, PEG_BENCH_4BAG_CGP ";");
   Game *game = config_get_game(config);
   ThreadControl *thread_control = config_get_thread_control(config);
@@ -495,9 +514,10 @@ void test_peginf_benchmark(void) {
       win_pct_create(config_get_data_paths(config), DEFAULT_WIN_PCT,
                      error_stack);
   assert(error_stack_is_empty(error_stack));
+  g_bench_num_threads = config_get_num_threads(config);
 
-  printf("  PEG A/B benchmark (4-in-bag CSW24, budget %.1fs/turn):\n",
-         PEG_BENCH_TURN_BUDGET_S);
+  printf("  PEG A/B benchmark (4-in-bag CSW24, budget %.1fs/turn, %d threads):\n",
+         PEG_BENCH_TURN_BUDGET_S, g_bench_num_threads);
 
   // Run the A/B for each player as the inferring player. In this position p0
   // moves first (no opponent prior move -> inference is a no-op on its only PEG
@@ -543,10 +563,65 @@ void test_peginf_benchmark(void) {
 // captured state (same bag order) and tally the inferring player's spread delta,
 // split by inference type. The A/B signal -- whether inference improves play --
 // emerges from this aggregate, not from any single position.
+// Win points from the inferring player's final spread: win 1.0, tie 0.5, loss 0.
+static double peg_bench_win_points(int spread) {
+  if (spread > 0) {
+    return 1.0;
+  }
+  return spread == 0 ? 0.5 : 0.0;
+}
+
+// Per-class (and overall) A/B tallies.
+typedef struct {
+  int n;
+  long sum_delta;   // sum of (spread_b - spread_a)
+  int b_better;     // delta > 0
+  int a_better;     // delta < 0
+  int ties;         // delta == 0
+  double a_winpts;  // sum of win points for arm A
+  double b_winpts;  // sum of win points for arm B
+} PegBenchTally;
+
+static void peg_bench_tally_add(PegBenchTally *t, int spread_a, int spread_b) {
+  t->n++;
+  const int delta = spread_b - spread_a;
+  t->sum_delta += delta;
+  if (delta > 0) {
+    t->b_better++;
+  } else if (delta < 0) {
+    t->a_better++;
+  } else {
+    t->ties++;
+  }
+  t->a_winpts += peg_bench_win_points(spread_a);
+  t->b_winpts += peg_bench_win_points(spread_b);
+}
+
+static void peg_bench_tally_print(const char *label, const PegBenchTally *t) {
+  if (t->n == 0) {
+    printf("  %s: no positions\n", label);
+    return;
+  }
+  const int decisive = t->b_better + t->a_better;
+  printf("  %s (n=%d): win%% A %.1f%% vs B %.1f%% (delta %+.1f pts); "
+         "mean spread delta %+.1f; B better %d, A better %d, tie %d",
+         label, t->n, 100.0 * t->a_winpts / t->n, 100.0 * t->b_winpts / t->n,
+         t->b_winpts - t->a_winpts, (double)t->sum_delta / t->n, t->b_better,
+         t->a_better, t->ties);
+  if (decisive > 0) {
+    printf(" (of %d decisive: B %.0f%%)", decisive,
+           100.0 * t->b_better / decisive);
+  }
+  printf("\n");
+}
+
 void test_peginf_benchmark_generate(void) {
-  Config *config = config_create_or_die(
-      "set -lex CSW24 -s1 equity -s2 equity -r1 all -r2 all -numplays 15 "
-      "-threads 1");
+  char config_cmd[256];
+  snprintf(config_cmd, sizeof(config_cmd),
+           "set -lex CSW24 -s1 equity -s2 equity -r1 all -r2 all -numplays 15 "
+           "-threads %d",
+           get_num_cores());
+  Config *config = config_create_or_die(config_cmd);
   load_and_exec_config_or_die(config, "cgp " EMPTY_CGP);
   Game *game = config_get_game(config);
   ThreadControl *thread_control = config_get_thread_control(config);
@@ -555,21 +630,29 @@ void test_peginf_benchmark_generate(void) {
   WinPct *win_pcts = win_pct_create(config_get_data_paths(config),
                                     DEFAULT_WIN_PCT, error_stack);
   assert(error_stack_is_empty(error_stack));
+  g_bench_num_threads = config_get_num_threads(config);
 
-  PegBenchPosition *positions = malloc_or_die(
-      sizeof(PegBenchPosition) * (PEG_BENCH_MAX_SIM + PEG_BENCH_MAX_PEG));
-  const int n = peg_bench_generate(game, move_list, positions, PEG_BENCH_MAX_SIM,
-                                   PEG_BENCH_MAX_PEG, /*base_seed=*/1,
-                                   PEG_BENCH_GAME_CAP);
-  printf("  PEG A/B aggregation: generated %d positions, budget %.1fs/turn\n", n,
-         PEG_BENCH_TURN_BUDGET_S);
+  // Quotas, seed, and game cap are env-overridable (PEGBENCH_SIM / _PEG / _SEED
+  // / _GAMECAP) so a large run needs no rebuild.
+  const int max_sim = peg_bench_env_int("PEGBENCH_SIM", PEG_BENCH_MAX_SIM);
+  const int max_peg = peg_bench_env_int("PEGBENCH_PEG", PEG_BENCH_MAX_PEG);
+  const uint64_t base_seed =
+      (uint64_t)peg_bench_env_int("PEGBENCH_SEED", 1);
+  const uint64_t game_cap =
+      (uint64_t)peg_bench_env_int("PEGBENCH_GAMECAP", PEG_BENCH_GAME_CAP);
 
-  int b_better = 0;
-  int a_better = 0;
-  int ties = 0;
-  long sum_delta = 0;
-  int sim_n = 0;
-  int peg_n = 0;
+  PegBenchPosition *positions =
+      malloc_or_die(sizeof(PegBenchPosition) * (size_t)(max_sim + max_peg));
+  const int n = peg_bench_generate(game, move_list, positions, max_sim, max_peg,
+                                   base_seed, game_cap);
+  printf("  PEG A/B aggregation: generated %d positions (target %d sim + %d "
+         "peg), budget %.1fs/turn, %d threads\n",
+         n, max_sim, max_peg, PEG_BENCH_TURN_BUDGET_S, g_bench_num_threads);
+
+  PegBenchTally overall = {0};
+  PegBenchTally sim = {0};
+  PegBenchTally peg = {0};
+  const double t_start = peg_bench_now_s();
   for (int i = 0; i < n; i++) {
     PegBenchPosition *p = &positions[i];
     const bool sim_inf = p->prev_turn_bag >= PEG_BENCH_SIM_INFER_BAG;
@@ -589,24 +672,12 @@ void test_peginf_benchmark_generate(void) {
         game_b, move_list, thread_control, win_pcts, p->inferring_player,
         /*use_inference=*/true, &ctx, /*verbose=*/false, error_stack);
 
-    const int delta = spread_b - spread_a;
-    sum_delta += delta;
-    if (delta > 0) {
-      b_better++;
-    } else if (delta < 0) {
-      a_better++;
-    } else {
-      ties++;
-    }
-    if (sim_inf) {
-      sim_n++;
-    } else {
-      peg_n++;
-    }
+    peg_bench_tally_add(&overall, spread_a, spread_b);
+    peg_bench_tally_add(sim_inf ? &sim : &peg, spread_a, spread_b);
     printf("    pos %2d  infer p%d  opp-bag=%d  %s-inf  A %+d  B %+d  "
            "delta %+d\n",
            i, p->inferring_player, p->prev_turn_bag, sim_inf ? "sim" : "peg",
-           spread_a, spread_b, delta);
+           spread_a, spread_b, spread_b - spread_a);
 
     assert(game_over(game_a));
     assert(game_over(game_b));
@@ -615,11 +686,10 @@ void test_peginf_benchmark_generate(void) {
     peg_bench_position_destroy(p);
   }
 
-  if (n > 0) {
-    printf("  AGGREGATE over %d positions (%d sim-inf, %d peg-inf): "
-           "B better %d, A better %d, tie %d; mean spread delta %+.1f\n",
-           n, sim_n, peg_n, b_better, a_better, ties, (double)sum_delta / n);
-  }
+  printf("  --- A/B results (%.0fs) ---\n", peg_bench_now_s() - t_start);
+  peg_bench_tally_print("OVERALL", &overall);
+  peg_bench_tally_print("sim-inf", &sim);
+  peg_bench_tally_print("peg-inf", &peg);
   assert(error_stack_is_empty(error_stack));
 
   free(positions);

--- a/test/peginf_benchmark.c
+++ b/test/peginf_benchmark.c
@@ -1,0 +1,167 @@
+// A/B benchmark for pre-endgame (PEG) inference. The end goal: from PEG
+// positions, play the game out with Player A (uniform PEG) vs Player B
+// (inference-weighted PEG), equal per-turn budget, and tally the win%/spread
+// difference, logging per-turn wall time to confirm neither arm overruns.
+//
+// This is built incrementally. THIS increment lands the playout core: from a
+// position, choose and play each move -- PEG (greedy seed) while the bag holds
+// [PEG_MIN_BAG, PEG_MAX_BAG] tiles, a static best otherwise (a placeholder for
+// the d25 time-limited endgame) -- until the game ends, logging per-turn time
+// against the budget. The inference variant (Player B), position generation
+// (static -> sim -> <=4, and PEG -> PEG), and the A/B aggregation build on top.
+
+#include "../src/def/equity_defs.h"
+#include "../src/def/move_defs.h"
+#include "../src/def/peg_defs.h"
+#include "../src/def/thread_control_defs.h"
+#include "../src/ent/bag.h"
+#include "../src/ent/equity.h"
+#include "../src/ent/game.h"
+#include "../src/ent/move.h"
+#include "../src/ent/player.h"
+#include "../src/ent/thread_control.h"
+#include "../src/impl/config.h"
+#include "../src/impl/gameplay.h"
+#include "../src/impl/move_gen.h"
+#include "../src/impl/peg.h"
+#include "../src/util/io_util.h"
+#include "test_util.h"
+#include <assert.h>
+#include <stdio.h>
+#include <time.h>
+
+// A real 4-in-bag CSW24 pre-endgame: player 0 (ACEINOP) on turn, bag = 4.
+#define PEG_BENCH_4BAG_CGP                                                    \
+  "cgp 3V3W6L/1BEATY1U5GI/2XU3S4FEN/3TA2H4LOY/2GEN1DUCAT1AD1/2O1I1I2WRITE1/"  \
+  "2V1M1ZOAEA4/3JAGER2DRILL/2BOtONE5O1/1FERER7Q1/4S8U1/12NaM/12ATE/13ST/14H " \
+  "ACEINOP/DEIINOS 361/397 0 -lex CSW24"
+
+#define PEG_BENCH_TURN_BUDGET_S 3.0
+#define PEG_BENCH_MAX_CANDIDATES 20
+
+static double peg_bench_now_s(void) {
+  struct timespec t;
+  clock_gettime(CLOCK_MONOTONIC, &t);
+  return (double)t.tv_sec + (double)t.tv_nsec * 1e-9;
+}
+
+// Choose and play one move for the player on turn. While the bag is in the PEG
+// range, solve it with the greedy pre-endgame seed within budget_s; otherwise
+// play the static best (placeholder for the d25 endgame at bag 0). *elapsed_out
+// is the wall time spent.
+static void peg_bench_play_turn(Game *game, MoveList *move_list,
+                                ThreadControl *thread_control, double budget_s,
+                                double *elapsed_out, ErrorStack *error_stack) {
+  const double t0 = peg_bench_now_s();
+  const int bag = bag_get_letters(game_get_bag(game));
+  bool played = false;
+  if (bag >= PEG_MIN_BAG && bag <= PEG_MAX_BAG) {
+    // Supply the candidate field explicitly: peg_solve's own root move
+    // generation is unused by every caller (all pass only_moves) and currently
+    // returns just a pass here. Top-N by static equity is a sound field, and
+    // capping it keeps each greedy solve fast.
+    move_list_reset(move_list);
+    const MoveGenArgs gen_args = {
+        .game = game,
+        .move_list = move_list,
+        .move_record_type = MOVE_RECORD_ALL,
+        .move_sort_type = MOVE_SORT_EQUITY,
+        .override_kwg = NULL,
+        .eq_margin_movegen = 0,
+        .target_equity = EQUITY_MAX_VALUE,
+        .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+        .tiles_played_bv = NULL,
+    };
+    generate_moves(&gen_args);
+    move_list_sort_moves(move_list);
+    const int total = move_list_get_count(move_list);
+    const int n_cand = total < PEG_BENCH_MAX_CANDIDATES ? total
+                                                        : PEG_BENCH_MAX_CANDIDATES;
+    const Move *cands[PEG_BENCH_MAX_CANDIDATES];
+    for (int i = 0; i < n_cand; i++) {
+      cands[i] = move_list_get_move(move_list, i);
+    }
+    if (n_cand > 0) {
+      PegArgs peg_args = {0};
+      peg_args.game = game;
+      peg_args.thread_control = thread_control;
+      peg_args.num_threads = 1;
+      peg_args.greedy_seed_only = true;
+      peg_args.time_budget_seconds = budget_s;
+      peg_args.only_moves = cands;
+      peg_args.n_only_moves = n_cand;
+      thread_control_set_status(thread_control, THREAD_CONTROL_STATUS_STARTED);
+      PegResult peg_result = {0};
+      peg_solve(&peg_args, &peg_result, error_stack);
+      if (error_stack_is_empty(error_stack) && peg_result.n_top_cands > 0 &&
+          peg_result.best_win >= 0.0) {
+        play_move(&peg_result.best_move, game, NULL);
+        played = true;
+      }
+      peg_result_destroy(&peg_result);
+    }
+  }
+  if (!played) {
+    // Endgame (bag 0) or a solve that produced nothing: static best for now.
+    const Move *move = get_top_equity_move(game, move_list);
+    play_move(move, game, NULL);
+  }
+  *elapsed_out = peg_bench_now_s() - t0;
+}
+
+// Play the game to the end from its current state, logging per-turn wall time
+// against the budget. Returns player 0's final spread (score0 - score1).
+static int peg_bench_play_out(Game *game, MoveList *move_list,
+                              ThreadControl *thread_control,
+                              ErrorStack *error_stack) {
+  int turn = 0;
+  double total = 0.0;
+  double worst = 0.0;
+  while (!game_over(game)) {
+    const int player_idx = game_get_player_on_turn_index(game);
+    const int bag = bag_get_letters(game_get_bag(game));
+    double elapsed = 0.0;
+    peg_bench_play_turn(game, move_list, thread_control, PEG_BENCH_TURN_BUDGET_S,
+                        &elapsed, error_stack);
+    total += elapsed;
+    if (elapsed > worst) {
+      worst = elapsed;
+    }
+    printf("    turn %2d  p%d  bag=%d  %.2fs%s\n", ++turn, player_idx, bag,
+           elapsed,
+           elapsed > PEG_BENCH_TURN_BUDGET_S * 1.5 ? "  *** OVER BUDGET" : "");
+    if (!error_stack_is_empty(error_stack)) {
+      printf("    ERROR on turn %d: ", turn);
+      error_stack_print_and_reset(error_stack);
+      break;
+    }
+  }
+  printf("    (%d turns, %.2fs total, worst turn %.2fs vs %.2fs budget)\n", turn,
+         total, worst, PEG_BENCH_TURN_BUDGET_S);
+  return equity_to_int(player_get_score(game_get_player(game, 0))) -
+         equity_to_int(player_get_score(game_get_player(game, 1)));
+}
+
+void test_peginf_benchmark(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW24 -s1 equity -s2 equity -r1 all -r2 all -numplays 15 "
+      "-threads 1");
+  load_and_exec_config_or_die(config, PEG_BENCH_4BAG_CGP ";");
+  Game *game = config_get_game(config);
+  ThreadControl *thread_control = config_get_thread_control(config);
+  MoveList *move_list = move_list_create(64);
+  ErrorStack *error_stack = error_stack_create();
+
+  printf("  PEG benchmark playout (4-in-bag CSW24, budget %.1fs/turn):\n",
+         PEG_BENCH_TURN_BUDGET_S);
+  const int spread =
+      peg_bench_play_out(game, move_list, thread_control, error_stack);
+  printf("  final spread (p0 - p1): %+d\n", spread);
+
+  assert(game_over(game));
+  assert(error_stack_is_empty(error_stack));
+
+  move_list_destroy(move_list);
+  error_stack_destroy(error_stack);
+  config_destroy(config);
+}

--- a/test/peginf_benchmark.c
+++ b/test/peginf_benchmark.c
@@ -32,6 +32,9 @@
 #include "../src/ent/player.h"
 #include "../src/ent/rack.h"
 #include "../src/ent/thread_control.h"
+#include "../src/ent/sim_args.h"
+#include "../src/ent/sim_results.h"
+#include "../src/ent/stats.h"
 #include "../src/ent/win_pct.h"
 #include "../src/impl/config.h"
 #include "../src/impl/endgame.h"
@@ -39,10 +42,16 @@
 #include "../src/impl/gameplay.h"
 #include "../src/impl/move_gen.h"
 #include "../src/impl/peg.h"
+#include "../src/impl/inference.h"
 #include "../src/impl/peg_inference.h"
 #include "../src/impl/simmed_inference.h"
+#include "../src/impl/simmer.h"
+#include "../src/str/move_string.h"
+#include "../src/str/rack_string.h"
 #include "../src/compat/memory_info.h"
 #include "../src/util/io_util.h"
+#include "../src/util/string_util.h"
+#include <math.h>
 #include "test_constants.h"
 #include "test_util.h"
 #include <assert.h>
@@ -87,6 +96,106 @@ static int g_bench_samples = PEG_BENCH_INFERENCE_SAMPLES;
 // TRUE leave instead of running inference -- the ceiling of leave inference and
 // a check that leave results are applied correctly.
 static bool g_bench_psychic = false;
+// Greedy stage-0-only move selection (PEGBENCH_GREEDY, default OFF). Greedy
+// values every scenario with a shallow greedy rollout, so the opponent prior
+// can't translate into better moves -- off runs the full staged solve like real
+// play (see peg_bench_config_solver). Default off is the fix.
+static bool g_bench_greedy = false;
+// Nested inner-peg recursion depth (PEGBENCH_NESTDEPTH, default
+// PEG_NESTED_DEFAULT_DEPTH=1). A value >= the bag size nests the opponent's
+// continuation all the way to the exact endgame (no greedy floor), so cranking
+// this is the scoping lever for the win% overconfidence: if a deeper (more
+// adversarial) continuation shrinks the peg-vs-ground-truth gap, the bias is the
+// shallow/greedy continuation rather than winner's-curse selection.
+static int g_bench_nest_depth = PEG_NESTED_DEFAULT_DEPTH;
+// Inference-mode outer halving head (PEGBENCH_INFERTOPK, 0 = default {32,...}).
+// The deep stages SAMPLE the opponent rack (inference_samples per candidate), so
+// with the full 32-wide field the sampled endgame refinement can't finish in
+// budget and the solve falls back to the greedy seed. Keeping only the top few
+// candidates (the greedy seed still ranks the whole field) lets the inference
+// solve reach deep stages. Schedule built as {k, k/2, ..., 2}.
+static int g_bench_infer_topk = 0;
+// Only capture "contested" positions where |score(p0) - score(p1)| <= this
+// (PEGBENCH_CONTESTED; 0 = no filter). Blowouts are decided regardless of the
+// opponent's rack, so inference can only matter in close positions.
+static int g_bench_contested = 0;
+// Calibration mode (PEGBENCH_CALIB = per-bucket quota, 0 = off): instead of the
+// A/B ground truth, score the INFERENCE ITSELF against the known true leave --
+// no solves, no playouts. For each position run the real inference and record
+// the confidence statistic (top-leave mass share) alongside where the true
+// leave landed (found / mass / rank). Positions are STRATIFIED by true-leave
+// size k (0..7): each k bucket accepts up to the quota, then further k
+// positions are skipped, so rare sizes (small plays => large leaves) get
+// coverage instead of being swamped by the common 4-5s. The resulting
+// accuracy-vs-confidence curve answers whether a confidence gate can make real
+// inference useful: steep => gate viable; flat => the inference weights are
+// miscalibrated and the generator is what needs fixing.
+static int g_bench_calib = 0;
+// Calibration slice filters: only accept positions whose true-leave size is in
+// [PEGBENCH_CALIB_KMIN, PEGBENCH_CALIB_KMAX], and (PEGBENCH_CALIB_SIMONLY) only
+// sim-inference positions (bag >= PEG_BENCH_SIM_INFER_BAG) -- the peg-inference
+// regime currently returns an empty support, so a budget study on it is
+// meaningless.
+static int g_bench_calib_kmin = 0;
+static int g_bench_calib_kmax = 7;
+static bool g_bench_calib_simonly = false;
+// Sim-inference per-leaf evaluation iterations (PEGBENCH_INF_PROBE/FULL,
+// defaults 20/40): the second budget lever -- time_budget_s bounds how many
+// leaves the MC loop samples (coverage), these bound how sharply each sampled
+// leaf is weighted (ranking quality).
+static int g_bench_inf_probe = 20;
+static int g_bench_inf_full = 40;
+// peg-inference (bag <= 4) tuning. The 0.1s default inner-solve budget starves
+// every candidate-leave evaluation: the observed move's eval misses the
+// deadline, its utility is unusable, the leave records weight 0, and the
+// support comes out EMPTY (the 0-items regime the calibration found).
+// PEGBENCH_PEGINF_SOLVE raises the per-eval budget; PEGBENCH_PEGINF_EXH raises
+// exhaustive_max_leave so k <= that size enumerates ALL leaves (coverage)
+// instead of MC-sampling a tiny fraction.
+static double g_bench_peginf_solve_s = 0.1;
+static int g_bench_peginf_exh = 1;
+// Realistic-opponent generation (PEGBENCH_REALOPP, default off): instead of a
+// static-equity player, generated games play SIM moves at bag >= 5 and uniform
+// PEG_SOLVE moves at bag <= 4 once the bag reaches PEGBENCH_GEN_AUTHBAG
+// (static-equity above that, where the inference never conditions -- it only
+// sees the opponent's LAST move, at bag <= 11). This matches the opponent's
+// actual policy to the model simmed/peg inference assumes, removing the
+// model-mismatch that suppressed inference accuracy against a static player.
+// PEGBENCH_GEN_SIMITERS sims per generated move (2-ply, matching the
+// inference's inner sims); PEGBENCH_GEN_PEGBUDGET seconds per generated peg
+// move.
+static bool g_bench_realopp = false;
+static int g_bench_gen_authbag = 12;
+static int g_bench_gen_simiters = 100;
+static double g_bench_gen_pegbudget = 5.0;
+// Small-play gate (PEGBENCH_GATE, default off): arm B trusts the inference only
+// on a sim-inference play whose estimated kept-leave size k_est is inside
+// [PEGBENCH_GATE_KMIN, PEGBENCH_GATE_KMAX] (default 3..6 -- excludes bingos and
+// big plays, where the inference is least accurate). The prior handed to
+// peg_solve is the aggregated TOP-N leaves (PEGBENCH_GATE_TOPN, default 4,
+// which fits the exact small-support enumeration path); otherwise uniform
+// (B == A). See the gate block in the ground-truth loop.
+static bool g_bench_gate = false;
+static int g_bench_gate_topn = 4;
+static int g_bench_gate_kmin = 3;
+static int g_bench_gate_kmax = 6;
+// Minimum OPPONENT-turn bag for the gate (PEGBENCH_GATE_OBMIN, default
+// PEG_BENCH_SIM_INFER_BAG). The overnight slice showed the inference HURTS at
+// opp-bag exactly 5 (-0.105, the sim's inner 2-ply rolls straight into the
+// pre-endgame where its opponent model is least faithful) and HELPS at >= 6
+// (+0.038): gate on 6 to drop the poisoned boundary cells.
+static int g_bench_gate_obmin = PEG_BENCH_SIM_INFER_BAG;
+// Maximum opponent-turn bag for the gate (PEGBENCH_GATE_OBMAX): with OBMIN this
+// pins an exact opponent-bag slice, e.g. OBMIN=OBMAX=7 with k=1 selects
+// "opponent played 6 tiles, one tile left in the bag at the mover's turn".
+static int g_bench_gate_obmax = 99;
+// Monte-Carlo samples for the ground-truth evaluation of a move (PEGBENCH_GT).
+static int g_bench_gt_samples = 40;
+// Tight per-endgame budget for the ground-truth MC playouts (PEGBENCH_GTENDGAME)
+// -- kept small because it runs once per sample; small racks solve exactly well
+// within it, hard stuck-tile ones cut off to a heuristic value (fine for an
+// average, and identical for both compared moves).
+static double g_bench_gt_endgame = 2.0;
 
 // Read a positive integer environment override, or fall back to def.
 static int peg_bench_env_int(const char *name, int def) {
@@ -96,6 +205,16 @@ static int peg_bench_env_int(const char *name, int def) {
   }
   const int parsed = atoi(v);
   return parsed > 0 ? parsed : def;
+}
+
+// Read a boolean environment override (0 = false, non-zero = true, unset =
+// def). Unlike peg_bench_env_int, "0" is a valid (false) value here.
+static bool peg_bench_env_bool(const char *name, bool def) {
+  const char *v = getenv(name);
+  if (v == NULL) {
+    return def;
+  }
+  return atoi(v) != 0;
 }
 
 // Read a positive double environment override, or fall back to def.
@@ -134,6 +253,27 @@ typedef struct {
   Rack nontarget_known_rack;
   InferenceArgs args;
 } PegBenchInferSetup;
+
+// Debug callback (PEGBENCH_PEGINF_DBG): one line per evaluated candidate leave,
+// to diagnose why peg-inference records nothing. obs_idx = -1 means the
+// observed move never entered the candidate field (e.g. an observed exchange
+// with bag < RACK_SIZE builds no exchange arms); gap > 4*margin with weight 0
+// is the static pre-filter cut; gap 0 with weight 0 is a failed/deadlined
+// inner solve or unusable observed utility.
+static void peg_bench_peginf_dbg(const Rack *candidate_leave,
+                                 const MoveList *move_list, int obs_idx,
+                                 double gap, double weight,
+                                 const Game *inner_game, void *user_data) {
+  (void)move_list;
+  const LetterDistribution *ld = game_get_ld(inner_game);
+  StringBuilder *sb = string_builder_create();
+  string_builder_add_rack(sb, candidate_leave, ld, false);
+  printf("      [peginf-dbg] leave=%-7s obs_idx=%d gap=%.4f weight=%.5f\n",
+         string_builder_peek(sb), obs_idx, gap, weight);
+  fflush(stdout);
+  string_builder_destroy(sb);
+  (void)user_data;
+}
 
 static void peg_bench_fill_infer_args(PegBenchInferSetup *setup,
                                       const Game *game_before_prev,
@@ -181,15 +321,22 @@ static bool peg_bench_run_inference(const Game *game_before_prev,
   peg_bench_fill_infer_args(&setup, game_before_prev, prev_move,
                             prev_player_index, thread_control);
   thread_control_set_status(thread_control, THREAD_CONTROL_STATUS_STARTED);
-  if (prev_turn_bag >= PEG_BENCH_SIM_INFER_BAG) {
+  // PEGBENCH_STATIC_INF: plain static-equity consistency inference (margin 0,
+  // movegen-only -- no sims, no inner solves; works at ANY bag). This is the
+  // MATCHED model for the benchmark opponent, which plays get_top_equity_move:
+  // the true leave is accepted by construction, so found = 100% and the open
+  // question becomes concentration (how few other leaves are consistent).
+  if (getenv("PEGBENCH_STATIC_INF") != NULL) {
+    infer_without_ctx(&setup.args, results, error_stack);
+  } else if (prev_turn_bag >= PEG_BENCH_SIM_INFER_BAG) {
     const SimmedInferenceArgs si_args = {
         .base = &setup.args,
         .observed_move = prev_move,
         .win_pcts = win_pcts,
         .num_candidate_plays = PEG_BENCH_INFER_CANDIDATES,
         .num_inner_sim_plies = 2,
-        .probe_iterations = 20,
-        .full_iterations = 40,
+        .probe_iterations = g_bench_inf_probe,
+        .full_iterations = g_bench_inf_full,
         .time_budget_s = budget_s,
         .sim_equity_margin = 3.0,
     };
@@ -203,9 +350,11 @@ static bool peg_bench_run_inference(const Game *game_before_prev,
         .base = &setup.args,
         .observed_move = prev_move,
         .num_candidate_plays = PEG_BENCH_INFER_CANDIDATES,
-        .exhaustive_max_leave = 1,
-        .peg_time_budget_s = 0.1,
+        .exhaustive_max_leave = g_bench_peginf_exh,
+        .peg_time_budget_s = g_bench_peginf_solve_s,
         .time_budget_s = budget_s,
+        .leave_callback =
+            getenv("PEGBENCH_PEGINF_DBG") != NULL ? peg_bench_peginf_dbg : NULL,
     };
     peg_infer(&peg_args, results, error_stack);
   }
@@ -218,11 +367,30 @@ static bool peg_bench_run_inference(const Game *game_before_prev,
 
 // ── Move selection ───────────────────────────────────────────────────────────
 
+// Per-level nested-recursion candidate caps, matching the CLI default.
+static const int PEG_BENCH_NESTED_CAPS[] = {8, 4, 2};
+
+// Configure a PegArgs the way the real PEG solver runs in play (config.c): the
+// full staged halving solve (unless greedy) with nested inner-peg lookahead on
+// non-emptier leaves -- so scenarios are valued by exact endgames / recursive
+// sub-pegs, not a shallow greedy rollout. A zero-init PegArgs leaves nested OFF,
+// which made every scenario a weak greedy playout (the reason perfect opponent
+// info couldn't move the needle).
+static void peg_bench_config_solver(PegArgs *a) {
+  a->greedy_seed_only = g_bench_greedy;
+  a->nested_enabled = true;
+  a->nested_max_depth = g_bench_nest_depth;
+  a->nested_cand_caps = PEG_BENCH_NESTED_CAPS;
+  a->nested_n_cand_caps =
+      (int)(sizeof(PEG_BENCH_NESTED_CAPS) / sizeof(PEG_BENCH_NESTED_CAPS[0]));
+  a->nested_stride = 0;
+}
+
 // Solve and play the endgame (bag empty), capped to budget_s. Copies the played
 // move to *out_move. Returns true if a move was played.
 static bool peg_bench_play_endgame(Game *game, ThreadControl *thread_control,
-                                   double budget_s, Move *out_move,
-                                   ErrorStack *error_stack) {
+                                   double budget_s, int num_threads,
+                                   Move *out_move, ErrorStack *error_stack) {
   EndgameArgs endgame_args = {0};
   endgame_args.thread_control = thread_control;
   endgame_args.game = game;
@@ -230,7 +398,7 @@ static bool peg_bench_play_endgame(Game *game, ThreadControl *thread_control,
   endgame_args.tt_fraction_of_mem = 0.05;
   endgame_args.initial_small_move_arena_size =
       DEFAULT_INITIAL_SMALL_MOVE_ARENA_SIZE;
-  endgame_args.num_threads = g_bench_num_threads;
+  endgame_args.num_threads = num_threads;
   endgame_args.use_heuristics = true;
   endgame_args.forced_pass_bypass = true;
   endgame_args.enable_pv_display = true;
@@ -279,8 +447,8 @@ static void peg_bench_play_turn(Game *game, MoveList *move_list,
   const int bag = bag_get_letters(game_get_bag(game));
   bool played = false;
   if (bag == 0) {
-    played = peg_bench_play_endgame(game, thread_control, budget_s, out_move,
-                                    error_stack);
+    played = peg_bench_play_endgame(game, thread_control, budget_s,
+                                    g_bench_num_threads, out_move, error_stack);
   } else if (bag >= PEG_MIN_BAG && bag <= PEG_MAX_BAG) {
     // Supply the candidate field explicitly (peg_solve's own root move gen is
     // unused by callers and returns only a pass); top-N by static equity.
@@ -310,7 +478,7 @@ static void peg_bench_play_turn(Game *game, MoveList *move_list,
       peg_args.game = game;
       peg_args.thread_control = thread_control;
       peg_args.num_threads = g_bench_num_threads;
-      peg_args.greedy_seed_only = true;
+      peg_bench_config_solver(&peg_args);
       peg_args.time_budget_seconds = budget_s;
       peg_args.only_moves = cands;
       peg_args.n_only_moves = n_cand;
@@ -363,11 +531,122 @@ static InferenceResults *peg_bench_psychic_prior(const Game *game_before_prev,
   }
   AliasMethod *alias = alias_method_create();
   alias_method_add_rack(alias, &leave, 1);
+  // PEGBENCH_PSYCHIC_MULTI: add the true leave a SECOND time so num_items == 2.
+  // That routes the (still-perfect-info) psychic prior through the MULTI-support
+  // paths (peg_enumerate_support / peg_collect_support) instead of the point-mass
+  // pinned path -- a correctness probe: if psychic then still scores ~+0.024, the
+  // support-enumeration machinery is correct and a bad REAL-inference result is
+  // inference inaccuracy, not a machinery bug.
+  if (getenv("PEGBENCH_PSYCHIC_MULTI") != NULL) {
+    alias_method_add_rack(alias, &leave, 1);
+  }
   if (!alias_method_generate_tables(alias)) {
     alias_method_destroy(alias);
     return NULL;
   }
   return inference_results_create(alias); // takes ownership of alias
+}
+
+// Dump one peg_solve candidate ranking (greedy full field) for debugging.
+static void peg_bench_dump_ranking(const char *label, const PegResult *r,
+                                   const Game *game) {
+  const Board *board = game_get_board(game);
+  const LetterDistribution *ld = game_get_ld(game);
+  StringBuilder *sb = string_builder_create();
+  printf("    %s (%d cands, best_win=%.4f):\n", label, r->n_top_cands,
+         r->best_win);
+  for (int i = 0; i < r->n_top_cands; i++) {
+    const PegRankedCand *c = &r->top_cands[i];
+    string_builder_clear(sb);
+    string_builder_add_move(sb, board, &c->move, ld, true);
+    printf("      #%-2d %-16s win=%.4f spread=%+6.1f nscen=%d win=%lld tie=%lld "
+           "wsum=%lld\n",
+           i, string_builder_peek(sb), c->win_pct, c->mean_spread,
+           c->n_scenarios, (long long)c->win_count, (long long)c->tie_count,
+           (long long)c->weight_sum);
+  }
+  string_builder_destroy(sb);
+}
+
+// Run peg_solve on this position under both uniform and psychic priors (greedy,
+// so top_cands is the full field) and dump both rankings. Exposes whether the
+// psychic re-ranking is sane and its scenario weights are handled correctly.
+static void peg_bench_debug_rankings(Game *game, MoveList *move_list,
+                                     ThreadControl *thread_control,
+                                     InferenceResults *prior, int samples,
+                                     uint64_t seed) {
+  move_list_reset(move_list);
+  const MoveGenArgs gen_args = {
+      .game = game,
+      .move_list = move_list,
+      .move_record_type = MOVE_RECORD_ALL,
+      .move_sort_type = MOVE_SORT_EQUITY,
+      .override_kwg = NULL,
+      .eq_margin_movegen = 0,
+      .target_equity = EQUITY_MAX_VALUE,
+      .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+      .tiles_played_bv = NULL,
+  };
+  generate_moves(&gen_args);
+  move_list_sort_moves(move_list);
+  const int total = move_list_get_count(move_list);
+  const int n_cand =
+      total < PEG_BENCH_MAX_CANDIDATES ? total : PEG_BENCH_MAX_CANDIDATES;
+  const Move *cands[PEG_BENCH_MAX_CANDIDATES];
+  for (int i = 0; i < n_cand; i++) {
+    cands[i] = move_list_get_move(move_list, i);
+  }
+  ErrorStack *es = error_stack_create();
+
+  PegArgs base = {0};
+  base.game = game;
+  base.thread_control = thread_control;
+  base.num_threads = g_bench_num_threads;
+  base.greedy_seed_only = true;
+  base.time_budget_seconds = g_bench_budget_s;
+  base.only_moves = cands;
+  base.n_only_moves = n_cand;
+
+  thread_control_set_status(thread_control, THREAD_CONTROL_STATUS_STARTED);
+  PegResult ur = {0};
+  peg_solve(&base, &ur, es);
+  peg_bench_dump_ranking("UNIFORM", &ur, game);
+
+  PegArgs pa = base;
+  pa.opp_leave_prior = prior;
+  pa.inference_samples = samples;
+  pa.inference_seed = seed;
+  thread_control_set_status(thread_control, THREAD_CONTROL_STATUS_STARTED);
+  PegResult pr = {0};
+  peg_solve(&pa, &pr, es);
+  peg_bench_dump_ranking("PSYCHIC", &pr, game);
+  peg_result_destroy(&pr);
+
+  // Determinism probe: re-run the identical psychic solve twice more and print
+  // the #0 move each time. If the top move varies, peg_solve is non-deterministic
+  // (multi-threaded scenario/endgame eval), so A/B deltas are partly noise.
+  const Board *board = game_get_board(game);
+  const LetterDistribution *ld = game_get_ld(game);
+  StringBuilder *sb = string_builder_create();
+  for (int rep = 0; rep < 3; rep++) {
+    thread_control_set_status(thread_control, THREAD_CONTROL_STATUS_STARTED);
+    PegResult rr = {0};
+    peg_solve(&pa, &rr, es);
+    string_builder_clear(sb);
+    if (rr.n_top_cands > 0) {
+      string_builder_add_move(sb, board, &rr.top_cands[0].move, ld, true);
+    }
+    printf("      [determinism] psychic rep %d: #0=%-16s win=%.4f spread=%+.1f\n",
+           rep, string_builder_peek(sb),
+           rr.n_top_cands > 0 ? rr.top_cands[0].win_pct : -1.0,
+           rr.n_top_cands > 0 ? rr.top_cands[0].mean_spread : 0.0);
+    peg_result_destroy(&rr);
+  }
+  string_builder_destroy(sb);
+
+  fflush(stdout);
+  peg_result_destroy(&ur);
+  error_stack_destroy(es);
 }
 
 // ── Playout ──────────────────────────────────────────────────────────────────
@@ -427,6 +706,42 @@ static int peg_bench_play_out(Game *game, MoveList *move_list,
         psychic_res =
             peg_bench_psychic_prior(game_before_prev, &prev_move, prev_player);
         prior = psychic_res;
+        if (getenv("PEGBENCH_DEBUG_PSYCHIC") != NULL) {
+          // Verify the computed "true leave" is a subset of the opponent's
+          // ACTUAL current rack. If not, the leave models tiles the opponent
+          // does not hold -- a bug, not a finding.
+          const int ld_size = ld_get_size(game_get_ld(game));
+          const Rack *before =
+              player_get_rack(game_get_player(game_before_prev, prev_player));
+          const Rack *opp_now =
+              player_get_rack(game_get_player(game, prev_player));
+          Rack played;
+          peg_bench_extract_played_tiles(&prev_move, ld_size, &played);
+          int subset_ok = 1;
+          int leave_sz = 0;
+          for (int ml = 0; ml < ld_size; ml++) {
+            int keep = (int)rack_get_letter(before, ml) -
+                       (int)rack_get_letter(&played, ml);
+            if (keep < 0) {
+              keep = 0;
+            }
+            leave_sz += keep;
+            if (keep > (int)rack_get_letter(opp_now, ml)) {
+              subset_ok = 0;
+            }
+          }
+          printf("      [psy-dbg] turn=%d opp=p%d opp-bag=%d leave_size=%d "
+                 "opp_now_size=%d leave_subset_of_opp_now=%s\n",
+                 turn + 1, prev_player, prev_turn_bag, leave_sz,
+                 rack_get_total_letters(opp_now), subset_ok ? "YES" : "NO(BUG)");
+          fflush(stdout);
+        }
+        if (getenv("PEGBENCH_DEBUG_PEG") != NULL && psychic_res != NULL) {
+          printf("    === peg ranking debug (turn %d, opp-bag=%d) ===\n",
+                 turn + 1, prev_turn_bag);
+          peg_bench_debug_rankings(game, move_list, thread_control, psychic_res,
+                                   g_bench_samples, 42 + (uint64_t)turn);
+        }
       } else {
         const double infer_budget =
             g_bench_budget_s * PEG_BENCH_INFER_BUDGET_FRAC;
@@ -490,6 +805,210 @@ static int peg_bench_play_out(Game *game, MoveList *move_list,
   return inferring_player == 0 ? p0_spread : -p0_spread;
 }
 
+// ── Ground-truth move evaluation ─────────────────────────────────────────────
+
+// The mover's chosen PEG move for this position: greedy peg_solve over the top
+// candidates, weighted by `prior` when non-NULL. Copies it to *out; false if no
+// move was produced.
+static bool peg_bench_best_move(Game *game, MoveList *move_list,
+                                ThreadControl *thread_control,
+                                const InferenceResults *prior, int samples,
+                                uint64_t seed, Move *out, double *out_peg_win,
+                                double *out_peg_spread, int *out_peg_stage,
+                                ErrorStack *error_stack) {
+  move_list_reset(move_list);
+  const MoveGenArgs gen_args = {
+      .game = game,
+      .move_list = move_list,
+      .move_record_type = MOVE_RECORD_ALL,
+      .move_sort_type = MOVE_SORT_EQUITY,
+      .override_kwg = NULL,
+      .eq_margin_movegen = 0,
+      .target_equity = EQUITY_MAX_VALUE,
+      .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+      .tiles_played_bv = NULL,
+  };
+  generate_moves(&gen_args);
+  move_list_sort_moves(move_list);
+  const int total = move_list_get_count(move_list);
+  const int n_cand =
+      total < PEG_BENCH_MAX_CANDIDATES ? total : PEG_BENCH_MAX_CANDIDATES;
+  if (n_cand == 0) {
+    return false;
+  }
+  const Move *cands[PEG_BENCH_MAX_CANDIDATES];
+  for (int i = 0; i < n_cand; i++) {
+    cands[i] = move_list_get_move(move_list, i);
+  }
+  PegArgs peg_args = {0};
+  peg_args.game = game;
+  peg_args.thread_control = thread_control;
+  peg_args.num_threads = g_bench_num_threads;
+  peg_bench_config_solver(&peg_args);
+  peg_args.time_budget_seconds = g_bench_budget_s;
+  peg_args.only_moves = cands;
+  peg_args.n_only_moves = n_cand;
+  peg_args.opp_leave_prior = prior;
+  peg_args.inference_samples = prior ? samples : 0;
+  peg_args.inference_seed = seed;
+  // Inference mode: narrow the outer halving field so the costly sampled deep
+  // stages fit the budget (the greedy seed still ranks all cands; only the top
+  // g_bench_infer_topk carry into the depth ramp). Lives on the stack for the
+  // duration of this peg_solve call.
+  int infer_schedule[8];
+  if (prior != NULL && g_bench_infer_topk > 1) {
+    int n = 0;
+    for (int k = g_bench_infer_topk; k > 2 && n < 7; k /= 2) {
+      infer_schedule[n++] = k;
+    }
+    infer_schedule[n++] = 2;
+    peg_args.stage_top_k = infer_schedule;
+    peg_args.num_stages = n;
+  }
+  thread_control_set_status(thread_control, THREAD_CONTROL_STATUS_STARTED);
+  PegResult r = {0};
+  peg_solve(&peg_args, &r, error_stack);
+  bool ok = false;
+  if (error_stack_is_empty(error_stack) && r.n_top_cands > 0 &&
+      r.best_win >= 0.0) {
+    move_copy(out, &r.best_move);
+    // peg_solve's OWN estimate for the chosen move (top_cands[0] == best_move),
+    // surfaced so callers can compare peg's win% to the ground truth
+    // (calibration: does the solver believe it wins by more than reality?).
+    if (out_peg_win != NULL) {
+      *out_peg_win = r.top_cands[0].win_pct;
+    }
+    if (out_peg_spread != NULL) {
+      *out_peg_spread = r.top_cands[0].mean_spread;
+    }
+    // Deepest stage reached (0 = greedy seed only; >0 = a halving stage at
+    // fidelity 2+ completed). If this is 0, the fidelity knobs (nested depth,
+    // emptier endgame plies) never fire -- the win% is a greedy playout.
+    if (out_peg_stage != NULL) {
+      *out_peg_stage = r.last_completed_stage;
+    }
+    ok = true;
+  }
+  // Optional: dump the full per-candidate outcomes table (win%/spread + W/T/wsum
+  // scenario counts) for the last completed stage. Labels the arm by whether an
+  // opponent-leave prior is in effect (PSYCHIC/inference vs UNIFORM).
+  if (getenv("PEGBENCH_DUMPCANDS") != NULL && r.n_top_cands > 0) {
+    printf("      [%s stage=%d] cand outcomes:\n",
+           prior != NULL ? (g_bench_psychic ? "PSYCHIC" : "INFER") : "UNIFORM",
+           r.last_completed_stage);
+    peg_bench_dump_ranking(prior != NULL ? "  ranked" : "  ranked", &r, game);
+  }
+  peg_result_destroy(&r);
+  return ok;
+}
+
+// Play out with static-equity moves (both players) until the bag empties, then
+// the budget-capped d25 endgame; return the inferring player's final spread.
+static int peg_bench_static_playout(Game *game, MoveList *move_list,
+                                    ThreadControl *thread_control,
+                                    int inferring_player, double endgame_budget,
+                                    ErrorStack *error_stack) {
+  while (!game_over(game)) {
+    const int bag = bag_get_letters(game_get_bag(game));
+    bool played = false;
+    if (bag == 0) {
+      Move mv;
+      // Single-threaded => deterministic: the ground truth must not vary with
+      // the parallel endgame's thread scheduling, or same-move samples diverge.
+      played = peg_bench_play_endgame(game, thread_control, endgame_budget,
+                                      /*num_threads=*/1, &mv, error_stack);
+    }
+    if (!played) {
+      Move mv;
+      move_copy(&mv, get_top_equity_move(game, move_list));
+      play_move(&mv, game, NULL);
+    }
+    if (!error_stack_is_empty(error_stack)) {
+      error_stack_print_and_reset(error_stack);
+      break;
+    }
+  }
+  const int p0 = equity_to_int(player_get_score(game_get_player(game, 0)));
+  const int p1 = equity_to_int(player_get_score(game_get_player(game, 1)));
+  return inferring_player == 0 ? p0 - p1 : p1 - p0;
+}
+
+// Ground-truth expected value of playing `move` from `pos`: for each of n
+// samples, pin the opponent's rack to (actual_leave + a random completion) and
+// reseed the bag (game_seed then set_random_rack, the sim model), play the move,
+// then static-playout to the end. Averages the inferring player's spread and
+// counts wins. The per-sample seeds are shared across the moves being compared
+// so the draws are paired.
+static void peg_bench_ground_truth(const Game *pos, const Move *move,
+                                   const Rack *actual_leave, int opp_idx,
+                                   int inferring_player, int n,
+                                   uint64_t base_seed, MoveList *move_list,
+                                   ThreadControl *thread_control,
+                                   double endgame_budget, ErrorStack *error_stack,
+                                   double *mean_spread_out, double *win_pts_out) {
+  double sum_spread = 0.0;
+  double win_pts = 0.0;
+  for (int r = 0; r < n; r++) {
+    Game *g = game_duplicate(pos);
+    game_seed(g, base_seed + (uint64_t)r);
+    set_random_rack(g, opp_idx, actual_leave);
+    Move m;
+    move_copy(&m, move);
+    play_move(&m, g, NULL);
+    const int sp = peg_bench_static_playout(g, move_list, thread_control,
+                                            inferring_player, endgame_budget,
+                                            error_stack);
+    sum_spread += sp;
+    win_pts += (sp > 0) ? 1.0 : (sp == 0 ? 0.5 : 0.0);
+    game_destroy(g);
+  }
+  *mean_spread_out = sum_spread / n;
+  *win_pts_out = win_pts / n;
+}
+
+// Compute the opponent's true leave (pre-move rack minus played tiles).
+static void peg_bench_true_leave(const Game *game_before_prev,
+                                 const Move *prev_move, int prev_player,
+                                 Rack *leave) {
+  const int ld_size = ld_get_size(game_get_ld(game_before_prev));
+  const Rack *before =
+      player_get_rack(game_get_player(game_before_prev, prev_player));
+  Rack played;
+  peg_bench_extract_played_tiles(prev_move, ld_size, &played);
+  rack_set_dist_size_and_reset(leave, ld_size);
+  for (int ml = 0; ml < ld_size; ml++) {
+    const int keep =
+        (int)rack_get_letter(before, ml) - (int)rack_get_letter(&played, ml);
+    for (int k = 0; k < keep; k++) {
+      rack_add_letter(leave, (MachineLetter)ml);
+    }
+  }
+}
+
+// Whether two tile-placement/pass moves are the same play (so their ground
+// truth is identical -- no point sampling it).
+static bool peg_bench_moves_equal(const Move *a, const Move *b) {
+  if (move_get_type(a) != move_get_type(b)) {
+    return false;
+  }
+  if (move_get_type(a) != GAME_EVENT_TILE_PLACEMENT_MOVE) {
+    return true; // passes/exchanges of the same type: treat as equal
+  }
+  if (move_get_row_start(a) != move_get_row_start(b) ||
+      move_get_col_start(a) != move_get_col_start(b) ||
+      move_get_dir(a) != move_get_dir(b) ||
+      move_get_tiles_length(a) != move_get_tiles_length(b)) {
+    return false;
+  }
+  const int n = move_get_tiles_length(a);
+  for (int i = 0; i < n; i++) {
+    if (move_get_tile(a, i) != move_get_tile(b, i)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 // ── Position generation ──────────────────────────────────────────────────────
 
 // A generated PEG benchmark position: the inferring player is on turn in the
@@ -514,12 +1033,106 @@ static void peg_bench_position_destroy(PegBenchPosition *p) {
 // -- the transition into the PEG zone) and peg-inf positions (PEG->PEG, opponent
 // moved with a bag <= 4 having played few tiles). Peg-inf positions are rare in
 // static play, so many games are scanned. Returns the number captured.
+// Generation-policy SIM move: sim the top static candidates (2-ply BAI, same
+// shape as the inference's inner sims) and play the best by win%. Mirrors
+// RUN_INNER_SIM in simmed_inference.c. Returns false (caller falls back to
+// static) on an empty field or sim error.
+static bool peg_bench_sim_move(Game *game, MoveList *move_list,
+                               WinPct *win_pcts,
+                               ThreadControl *thread_control, int iters,
+                               uint64_t seed, Move *out) {
+  move_list_reset(move_list);
+  const MoveGenArgs gen_args = {
+      .game = game,
+      .move_list = move_list,
+      .move_record_type = MOVE_RECORD_ALL,
+      .move_sort_type = MOVE_SORT_EQUITY,
+      .override_kwg = NULL,
+      .eq_margin_movegen = 0,
+      .target_equity = EQUITY_MAX_VALUE,
+      .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+      .tiles_played_bv = NULL,
+  };
+  generate_moves(&gen_args);
+  move_list_sort_moves(move_list);
+  int arms = move_list_get_count(move_list);
+  if (arms == 0) {
+    return false;
+  }
+  if (arms == 1) {
+    move_copy(out, move_list_get_move(move_list, 0));
+    return true;
+  }
+  if (arms > 8) {
+    arms = 8;
+  }
+  move_list->count = arms; // sim only the top arms (peg_inference.c pattern)
+  thread_control_set_status(thread_control, THREAD_CONTROL_STATUS_STARTED);
+  SimArgs sa;
+  sim_args_fill(/*num_plies=*/2, move_list, arms, /*known_opp_rack=*/NULL,
+                win_pcts, /*inference_results=*/NULL, thread_control, game,
+                /*sim_with_inference=*/false, /*use_heat_map=*/false,
+                g_bench_num_threads, /*print_interval=*/0,
+                /*max_display_plays=*/arms, /*max_display_plies=*/2, seed,
+                (uint64_t)iters, /*min_play_iterations=*/1, /*scond=*/101.0,
+                BAI_THRESHOLD_NONE, /*time_limit_seconds=*/9999,
+                BAI_SAMPLING_RULE_ROUND_ROBIN, /*cutoff=*/0.0,
+                /*inference_args=*/NULL, &sa);
+  SimResults *sr = sim_results_create(0.0);
+  ErrorStack *es = error_stack_create();
+  simulate_without_ctx(&sa, sr, es);
+  bool ok = error_stack_is_empty(es);
+  if (ok) {
+    int best = 0;
+    double best_wp = -1.0;
+    for (int i = 0; i < arms; i++) {
+      const double wp = stat_get_mean(simmed_play_get_win_pct_stat(
+          sim_results_get_simmed_play(sr, i)));
+      if (wp > best_wp) {
+        best_wp = wp;
+        best = i;
+      }
+    }
+    // Read the move off the simmed play itself (robust to any result
+    // reordering inside the simmer).
+    move_copy(out, simmed_play_get_move(sim_results_get_simmed_play(sr, best)));
+  }
+  error_stack_destroy(es);
+  sim_results_destroy(sr);
+  return ok;
+}
+
+// Generation-policy PEG move: a uniform peg_solve at the generation budget.
+// Reuses peg_bench_best_move, temporarily overriding its budget global (test
+// code; single-threaded generation loop).
+static bool peg_bench_gen_peg_move(Game *game, MoveList *move_list,
+                                   ThreadControl *thread_control, uint64_t seed,
+                                   Move *out, ErrorStack *es) {
+  const double saved_budget = g_bench_budget_s;
+  g_bench_budget_s = g_bench_gen_pegbudget;
+  double w = 0.0, s = 0.0;
+  int st = -1;
+  const bool ok = peg_bench_best_move(game, move_list, thread_control, NULL, 0,
+                                      seed, out, &w, &s, &st, es);
+  g_bench_budget_s = saved_budget;
+  if (!ok) {
+    error_stack_reset(es); // fall back to static, don't poison the caller
+  }
+  return ok;
+}
+
 static int peg_bench_generate(Game *proto, MoveList *move_list,
+                              WinPct *win_pcts,
+                              ThreadControl *thread_control,
                               PegBenchPosition *out, int max_sim, int max_peg,
                               uint64_t base_seed, uint64_t game_cap) {
   int n = 0;
   int n_sim = 0;
   int n_peg = 0;
+  // Deterministic per-move seed and scratch error stack for the realistic
+  // generation policy (see g_bench_realopp).
+  uint64_t gen_turn_seed = base_seed + 777000000u;
+  ErrorStack *gen_es = error_stack_create();
   for (uint64_t g = 0; (n_sim < max_sim || n_peg < max_peg) && g < game_cap;
        g++) {
     game_reset(proto);
@@ -538,7 +1151,13 @@ static int peg_bench_generate(Game *proto, MoveList *move_list,
           have_prev &&
           (move_get_type(&prev_move) == GAME_EVENT_TILE_PLACEMENT_MOVE ||
            move_get_type(&prev_move) == GAME_EVENT_EXCHANGE);
-      if (inferable && bag >= PEG_MIN_BAG && bag <= PEG_MAX_BAG) {
+      const int score_gap =
+          abs(equity_to_int(player_get_score(game_get_player(proto, 0))) -
+              equity_to_int(player_get_score(game_get_player(proto, 1))));
+      const bool contested =
+          g_bench_contested <= 0 || score_gap <= g_bench_contested;
+      if (inferable && contested && bag >= PEG_MIN_BAG &&
+          bag <= PEG_MAX_BAG) {
         const bool sim_inf = prev_turn_bag >= PEG_BENCH_SIM_INFER_BAG;
         if ((sim_inf && n_sim < max_sim) || (!sim_inf && n_peg < max_peg)) {
           PegBenchPosition *p = &out[n++];
@@ -557,7 +1176,24 @@ static int peg_bench_generate(Game *proto, MoveList *move_list,
       }
       Game *snap = game_duplicate(proto);
       Move played;
-      move_copy(&played, get_top_equity_move(proto, move_list));
+      bool picked = false;
+      // Realistic policy inside the window the inference conditions on: SIM
+      // moves at bag >= 5, uniform PEG moves at bag <= 4. Static equity above
+      // the window and as the fallback on any solver failure.
+      if (g_bench_realopp && bag >= 1 && bag <= g_bench_gen_authbag) {
+        gen_turn_seed++;
+        if (bag >= PEG_BENCH_SIM_INFER_BAG) {
+          picked = peg_bench_sim_move(proto, move_list, win_pcts,
+                                      thread_control, g_bench_gen_simiters,
+                                      gen_turn_seed, &played);
+        } else {
+          picked = peg_bench_gen_peg_move(proto, move_list, thread_control,
+                                          gen_turn_seed, &played, gen_es);
+        }
+      }
+      if (!picked) {
+        move_copy(&played, get_top_equity_move(proto, move_list));
+      }
       play_move(&played, proto, NULL);
       game_copy(before_prev, snap);
       game_destroy(snap);
@@ -568,6 +1204,7 @@ static int peg_bench_generate(Game *proto, MoveList *move_list,
     }
     game_destroy(before_prev);
   }
+  error_stack_destroy(gen_es);
   return n;
 }
 
@@ -592,7 +1229,8 @@ void test_peginf_benchmark(void) {
       peg_bench_env_double("PEGBENCH_BUDGET", PEG_BENCH_TURN_BUDGET_S);
   g_bench_samples =
       peg_bench_env_int("PEGBENCH_SAMPLES", PEG_BENCH_INFERENCE_SAMPLES);
-  g_bench_psychic = peg_bench_env_int("PEGBENCH_PSYCHIC", 0) != 0;
+  g_bench_psychic = peg_bench_env_bool("PEGBENCH_PSYCHIC", false);
+  g_bench_greedy = peg_bench_env_bool("PEGBENCH_GREEDY", false);
 
   printf("  PEG A/B benchmark (4-in-bag CSW24, budget %.1fs/turn, %d threads):\n",
          g_bench_budget_s, g_bench_num_threads);
@@ -713,7 +1351,8 @@ void test_peginf_benchmark_generate(void) {
       peg_bench_env_double("PEGBENCH_BUDGET", PEG_BENCH_TURN_BUDGET_S);
   g_bench_samples =
       peg_bench_env_int("PEGBENCH_SAMPLES", PEG_BENCH_INFERENCE_SAMPLES);
-  g_bench_psychic = peg_bench_env_int("PEGBENCH_PSYCHIC", 0) != 0;
+  g_bench_psychic = peg_bench_env_bool("PEGBENCH_PSYCHIC", false);
+  g_bench_greedy = peg_bench_env_bool("PEGBENCH_GREEDY", false);
 
   // Quotas, seed, and game cap are env-overridable (PEGBENCH_SIM / _PEG / _SEED
   // / _GAMECAP) so a large run needs no rebuild.
@@ -726,12 +1365,14 @@ void test_peginf_benchmark_generate(void) {
 
   PegBenchPosition *positions =
       malloc_or_die(sizeof(PegBenchPosition) * (size_t)(max_sim + max_peg));
-  const int n = peg_bench_generate(game, move_list, positions, max_sim, max_peg,
-                                   base_seed, game_cap);
+  const int n = peg_bench_generate(game, move_list, win_pcts, thread_control,
+                                   positions, max_sim, max_peg, base_seed,
+                                   game_cap);
   printf("  PEG A/B aggregation: generated %d positions (target %d sim + %d "
-         "peg), budget %.1fs/turn, %d threads, arm B = %s\n",
+         "peg), budget %.1fs/turn, %d threads, arm B = %s, move-sel = %s\n",
          n, max_sim, max_peg, g_bench_budget_s, g_bench_num_threads,
-         g_bench_psychic ? "PSYCHIC (true opponent leave)" : "inference");
+         g_bench_psychic ? "PSYCHIC (true opponent leave)" : "inference",
+         g_bench_greedy ? "greedy stage-0" : "full halving stages");
 
   // Debug: skip playing positions before this index (generation is
   // deterministic, so this jumps straight to a specific position to reproduce).
@@ -791,6 +1432,738 @@ void test_peginf_benchmark_generate(void) {
   config_destroy(config);
 }
 
+// Aggregated top-N: collect the N distinct leaves with the largest SUMMED mass
+// (duplicates aggregated) into out_racks/out_weights (descending). Returns the
+// number filled (0 on empty support). O(n^2) rack compares; supports are a few
+// hundred items.
+static int peg_bench_top_leaves(AliasMethod *am, int ld_size, int topn,
+                                Rack *out_racks, int64_t *out_weights) {
+  const int n = alias_method_num_items(am);
+  if (n <= 0 || topn <= 0) {
+    return 0;
+  }
+  Rack item;
+  rack_set_dist_size_and_reset(&item, ld_size);
+  Rack probe;
+  rack_set_dist_size_and_reset(&probe, ld_size);
+  int n_out = 0;
+  for (int i = 0; i < n; i++) {
+    rack_reset(&item);
+    alias_method_get_item(am, i, &item);
+    bool seen = false;
+    for (int j = 0; j < i && !seen; j++) {
+      rack_reset(&probe);
+      alias_method_get_item(am, j, &probe);
+      seen = racks_are_equal(&probe, &item);
+    }
+    if (seen) {
+      continue;
+    }
+    int64_t sum = 0;
+    for (int j = i; j < n; j++) {
+      rack_reset(&probe);
+      const uint32_t w = alias_method_get_item(am, j, &probe);
+      if (racks_are_equal(&probe, &item)) {
+        sum += (int64_t)w;
+      }
+    }
+    // Insert into the sorted top-N.
+    if (n_out < topn || sum > out_weights[topn - 1]) {
+      int pos = n_out < topn ? n_out : topn - 1;
+      if (n_out < topn) {
+        n_out++;
+      }
+      while (pos > 0 && out_weights[pos - 1] < sum) {
+        rack_copy(&out_racks[pos], &out_racks[pos - 1]);
+        out_weights[pos] = out_weights[pos - 1];
+        pos--;
+      }
+      rack_copy(&out_racks[pos], &item);
+      out_weights[pos] = sum;
+    }
+  }
+  return n_out;
+}
+
+// The inference support may contain DUPLICATE entries for the same leave (one
+// alias item per accepted evaluation). Aggregate by distinct leave and return
+// the leave with the largest SUMMED mass in *out, its aggregated share in
+// *out_share, and the number of distinct leaves. O(n^2) rack compares; supports
+// are a few hundred items. Returns false on an empty support.
+static bool peg_bench_top_leave(AliasMethod *am, int ld_size, Rack *out,
+                                double *out_share, int *out_distinct) {
+  const int n = alias_method_num_items(am);
+  if (n <= 0) {
+    return false;
+  }
+  Rack item;
+  rack_set_dist_size_and_reset(&item, ld_size);
+  Rack probe;
+  rack_set_dist_size_and_reset(&probe, ld_size);
+  int64_t total = 0;
+  for (int i = 0; i < n; i++) {
+    total += (int64_t)alias_method_item_count(am, i);
+  }
+  if (total <= 0) {
+    return false;
+  }
+  int64_t best_sum = -1;
+  int distinct = 0;
+  for (int i = 0; i < n; i++) {
+    rack_reset(&item);
+    alias_method_get_item(am, i, &item);
+    // Count each distinct leave once: skip if an identical rack appeared
+    // earlier in the list.
+    bool seen = false;
+    for (int j = 0; j < i && !seen; j++) {
+      rack_reset(&probe);
+      alias_method_get_item(am, j, &probe);
+      seen = racks_are_equal(&probe, &item);
+    }
+    if (seen) {
+      continue;
+    }
+    distinct++;
+    int64_t sum = 0;
+    for (int j = i; j < n; j++) {
+      rack_reset(&probe);
+      const uint32_t w = alias_method_get_item(am, j, &probe);
+      if (racks_are_equal(&probe, &item)) {
+        sum += (int64_t)w;
+      }
+    }
+    if (sum > best_sum) {
+      best_sum = sum;
+      rack_copy(out, &item);
+    }
+  }
+  *out_share = (double)best_sum / (double)total;
+  if (out_distinct != NULL) {
+    *out_distinct = distinct;
+  }
+  return true;
+}
+
+// Record one calibration observation: how the inferred leave distribution
+// relates to the KNOWN true leave. Emits a machine-parseable [calib] line:
+//   k          true-leave size (information content proxy)
+//   bag        bag size when the opponent moved (sim- vs peg-inference regime)
+//   n_leaves   support size of the inferred distribution
+//   conf       top-leave mass share (the runtime-computable confidence stat)
+//   found      1 if the true leave is in the support at all
+//   true_mass  prior mass assigned to the true leave
+//   true_rank  1-based weight rank of the true leave (0 = not found)
+static void peg_bench_calib_record(InferenceResults *results,
+                                   const Rack *true_leave, int k, int prev_bag,
+                                   const LetterDistribution *ld) {
+  AliasMethod *am = inference_results_get_alias_method(results);
+  const int n = alias_method_num_items(am);
+  const int ld_size = ld_get_size(ld);
+  Rack item;
+  rack_set_dist_size_and_reset(&item, ld_size);
+  Rack probe;
+  rack_set_dist_size_and_reset(&probe, ld_size);
+  int64_t total = 0;
+  int64_t true_w = 0;
+  for (int i = 0; i < n; i++) {
+    rack_reset(&item);
+    const uint32_t w = alias_method_get_item(am, i, &item);
+    total += (int64_t)w;
+    if (racks_are_equal(&item, true_leave)) {
+      true_w += (int64_t)w; // duplicates: sum the leave's total mass
+    }
+  }
+  // Aggregated top leave (duplicates summed) -- the leave a top-1 gate would
+  // actually act on -- and the true leave's rank among DISTINCT leaves by
+  // aggregated mass.
+  Rack top_rack;
+  rack_set_dist_size_and_reset(&top_rack, ld_size);
+  double conf = 0.0;
+  int n_distinct = 0;
+  const bool has_top =
+      peg_bench_top_leave(am, ld_size, &top_rack, &conf, &n_distinct);
+  int rank = 0;
+  if (true_w > 0) {
+    rank = 1;
+    for (int i = 0; i < n; i++) {
+      rack_reset(&item);
+      alias_method_get_item(am, i, &item);
+      if (racks_are_equal(&item, true_leave)) {
+        continue;
+      }
+      bool seen = false;
+      for (int j = 0; j < i && !seen; j++) {
+        rack_reset(&probe);
+        alias_method_get_item(am, j, &probe);
+        seen = racks_are_equal(&probe, &item);
+      }
+      if (seen) {
+        continue;
+      }
+      int64_t sum = 0;
+      for (int j = i; j < n; j++) {
+        rack_reset(&probe);
+        const uint32_t w = alias_method_get_item(am, j, &probe);
+        if (racks_are_equal(&probe, &item)) {
+          sum += (int64_t)w;
+        }
+      }
+      if (sum > true_w) {
+        rank++;
+      }
+    }
+  }
+  const bool top1_match = has_top && racks_are_equal(&top_rack, true_leave);
+  StringBuilder *sb = string_builder_create();
+  string_builder_add_rack(sb, true_leave, ld, false);
+  printf("[calib] k=%d bag=%d type=%s n_items=%d n_distinct=%d conf=%.4f "
+         "found=%d true_mass=%.5f true_rank=%d top1_match=%d leave=%s\n",
+         k, prev_bag, prev_bag >= PEG_BENCH_SIM_INFER_BAG ? "sim" : "peg", n,
+         n_distinct, conf, true_w > 0 ? 1 : 0,
+         total > 0 ? (double)true_w / (double)total : 0.0, rank,
+         top1_match ? 1 : 0, k == 0 ? "(empty)" : string_builder_peek(sb));
+  fflush(stdout);
+  string_builder_destroy(sb);
+}
+
+// Ceiling diagnostic (PEGBENCH_CEILING): GT-evaluate the top-K static candidates
+// DIRECTLY against the true opponent leave -- the exact same evaluation GT uses
+// to score the arms -- to find the GT-optimal move. Reports where the uniform
+// (A) and psychic (B) solver picks land relative to that ceiling. If the ceiling
+// (GT_best - GT_uniform) is large but psychic captures little of it, the solver
+// is failing to convert perfect information it provably has -- the handicap is
+// in peg_solve's application, not in the information.
+static void peg_bench_ceiling_analysis(const Game *pos, const Rack *actual_leave,
+                                       int opp_idx, int inferring_player,
+                                       const Move *move_a, const Move *move_b,
+                                       int gt_samples, uint64_t gt_seed,
+                                       MoveList *move_list,
+                                       ThreadControl *thread_control,
+                                       double endgame_budget,
+                                       ErrorStack *error_stack) {
+  move_list_reset(move_list);
+  const MoveGenArgs gen_args = {
+      .game = (Game *)pos,
+      .move_list = move_list,
+      .move_record_type = MOVE_RECORD_ALL,
+      .move_sort_type = MOVE_SORT_EQUITY,
+      .override_kwg = NULL,
+      .eq_margin_movegen = 0,
+      .target_equity = EQUITY_MAX_VALUE,
+      .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+      .tiles_played_bv = NULL,
+  };
+  generate_moves(&gen_args);
+  move_list_sort_moves(move_list);
+  const int total = move_list_get_count(move_list);
+  const int k = total < 10 ? total : 10;
+  // Copy candidates out: peg_bench_ground_truth reuses move_list internally.
+  Move cands[10];
+  for (int i = 0; i < k; i++) {
+    move_copy(&cands[i], move_list_get_move(move_list, i));
+  }
+  const Board *board = game_get_board(pos);
+  const LetterDistribution *ld = game_get_ld(pos);
+  StringBuilder *sb = string_builder_create();
+  double best_gt = -1.0, a_gt = -1.0, b_gt = -1.0;
+  int best_idx = 0;
+  printf("      [CEILING] GT-win of top-%d static cands (opp=true leave, "
+         "%d draws):\n",
+         k, gt_samples);
+  for (int i = 0; i < k; i++) {
+    double sp, win;
+    peg_bench_ground_truth(pos, &cands[i], actual_leave, opp_idx,
+                           inferring_player, gt_samples, gt_seed, move_list,
+                           thread_control, endgame_budget, error_stack, &sp,
+                           &win);
+    if (win > best_gt) {
+      best_gt = win;
+      best_idx = i;
+    }
+    const bool is_a = peg_bench_moves_equal(&cands[i], move_a);
+    const bool is_b = peg_bench_moves_equal(&cands[i], move_b);
+    if (is_a) {
+      a_gt = win;
+    }
+    if (is_b) {
+      b_gt = win;
+    }
+    string_builder_clear(sb);
+    string_builder_add_move(sb, board, &cands[i], ld, true);
+    printf("        %-18s gtWin=%.3f gtSpread=%+6.1f%s%s\n",
+           string_builder_peek(sb), win, sp, is_a ? " [A-uniform]" : "",
+           is_b ? " [B-psychic]" : "");
+  }
+  // The solver picks may sit below the top-K static field (a low-static,
+  // high-win% play); GT them directly so the comparison is complete.
+  double sp_tmp;
+  if (a_gt < 0.0) {
+    peg_bench_ground_truth(pos, move_a, actual_leave, opp_idx, inferring_player,
+                           gt_samples, gt_seed, move_list, thread_control,
+                           endgame_budget, error_stack, &sp_tmp, &a_gt);
+  }
+  if (b_gt < 0.0) {
+    peg_bench_ground_truth(pos, move_b, actual_leave, opp_idx, inferring_player,
+                           gt_samples, gt_seed, move_list, thread_control,
+                           endgame_budget, error_stack, &sp_tmp, &b_gt);
+  }
+  double ceil_gt = best_gt;
+  if (a_gt > ceil_gt) {
+    ceil_gt = a_gt;
+  }
+  if (b_gt > ceil_gt) {
+    ceil_gt = b_gt;
+  }
+  string_builder_clear(sb);
+  string_builder_add_move(sb, board, &cands[best_idx], ld, true);
+  printf("      [CEILING] GT-best(top-static)=%s %.3f | uniform=%.3f "
+         "psychic=%.3f | ceiling=%+.3f  psychic-capture=%+.3f\n",
+         string_builder_peek(sb), best_gt, a_gt, b_gt, ceil_gt - a_gt,
+         b_gt - a_gt);
+  string_builder_destroy(sb);
+}
+
+// Ground-truth benchmark: for each contested PEG position, compute the uniform
+// move (arm A) and the inference/psychic move (arm B), then measure each move's
+// GROUND-TRUTH expected result by Monte-Carlo over random draws that complete
+// the opponent's ACTUAL leave. Compares the two moves' expected win% and spread
+// -- the definitive "does the inference move actually win more often" test,
+// with single-playout variance averaged out.
+void test_peginf_benchmark_groundtruth(void) {
+  char config_cmd[256];
+  snprintf(config_cmd, sizeof(config_cmd),
+           "set -lex CSW24 -s1 equity -s2 equity -r1 all -r2 all -numplays 15 "
+           "-threads %d",
+           get_num_cores());
+  Config *config = config_create_or_die(config_cmd);
+  load_and_exec_config_or_die(config, "cgp " EMPTY_CGP);
+  Game *game = config_get_game(config);
+  ThreadControl *thread_control = config_get_thread_control(config);
+  MoveList *move_list = move_list_create(64);
+  ErrorStack *error_stack = error_stack_create();
+  WinPct *win_pcts = win_pct_create(config_get_data_paths(config),
+                                    DEFAULT_WIN_PCT, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  g_bench_num_threads = config_get_num_threads(config);
+  g_bench_budget_s =
+      peg_bench_env_double("PEGBENCH_BUDGET", PEG_BENCH_TURN_BUDGET_S);
+  g_bench_samples =
+      peg_bench_env_int("PEGBENCH_SAMPLES", PEG_BENCH_INFERENCE_SAMPLES);
+  g_bench_psychic = peg_bench_env_bool("PEGBENCH_PSYCHIC", true);
+  g_bench_greedy = peg_bench_env_bool("PEGBENCH_GREEDY", false);
+  g_bench_nest_depth =
+      peg_bench_env_int("PEGBENCH_NESTDEPTH", PEG_NESTED_DEFAULT_DEPTH);
+  g_bench_infer_topk = peg_bench_env_int("PEGBENCH_INFERTOPK", 0);
+  g_bench_calib = peg_bench_env_int("PEGBENCH_CALIB", 0);
+  g_bench_calib_kmin = peg_bench_env_int("PEGBENCH_CALIB_KMIN", 0);
+  g_bench_calib_kmax = peg_bench_env_int("PEGBENCH_CALIB_KMAX", 7);
+  g_bench_calib_simonly = peg_bench_env_bool("PEGBENCH_CALIB_SIMONLY", false);
+  g_bench_inf_probe = peg_bench_env_int("PEGBENCH_INF_PROBE", 20);
+  g_bench_inf_full = peg_bench_env_int("PEGBENCH_INF_FULL", 40);
+  g_bench_peginf_solve_s = peg_bench_env_double("PEGBENCH_PEGINF_SOLVE", 0.1);
+  g_bench_peginf_exh = peg_bench_env_int("PEGBENCH_PEGINF_EXH", 1);
+  g_bench_realopp = peg_bench_env_bool("PEGBENCH_REALOPP", false);
+  g_bench_gen_authbag = peg_bench_env_int("PEGBENCH_GEN_AUTHBAG", 12);
+  g_bench_gen_simiters = peg_bench_env_int("PEGBENCH_GEN_SIMITERS", 100);
+  g_bench_gen_pegbudget =
+      peg_bench_env_double("PEGBENCH_GEN_PEGBUDGET", 5.0);
+  g_bench_gate = peg_bench_env_bool("PEGBENCH_GATE", false);
+  g_bench_gate_topn = peg_bench_env_int("PEGBENCH_GATE_TOPN", 4);
+  g_bench_gate_kmin = peg_bench_env_int("PEGBENCH_GATE_KMIN", 3);
+  g_bench_gate_kmax = peg_bench_env_int("PEGBENCH_GATE_KMAX", 6);
+  g_bench_gate_obmin =
+      peg_bench_env_int("PEGBENCH_GATE_OBMIN", PEG_BENCH_SIM_INFER_BAG);
+  g_bench_gate_obmax = peg_bench_env_int("PEGBENCH_GATE_OBMAX", 99);
+  g_bench_contested = peg_bench_env_int("PEGBENCH_CONTESTED", 25);
+  g_bench_gt_samples = peg_bench_env_int("PEGBENCH_GT", 40);
+  g_bench_gt_endgame = peg_bench_env_double("PEGBENCH_GTENDGAME", 2.0);
+
+  const int max_sim = peg_bench_env_int("PEGBENCH_SIM", PEG_BENCH_MAX_SIM);
+  const int max_peg = peg_bench_env_int("PEGBENCH_PEG", PEG_BENCH_MAX_PEG);
+  const uint64_t base_seed = (uint64_t)peg_bench_env_int("PEGBENCH_SEED", 1);
+  const uint64_t game_cap =
+      (uint64_t)peg_bench_env_int("PEGBENCH_GAMECAP", PEG_BENCH_GAME_CAP);
+
+  // Wall-clock time limit (PEGBENCH_TIMELIMIT, seconds; 0 = one batch). While
+  // under the limit, keep generating fresh batches of contested positions and
+  // evaluating them, so the run can proceed for hours.
+  const double time_limit_s = peg_bench_env_double("PEGBENCH_TIMELIMIT", 0.0);
+
+  PegBenchPosition *positions =
+      malloc_or_die(sizeof(PegBenchPosition) * (size_t)(max_sim + max_peg));
+  printf("  PEG ground-truth: contested |gap|<=%d, arm B = %s, %d MC draws/move, "
+         "budget %.1fs, endgame %.1fs, %d threads, time-limit %.0fs\n",
+         g_bench_contested, g_bench_psychic ? "PSYCHIC" : "inference",
+         g_bench_gt_samples, g_bench_budget_s, g_bench_gt_endgame,
+         g_bench_num_threads, time_limit_s);
+
+  double sum_win_delta = 0.0;
+  double sum_spread_delta = 0.0;
+  int b_better = 0;
+  int a_better = 0;
+  int ties = 0;
+  int total_n = 0;
+  int same_move_n = 0;
+  int decisive_n = 0;
+  InferenceResults *inf_results = inference_results_create(NULL);
+  StringBuilder *sb = string_builder_create();
+  const LetterDistribution *ld = game_get_ld(game);
+  const double t_start = peg_bench_now_s();
+  uint64_t batch_seed = base_seed;
+  int batch = 0;
+  // Calibration-mode per-leave-size acceptance counters (index = true-leave
+  // size, clamped to 7). See g_bench_calib.
+  int calib_count[8] = {0};
+
+  do {
+    batch++;
+    const int n = peg_bench_generate(game, move_list, win_pcts,
+                                     thread_control, positions, max_sim,
+                                     max_peg, batch_seed, game_cap);
+    for (int i = 0; i < n; i++) {
+      PegBenchPosition *p = &positions[i];
+      const int opp_idx = p->prev_player;
+      Rack actual_leave;
+      peg_bench_true_leave(p->game_before_prev, &p->prev_move, p->prev_player,
+                           &actual_leave);
+
+      // Calibration mode: score the inference itself against the true leave,
+      // stratified by leave size (skip cheaply once a bucket is full). No
+      // solves, no playouts -- see g_bench_calib.
+      if (g_bench_calib > 0) {
+        int kb = (int)rack_get_total_letters(&actual_leave);
+        if (kb > 7) {
+          kb = 7;
+        }
+        const bool in_slice =
+            kb >= g_bench_calib_kmin && kb <= g_bench_calib_kmax &&
+            (!g_bench_calib_simonly ||
+             p->prev_turn_bag >= PEG_BENCH_SIM_INFER_BAG);
+        if (in_slice && calib_count[kb] < g_bench_calib) {
+          const double t_inf = peg_bench_now_s();
+          if (peg_bench_run_inference(
+                  p->game_before_prev, &p->prev_move, p->prev_player,
+                  p->prev_turn_bag, win_pcts, thread_control, inf_results,
+                  g_bench_budget_s * PEG_BENCH_INFER_BUDGET_FRAC,
+                  error_stack)) {
+            printf("[calib-inf] elapsed=%.1fs ", peg_bench_now_s() - t_inf);
+            peg_bench_calib_record(inf_results, &actual_leave, kb,
+                                   p->prev_turn_bag, ld);
+            calib_count[kb]++;
+          }
+        }
+        peg_bench_position_destroy(p);
+        continue;
+      }
+
+      const InferenceResults *prior = NULL;
+      InferenceResults *psychic_res = NULL;
+      InferenceResults *gated_res = NULL; // per-turn; destroyed with psychic_res
+      AliasMethod *gate_alias = NULL;     // owned by us, not by gated_res
+      int gate_k_est = -1;                // set when the gate fires
+      // In gate mode the gate condition is fully observable BEFORE inference
+      // (bag size + play length), so skip the expensive inference entirely on
+      // gated-off positions -- exactly as a realtime engine would.
+      bool gate_precheck = true;
+      if (g_bench_gate && !g_bench_psychic) {
+        const int pre_played = move_get_tiles_played(&p->prev_move);
+        const Rack *pre_rack = player_get_rack(
+            game_get_player(p->game_before_prev, p->prev_player));
+        const int pre_k = (int)rack_get_total_letters(pre_rack) - pre_played;
+        gate_precheck = p->prev_turn_bag >= g_bench_gate_obmin &&
+                        p->prev_turn_bag <= g_bench_gate_obmax &&
+                        pre_k >= g_bench_gate_kmin && pre_k <= g_bench_gate_kmax;
+        if (getenv("PEGBENCH_PREDBG") != NULL) {
+          printf("    [pre] bag=%d played=%d rack_before=%d pre_k=%d -> %d\n",
+                 p->prev_turn_bag, pre_played,
+                 (int)rack_get_total_letters(pre_rack), pre_k,
+                 gate_precheck ? 1 : 0);
+          fflush(stdout);
+        }
+      }
+      if (g_bench_psychic) {
+        psychic_res = peg_bench_psychic_prior(p->game_before_prev,
+                                              &p->prev_move, p->prev_player);
+        prior = psychic_res;
+      } else if (gate_precheck &&
+                 peg_bench_run_inference(
+                     p->game_before_prev, &p->prev_move, p->prev_player,
+                     p->prev_turn_bag, win_pcts, thread_control, inf_results,
+                     g_bench_budget_s * PEG_BENCH_INFER_BUDGET_FRAC,
+                     error_stack)) {
+        prior = inf_results;
+        // Play-length gate (PEGBENCH_GATE): arm B trusts the inference ONLY on
+        // a SIM-inference play whose estimated kept leave k_est = rack_before -
+        // tiles_played (both runtime-observable) lies in the configured slice
+        // [kmin, kmax] (default 3..6: excludes bingos/k=0 and the big plays
+        // where calibration shows the inference is least accurate). The prior
+        // handed to peg_solve is the aggregated TOP-N leaves (duplicates
+        // summed), which fits peg_solve's exact small-support enumeration.
+        // Everything else falls back to uniform (prior = NULL => B == A).
+        if (g_bench_gate) {
+          prior = NULL;
+          const int played = move_get_tiles_played(&p->prev_move);
+          const Rack *before_rack =
+              player_get_rack(game_get_player(p->game_before_prev,
+                                              p->prev_player));
+          const int k_est = (int)rack_get_total_letters(before_rack) - played;
+          AliasMethod *am = inference_results_get_alias_method(inf_results);
+          enum { GATE_MAX_TOPN = 8 };
+          const int topn =
+              g_bench_gate_topn > GATE_MAX_TOPN ? GATE_MAX_TOPN
+                                                : g_bench_gate_topn;
+          Rack top_racks[GATE_MAX_TOPN];
+          int64_t top_ws[GATE_MAX_TOPN];
+          for (int t = 0; t < GATE_MAX_TOPN; t++) {
+            rack_set_dist_size_and_reset(&top_racks[t], ld_get_size(ld));
+          }
+          int n_top = 0;
+          if (p->prev_turn_bag >= g_bench_gate_obmin &&
+              p->prev_turn_bag <= g_bench_gate_obmax &&
+              k_est >= g_bench_gate_kmin && k_est <= g_bench_gate_kmax) {
+            n_top = peg_bench_top_leaves(am, ld_get_size(ld), topn, top_racks,
+                                         top_ws);
+          }
+          if (n_top > 0) {
+            AliasMethod *ga = alias_method_create();
+            bool true_in_topn = false;
+            for (int t = 0; t < n_top; t++) {
+              alias_method_add_rack(ga, &top_racks[t], (int)top_ws[t]);
+              if (racks_are_equal(&top_racks[t], &actual_leave)) {
+                true_in_topn = true;
+              }
+            }
+            if (alias_method_generate_tables(ga)) {
+              // inference_results_destroy does NOT free a caller-supplied
+              // alias; gate_alias is destroyed alongside gated_res below.
+              gated_res = inference_results_create(ga);
+              gate_alias = ga;
+              prior = gated_res;
+              gate_k_est = k_est;
+              string_builder_clear(sb);
+              string_builder_add_rack(sb, &top_racks[0], ld, false);
+              printf("    [gate ON] k_est=%d topn=%d top1=%s in_topn=%d\n",
+                     k_est, n_top, string_builder_peek(sb),
+                     true_in_topn ? 1 : 0);
+              fflush(stdout);
+            } else {
+              alias_method_destroy(ga);
+            }
+          }
+        }
+      }
+
+      // Gate mode: a gated-off position contributes nothing (arm B == arm A by
+      // construction), so skip BOTH solves -- the dominant throughput win for
+      // the overnight run (gated-off positions previously burned a full arm-A
+      // solve before being discarded).
+      if (g_bench_gate && !g_bench_psychic && prior == NULL) {
+        peg_bench_position_destroy(p);
+        continue;
+      }
+
+      // Uniform move (arm A) and inference/psychic move (arm B).
+      Game *g_solve = game_duplicate(p->game);
+      Move move_a;
+      Move move_b;
+      double peg_a_win = -1.0, peg_a_spread = 0.0;
+      double peg_b_win = -1.0, peg_b_spread = 0.0;
+      int peg_a_stage = -1, peg_b_stage = -1;
+      const bool ok_a = peg_bench_best_move(
+          g_solve, move_list, thread_control, NULL, 0,
+          batch_seed + (uint64_t)i, &move_a, &peg_a_win, &peg_a_spread,
+          &peg_a_stage, error_stack);
+      const bool ok_b =
+          prior != NULL &&
+          peg_bench_best_move(g_solve, move_list, thread_control, prior,
+                              g_bench_samples, batch_seed + (uint64_t)i,
+                              &move_b, &peg_b_win, &peg_b_spread, &peg_b_stage,
+                              error_stack);
+      game_destroy(g_solve);
+      if (!ok_a || !ok_b) {
+        if (psychic_res != NULL) {
+          inference_results_destroy(psychic_res);
+        }
+        inference_results_destroy(gated_res);
+        alias_method_destroy(gate_alias);
+        peg_bench_position_destroy(p);
+        continue;
+      }
+
+      // Per-position stage-reached probe (every position, not just decisive):
+      // if this stays 0 the solve never got past the greedy seed and the deep
+      // staged evaluation never ran -- the whole point of the real config.
+      if (getenv("PEGBENCH_STAGEPROBE") != NULL) {
+        printf("    [stageprobe] pos %d: A stage=%d B stage=%d\n", i,
+               peg_a_stage, peg_b_stage);
+        fflush(stdout);
+      }
+
+      // If the inference/psychic move is the same as the uniform move, the
+      // ground truth is identical -- skip the (expensive, noise-only) MC.
+      total_n++;
+      if (peg_bench_moves_equal(&move_a, &move_b)) {
+        same_move_n++;
+        if (psychic_res != NULL) {
+          inference_results_destroy(psychic_res);
+        }
+        inference_results_destroy(gated_res);
+        alias_method_destroy(gate_alias);
+        peg_bench_position_destroy(p);
+        continue;
+      }
+
+      // Ground-truth expected value of each move (shared per-sample seeds =>
+      // paired opponent completions).
+      const uint64_t gt_seed = batch_seed + 1000u * (uint64_t)(i + 1);
+      double gt_a_spread;
+      double gt_a_win;
+      double gt_b_spread;
+      double gt_b_win;
+      peg_bench_ground_truth(p->game, &move_a, &actual_leave, opp_idx,
+                             p->inferring_player, g_bench_gt_samples, gt_seed,
+                             move_list, thread_control, g_bench_gt_endgame,
+                             error_stack, &gt_a_spread, &gt_a_win);
+      peg_bench_ground_truth(p->game, &move_b, &actual_leave, opp_idx,
+                             p->inferring_player, g_bench_gt_samples, gt_seed,
+                             move_list, thread_control, g_bench_gt_endgame,
+                             error_stack, &gt_b_spread, &gt_b_win);
+
+      if (getenv("PEGBENCH_CEILING") != NULL) {
+        peg_bench_ceiling_analysis(p->game, &actual_leave, opp_idx,
+                                   p->inferring_player, &move_a, &move_b,
+                                   g_bench_gt_samples, gt_seed, move_list,
+                                   thread_control, g_bench_gt_endgame,
+                                   error_stack);
+      }
+
+      const double win_delta = gt_b_win - gt_a_win;
+      const double spread_delta = gt_b_spread - gt_a_spread;
+      // Per-position slice record for gated runs: play-length slice analysis
+      // reads these lines (only differing-move positions reach here; gated-on
+      // same-move positions contribute delta 0 by construction).
+      if (gate_k_est >= 0) {
+        printf("    [gateGT] k_est=%d win_delta=%+.3f spread_delta=%+.1f\n",
+               gate_k_est, win_delta, spread_delta);
+        fflush(stdout);
+      }
+      sum_win_delta += win_delta;
+      sum_spread_delta += spread_delta;
+      if (win_delta > 1e-9) {
+        b_better++;
+      } else if (win_delta < -1e-9) {
+        a_better++;
+      } else {
+        ties++;
+      }
+
+      // A position is "decisive" when the inference move differs from uniform
+      // (paired seeds => identical results iff same move). Log full detail.
+      const bool win_decisive = fabs(win_delta) > 1e-9;
+      const bool decisive = win_decisive || fabs(spread_delta) > 0.5;
+      if (decisive) {
+        decisive_n++;
+        const Rack *mover_rack =
+            player_get_rack(game_get_player(p->game, p->inferring_player));
+        printf("  === DECISIVE #%d (batch %d, opp-bag=%d, %s-inf)%s ===\n",
+               decisive_n, batch, p->prev_turn_bag,
+               p->prev_turn_bag >= PEG_BENCH_SIM_INFER_BAG ? "sim" : "peg",
+               win_decisive ? "  [WIN-DELTA]" : "  [spread only]");
+        string_builder_clear(sb);
+        string_builder_add_rack(sb, mover_rack, ld, false);
+        printf("      mover(p%d) rack: %s | ", p->inferring_player,
+               string_builder_peek(sb));
+        string_builder_clear(sb);
+        string_builder_add_rack(sb, &actual_leave, ld, false);
+        printf("opp(p%d) true leave: %s\n", opp_idx, string_builder_peek(sb));
+        // Format moves against the captured position's board (not the shared
+        // generation proto) so play-through tiles resolve correctly.
+        const Board *pos_board = game_get_board(p->game);
+        string_builder_clear(sb);
+        string_builder_add_move(sb, pos_board, &move_a, ld, true);
+        printf("      A uniform:  %-18s -> gtWin %.2f (%.1f/%d)  gtSpread %+.1f"
+               "   [peg win %.2f sprd %+.1f]\n",
+               string_builder_peek(sb), gt_a_win,
+               gt_a_win * g_bench_gt_samples, g_bench_gt_samples, gt_a_spread,
+               peg_a_win, peg_a_spread);
+        string_builder_clear(sb);
+        string_builder_add_move(sb, pos_board, &move_b, ld, true);
+        printf("      B %-7s:  %-18s -> gtWin %.2f (%.1f/%d)  gtSpread %+.1f"
+               "   [peg win %.2f sprd %+.1f]\n",
+               g_bench_psychic ? "psychic" : "infer", string_builder_peek(sb),
+               gt_b_win, gt_b_win * g_bench_gt_samples, g_bench_gt_samples,
+               gt_b_spread, peg_b_win, peg_b_spread);
+        printf("      peg stage reached: A=%d B=%d (0 = greedy seed only)\n",
+               peg_a_stage, peg_b_stage);
+        printf("      => win delta %+.2f, spread delta %+.1f  [%s]\n", win_delta,
+               spread_delta,
+               win_delta > 1e-9 ? "B (inference) better"
+                                : (win_delta < -1e-9 ? "A (uniform) better"
+                                                     : "win tie, spread only"));
+        fflush(stdout);
+      }
+
+      if (psychic_res != NULL) {
+        inference_results_destroy(psychic_res);
+      }
+      inference_results_destroy(gated_res);
+      alias_method_destroy(gate_alias);
+      peg_bench_position_destroy(p);
+    }
+
+    const double elapsed = peg_bench_now_s() - t_start;
+    const int diff_n = total_n - same_move_n;
+    printf("  [batch %d | %.0fs | total=%d same-move=%d differing=%d] "
+           "winΔ over differing: B%d A%d tie%d; mean winΔ(all)=%+.4f\n",
+           batch, elapsed, total_n, same_move_n, diff_n, b_better, a_better,
+           ties, total_n ? sum_win_delta / total_n : 0.0);
+    fflush(stdout);
+    batch_seed += 1000000u;
+    if (g_bench_calib > 0) {
+      bool all_full = true;
+      printf("  [calib coverage after batch %d]", batch);
+      // k ranges 0..6: a placement plays >= 1 tile and an exchange keeps <= 6,
+      // so a 7-tile leave is impossible (passes are not inferable) -- do not
+      // wait on the k7 bucket, nor on buckets outside the calib slice.
+      const int cov_min = g_bench_calib_kmin < 0 ? 0 : g_bench_calib_kmin;
+      const int cov_max = g_bench_calib_kmax > 6 ? 6 : g_bench_calib_kmax;
+      for (int kb = cov_min; kb <= cov_max; kb++) {
+        printf(" k%d=%d/%d", kb, calib_count[kb], g_bench_calib);
+        if (calib_count[kb] < g_bench_calib) {
+          all_full = false;
+        }
+      }
+      printf("\n");
+      fflush(stdout);
+      if (all_full) {
+        break; // every possible leave-size bucket has its quota
+      }
+    }
+  } while (time_limit_s > 0.0 && (peg_bench_now_s() - t_start) < time_limit_s);
+
+  const int diff_n = total_n - same_move_n;
+  if (total_n > 0) {
+    printf("  GROUND-TRUTH FINAL (%d positions, %d same-move skipped, %d "
+           "differing over %d batches):\n"
+           "    mean win%% delta over ALL = %+.4f; over DIFFERING = %+.4f; "
+           "mean spread delta (differing) = %+.2f\n"
+           "    differing moves: B (psychic) better %d, A (uniform) better %d, "
+           "tie %d\n",
+           total_n, same_move_n, diff_n, batch, sum_win_delta / total_n,
+           diff_n ? sum_win_delta / diff_n : 0.0,
+           diff_n ? sum_spread_delta / diff_n : 0.0, b_better, a_better, ties);
+  }
+  assert(error_stack_is_empty(error_stack));
+
+  string_builder_destroy(sb);
+  inference_results_destroy(inf_results);
+  free(positions);
+  win_pct_destroy(win_pcts);
+  move_list_destroy(move_list);
+  error_stack_destroy(error_stack);
+  config_destroy(config);
+}
+
 // Diagnostic: run the d25 endgame on a single CGP (env PEGBENCH_CGP) repeatedly
 // at a controllable thread count (PEGBENCH_THREADS) to isolate whether the
 // zobrist_add_move overflow is a parallel-endgame race (crashes only with >1
@@ -825,7 +2198,8 @@ void test_peginf_endgame_repro(void) {
     Game *g = game_duplicate(game);
     Move mv;
     const bool played = peg_bench_play_endgame(
-        g, thread_control, g_bench_budget_s, &mv, error_stack);
+        g, thread_control, g_bench_budget_s, g_bench_num_threads, &mv,
+        error_stack);
     printf("    iter %2d: played=%d err=%d\n", i, played,
            !error_stack_is_empty(error_stack));
     fflush(stdout);

--- a/test/peginf_benchmark.c
+++ b/test/peginf_benchmark.c
@@ -34,6 +34,7 @@
 #include "../src/ent/win_pct.h"
 #include "../src/impl/config.h"
 #include "../src/impl/endgame.h"
+#include "../src/impl/cgp.h"
 #include "../src/impl/gameplay.h"
 #include "../src/impl/move_gen.h"
 #include "../src/impl/peg.h"
@@ -217,6 +218,13 @@ static bool peg_bench_play_endgame(Game *game, ThreadControl *thread_control,
   endgame_args.hard_time_limit = budget_s;
   endgame_args.external_deadline_ns =
       ctimer_monotonic_ns() + (int64_t)(budget_s * 1.0e9);
+
+  if (getenv("PEGBENCH_DUMP_ENDGAME") != NULL) {
+    char *cgp = game_get_cgp(game, /*write_player_on_turn_first=*/true);
+    printf("    ENDGAME_CGP %s\n", cgp);
+    fflush(stdout);
+    free(cgp);
+  }
 
   EndgameCtx *ctx = endgame_ctx_create();
   EndgameResults *results = endgame_results_create();
@@ -649,12 +657,20 @@ void test_peginf_benchmark_generate(void) {
          "peg), budget %.1fs/turn, %d threads\n",
          n, max_sim, max_peg, PEG_BENCH_TURN_BUDGET_S, g_bench_num_threads);
 
+  // Debug: skip playing positions before this index (generation is
+  // deterministic, so this jumps straight to a specific position to reproduce).
+  const int start = peg_bench_env_int("PEGBENCH_START", 0);
+
   PegBenchTally overall = {0};
   PegBenchTally sim = {0};
   PegBenchTally peg = {0};
   const double t_start = peg_bench_now_s();
   for (int i = 0; i < n; i++) {
     PegBenchPosition *p = &positions[i];
+    if (i < start) {
+      peg_bench_position_destroy(p);
+      continue;
+    }
     const bool sim_inf = p->prev_turn_bag >= PEG_BENCH_SIM_INFER_BAG;
     const PegBenchPrevCtx ctx = {
         .game_before_prev = p->game_before_prev,
@@ -695,6 +711,51 @@ void test_peginf_benchmark_generate(void) {
   free(positions);
   win_pct_destroy(win_pcts);
   move_list_destroy(move_list);
+  error_stack_destroy(error_stack);
+  config_destroy(config);
+}
+
+// Diagnostic: run the d25 endgame on a single CGP (env PEGBENCH_CGP) repeatedly
+// at a controllable thread count (PEGBENCH_THREADS) to isolate whether the
+// zobrist_add_move overflow is a parallel-endgame race (crashes only with >1
+// thread) or a deterministic position/depth bug (crashes single-threaded too).
+void test_peginf_endgame_repro(void) {
+  const char *cgp = getenv("PEGBENCH_CGP");
+  if (cgp == NULL) {
+    printf("  set PEGBENCH_CGP to a board+racks CGP\n");
+    return;
+  }
+  const int threads = peg_bench_env_int("PEGBENCH_THREADS", get_num_cores());
+  const int iters = peg_bench_env_int("PEGBENCH_ITERS", 30);
+  char cmd[256];
+  snprintf(cmd, sizeof(cmd),
+           "set -lex CSW24 -s1 equity -s2 equity -r1 all -r2 all -numplays 15 "
+           "-threads %d",
+           threads);
+  Config *config = config_create_or_die(cmd);
+  char cgp_cmd[512];
+  snprintf(cgp_cmd, sizeof(cgp_cmd), "cgp %s", cgp);
+  load_and_exec_config_or_die(config, cgp_cmd);
+  Game *game = config_get_game(config);
+  ThreadControl *thread_control = config_get_thread_control(config);
+  ErrorStack *error_stack = error_stack_create();
+  g_bench_num_threads = threads;
+
+  printf("  endgame repro: %d threads, %d iters, d%d\n", threads, iters,
+         PEG_BENCH_ENDGAME_PLIES);
+  for (int i = 0; i < iters; i++) {
+    Game *g = game_duplicate(game);
+    Move mv;
+    const bool played = peg_bench_play_endgame(
+        g, thread_control, PEG_BENCH_TURN_BUDGET_S, &mv, error_stack);
+    printf("    iter %2d: played=%d err=%d\n", i, played,
+           !error_stack_is_empty(error_stack));
+    fflush(stdout);
+    error_stack_reset(error_stack);
+    game_destroy(g);
+  }
+  printf("  DONE (no crash over %d iters)\n", iters);
+
   error_stack_destroy(error_stack);
   config_destroy(config);
 }

--- a/test/peginf_benchmark.c
+++ b/test/peginf_benchmark.c
@@ -21,6 +21,7 @@
 #include "../src/def/peg_defs.h"
 #include "../src/def/thread_control_defs.h"
 #include "../src/ent/bag.h"
+#include "../src/ent/alias_method.h"
 #include "../src/ent/endgame_results.h"
 #include "../src/ent/equity.h"
 #include "../src/ent/game.h"
@@ -82,6 +83,10 @@ static int g_bench_num_threads = 1;
 // (PEGBENCH_BUDGET / PEGBENCH_SAMPLES) so a larger-budget run needs no rebuild.
 static double g_bench_budget_s = PEG_BENCH_TURN_BUDGET_S;
 static int g_bench_samples = PEG_BENCH_INFERENCE_SAMPLES;
+// "Psychic" mode (PEGBENCH_PSYCHIC): arm B weights peg_solve by the opponent's
+// TRUE leave instead of running inference -- the ceiling of leave inference and
+// a check that leave results are applied correctly.
+static bool g_bench_psychic = false;
 
 // Read a positive integer environment override, or fall back to def.
 static int peg_bench_env_int(const char *name, int def) {
@@ -332,6 +337,39 @@ static void peg_bench_play_turn(Game *game, MoveList *move_list,
   *elapsed_out = peg_bench_now_s() - t0;
 }
 
+// "Psychic" prior: pin the opponent-leave distribution to the opponent's ACTUAL
+// kept tiles (leave = their pre-move rack minus the tiles they played) as a
+// point mass. Feeding this true leave through peg_solve's normal weighting path
+// -- which still samples the opponent's redraw from the unseen -- measures the
+// ceiling of leave inference and validates that leave results are applied
+// correctly (the same code path real inference uses, minus the estimation
+// error). Returns a fresh InferenceResults the caller must destroy, or NULL.
+static InferenceResults *peg_bench_psychic_prior(const Game *game_before_prev,
+                                                 const Move *prev_move,
+                                                 int prev_player) {
+  const int ld_size = ld_get_size(game_get_ld(game_before_prev));
+  const Rack *before =
+      player_get_rack(game_get_player(game_before_prev, prev_player));
+  Rack played;
+  peg_bench_extract_played_tiles(prev_move, ld_size, &played);
+  Rack leave;
+  rack_set_dist_size_and_reset(&leave, ld_size);
+  for (int ml = 0; ml < ld_size; ml++) {
+    const int keep =
+        (int)rack_get_letter(before, ml) - (int)rack_get_letter(&played, ml);
+    for (int k = 0; k < keep; k++) {
+      rack_add_letter(&leave, (MachineLetter)ml);
+    }
+  }
+  AliasMethod *alias = alias_method_create();
+  alias_method_add_rack(alias, &leave, 1);
+  if (!alias_method_generate_tables(alias)) {
+    alias_method_destroy(alias);
+    return NULL;
+  }
+  return inference_results_create(alias); // takes ownership of alias
+}
+
 // ── Playout ──────────────────────────────────────────────────────────────────
 
 // The opponent's previous-move context that lets inference fire on the very
@@ -377,6 +415,7 @@ static int peg_bench_play_out(Game *game, MoveList *move_list,
     Game *snapshot = game_duplicate(game);
 
     const InferenceResults *prior = NULL;
+    InferenceResults *psychic_res = NULL; // per-turn; destroyed after the turn
     double infer_elapsed = 0.0;
     const bool prev_inferable =
         have_prev && (move_get_type(&prev_move) == GAME_EVENT_TILE_PLACEMENT_MOVE ||
@@ -384,11 +423,18 @@ static int peg_bench_play_out(Game *game, MoveList *move_list,
     if (use_inference && on_turn == inferring_player && prev_inferable &&
         turn_bag >= PEG_MIN_BAG && turn_bag <= PEG_MAX_BAG) {
       const double t0 = peg_bench_now_s();
-      const double infer_budget = g_bench_budget_s * PEG_BENCH_INFER_BUDGET_FRAC;
-      if (peg_bench_run_inference(game_before_prev, &prev_move, prev_player,
-                                  prev_turn_bag, win_pcts, thread_control,
-                                  inf_results, infer_budget, error_stack)) {
-        prior = inf_results;
+      if (g_bench_psychic) {
+        psychic_res =
+            peg_bench_psychic_prior(game_before_prev, &prev_move, prev_player);
+        prior = psychic_res;
+      } else {
+        const double infer_budget =
+            g_bench_budget_s * PEG_BENCH_INFER_BUDGET_FRAC;
+        if (peg_bench_run_inference(game_before_prev, &prev_move, prev_player,
+                                    prev_turn_bag, win_pcts, thread_control,
+                                    inf_results, infer_budget, error_stack)) {
+          prior = inf_results;
+        }
       }
       infer_elapsed = peg_bench_now_s() - t0;
     }
@@ -412,8 +458,11 @@ static int peg_bench_play_out(Game *game, MoveList *move_list,
       printf(
           "    turn %2d  p%d  bag=%d  infer=%.2fs solve=%.2fs total=%.2fs%s%s\n",
           turn, on_turn, turn_bag, infer_elapsed, solve_elapsed, turn_total,
-          prior != NULL ? "  [inf]" : "",
+          prior != NULL ? (g_bench_psychic ? "  [psy]" : "  [inf]") : "",
           turn_total > g_bench_budget_s * 1.5 ? "  *** OVER" : "");
+    }
+    if (psychic_res != NULL) {
+      inference_results_destroy(psychic_res);
     }
 
     game_copy(game_before_prev, snapshot);
@@ -543,6 +592,7 @@ void test_peginf_benchmark(void) {
       peg_bench_env_double("PEGBENCH_BUDGET", PEG_BENCH_TURN_BUDGET_S);
   g_bench_samples =
       peg_bench_env_int("PEGBENCH_SAMPLES", PEG_BENCH_INFERENCE_SAMPLES);
+  g_bench_psychic = peg_bench_env_int("PEGBENCH_PSYCHIC", 0) != 0;
 
   printf("  PEG A/B benchmark (4-in-bag CSW24, budget %.1fs/turn, %d threads):\n",
          g_bench_budget_s, g_bench_num_threads);
@@ -663,6 +713,7 @@ void test_peginf_benchmark_generate(void) {
       peg_bench_env_double("PEGBENCH_BUDGET", PEG_BENCH_TURN_BUDGET_S);
   g_bench_samples =
       peg_bench_env_int("PEGBENCH_SAMPLES", PEG_BENCH_INFERENCE_SAMPLES);
+  g_bench_psychic = peg_bench_env_int("PEGBENCH_PSYCHIC", 0) != 0;
 
   // Quotas, seed, and game cap are env-overridable (PEGBENCH_SIM / _PEG / _SEED
   // / _GAMECAP) so a large run needs no rebuild.
@@ -678,8 +729,9 @@ void test_peginf_benchmark_generate(void) {
   const int n = peg_bench_generate(game, move_list, positions, max_sim, max_peg,
                                    base_seed, game_cap);
   printf("  PEG A/B aggregation: generated %d positions (target %d sim + %d "
-         "peg), budget %.1fs/turn, %d threads\n",
-         n, max_sim, max_peg, g_bench_budget_s, g_bench_num_threads);
+         "peg), budget %.1fs/turn, %d threads, arm B = %s\n",
+         n, max_sim, max_peg, g_bench_budget_s, g_bench_num_threads,
+         g_bench_psychic ? "PSYCHIC (true opponent leave)" : "inference");
 
   // Debug: skip playing positions before this index (generation is
   // deterministic, so this jumps straight to a specific position to reproduce).

--- a/test/peginf_benchmark.c
+++ b/test/peginf_benchmark.c
@@ -40,9 +40,11 @@
 #include "../src/impl/peg_inference.h"
 #include "../src/impl/simmed_inference.h"
 #include "../src/util/io_util.h"
+#include "test_constants.h"
 #include "test_util.h"
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <time.h>
 
@@ -62,6 +64,11 @@
 // Opponent's-turn bag >= this uses simmed inference; below uses peg inference.
 #define PEG_BENCH_SIM_INFER_BAG 5
 #define PEG_BENCH_INFER_CANDIDATES 7
+// Per-class quotas of generated PEG positions the aggregation benchmark plays
+// out A/B, and the cap on games scanned to fill them (peg-inf is rare).
+#define PEG_BENCH_MAX_SIM 6
+#define PEG_BENCH_MAX_PEG 4
+#define PEG_BENCH_GAME_CAP 300
 
 static double peg_bench_now_s(void) {
   struct timespec t;
@@ -286,12 +293,25 @@ static void peg_bench_play_turn(Game *game, MoveList *move_list,
 
 // ── Playout ──────────────────────────────────────────────────────────────────
 
+// The opponent's previous-move context that lets inference fire on the very
+// first turn of a replayed position (a generated PEG position starts with the
+// inferring player already on turn, right after the opponent's move).
+typedef struct {
+  const Game *game_before_prev; // state before the opponent's prev move
+  const Move *prev_move;        // opponent's prev move
+  int prev_player;              // opponent index
+  int prev_turn_bag;            // bag when the opponent moved (sim vs peg inf)
+} PegBenchPrevCtx;
+
 // Play the game to the end. The inferring player weights its PEG scenarios by
 // an inference of the opponent's previous move when use_inference is set; the
-// opponent always plays uniform PEG. Returns player 0's final spread.
+// opponent always plays uniform PEG. When init is non-NULL the playout starts
+// with that opponent-move context so inference can fire immediately. Returns the
+// inferring player's final spread.
 static int peg_bench_play_out(Game *game, MoveList *move_list,
                               ThreadControl *thread_control, WinPct *win_pcts,
                               int inferring_player, bool use_inference,
+                              const PegBenchPrevCtx *init, bool verbose,
                               ErrorStack *error_stack) {
   Game *game_before_prev = game_duplicate(game);
   InferenceResults *inf_results = inference_results_create(NULL);
@@ -300,6 +320,13 @@ static int peg_bench_play_out(Game *game, MoveList *move_list,
   bool have_prev = false;
   int prev_player = -1;
   int prev_turn_bag = 0;
+  if (init != NULL) {
+    game_copy(game_before_prev, init->game_before_prev);
+    move_copy(&prev_move, init->prev_move);
+    have_prev = true;
+    prev_player = init->prev_player;
+    prev_turn_bag = init->prev_turn_bag;
+  }
 
   int turn = 0;
   double worst = 0.0;
@@ -340,10 +367,14 @@ static int peg_bench_play_out(Game *game, MoveList *move_list,
     if (turn_total > worst) {
       worst = turn_total;
     }
-    printf("    turn %2d  p%d  bag=%d  infer=%.2fs solve=%.2fs total=%.2fs%s%s\n",
-           ++turn, on_turn, turn_bag, infer_elapsed, solve_elapsed, turn_total,
-           prior != NULL ? "  [inf]" : "",
-           turn_total > PEG_BENCH_TURN_BUDGET_S * 1.5 ? "  *** OVER" : "");
+    ++turn;
+    if (verbose) {
+      printf(
+          "    turn %2d  p%d  bag=%d  infer=%.2fs solve=%.2fs total=%.2fs%s%s\n",
+          turn, on_turn, turn_bag, infer_elapsed, solve_elapsed, turn_total,
+          prior != NULL ? "  [inf]" : "",
+          turn_total > PEG_BENCH_TURN_BUDGET_S * 1.5 ? "  *** OVER" : "");
+    }
 
     game_copy(game_before_prev, snapshot);
     game_destroy(snapshot);
@@ -357,8 +388,10 @@ static int peg_bench_play_out(Game *game, MoveList *move_list,
       break;
     }
   }
-  printf("    (%d turns, worst turn %.2fs vs %.2fs budget)\n", turn, worst,
-         PEG_BENCH_TURN_BUDGET_S);
+  if (verbose) {
+    printf("    (%d turns, worst turn %.2fs vs %.2fs budget)\n", turn, worst,
+           PEG_BENCH_TURN_BUDGET_S);
+  }
 
   inference_results_destroy(inf_results);
   game_destroy(game_before_prev);
@@ -366,6 +399,87 @@ static int peg_bench_play_out(Game *game, MoveList *move_list,
       equity_to_int(player_get_score(game_get_player(game, 0))) -
       equity_to_int(player_get_score(game_get_player(game, 1)));
   return inferring_player == 0 ? p0_spread : -p0_spread;
+}
+
+// ── Position generation ──────────────────────────────────────────────────────
+
+// A generated PEG benchmark position: the inferring player is on turn in the
+// PEG bag range, right after an inferable opponent move.
+typedef struct {
+  Game *game;             // inferring player on turn, bag in PEG range
+  Game *game_before_prev; // state before the opponent's prev move
+  Move prev_move;         // opponent's prev move
+  int prev_player;        // opponent index
+  int prev_turn_bag;      // bag when the opponent moved (sim vs peg inference)
+  int inferring_player;   // player on turn in `game`
+} PegBenchPosition;
+
+static void peg_bench_position_destroy(PegBenchPosition *p) {
+  game_destroy(p->game);
+  game_destroy(p->game_before_prev);
+}
+
+// Play static-eval games and capture states where the player on turn is in the
+// PEG bag range right after an inferable opponent move, filling a per-class
+// quota: sim-inf positions (opponent moved with a bag >= PEG_BENCH_SIM_INFER_BAG
+// -- the transition into the PEG zone) and peg-inf positions (PEG->PEG, opponent
+// moved with a bag <= 4 having played few tiles). Peg-inf positions are rare in
+// static play, so many games are scanned. Returns the number captured.
+static int peg_bench_generate(Game *proto, MoveList *move_list,
+                              PegBenchPosition *out, int max_sim, int max_peg,
+                              uint64_t base_seed, uint64_t game_cap) {
+  int n = 0;
+  int n_sim = 0;
+  int n_peg = 0;
+  for (uint64_t g = 0; (n_sim < max_sim || n_peg < max_peg) && g < game_cap;
+       g++) {
+    game_reset(proto);
+    game_seed(proto, base_seed + g);
+    draw_starting_racks(proto);
+    Game *before_prev = game_duplicate(proto);
+    Move prev_move;
+    memset(&prev_move, 0, sizeof(prev_move));
+    bool have_prev = false;
+    int prev_player = -1;
+    int prev_turn_bag = 0;
+    while (!game_over(proto) && (n_sim < max_sim || n_peg < max_peg)) {
+      const int on_turn = game_get_player_on_turn_index(proto);
+      const int bag = bag_get_letters(game_get_bag(proto));
+      const bool inferable =
+          have_prev &&
+          (move_get_type(&prev_move) == GAME_EVENT_TILE_PLACEMENT_MOVE ||
+           move_get_type(&prev_move) == GAME_EVENT_EXCHANGE);
+      if (inferable && bag >= PEG_MIN_BAG && bag <= PEG_MAX_BAG) {
+        const bool sim_inf = prev_turn_bag >= PEG_BENCH_SIM_INFER_BAG;
+        if ((sim_inf && n_sim < max_sim) || (!sim_inf && n_peg < max_peg)) {
+          PegBenchPosition *p = &out[n++];
+          p->game = game_duplicate(proto);
+          p->game_before_prev = game_duplicate(before_prev);
+          move_copy(&p->prev_move, &prev_move);
+          p->prev_player = prev_player;
+          p->prev_turn_bag = prev_turn_bag;
+          p->inferring_player = on_turn;
+          if (sim_inf) {
+            n_sim++;
+          } else {
+            n_peg++;
+          }
+        }
+      }
+      Game *snap = game_duplicate(proto);
+      Move played;
+      move_copy(&played, get_top_equity_move(proto, move_list));
+      play_move(&played, proto, NULL);
+      game_copy(before_prev, snap);
+      game_destroy(snap);
+      prev_move = played;
+      have_prev = true;
+      prev_player = on_turn;
+      prev_turn_bag = bag;
+    }
+    game_destroy(before_prev);
+  }
+  return n;
 }
 
 void test_peginf_benchmark(void) {
@@ -398,14 +512,14 @@ void test_peginf_benchmark(void) {
     const int spread_a =
         peg_bench_play_out(game_a, move_list, thread_control, win_pcts,
                            inferring_player, /*use_inference=*/false,
-                           error_stack);
+                           /*init=*/NULL, /*verbose=*/true, error_stack);
 
     printf("  Arm B (inference-weighted PEG):\n");
     Game *game_b = game_duplicate(game);
     const int spread_b =
         peg_bench_play_out(game_b, move_list, thread_control, win_pcts,
                            inferring_player, /*use_inference=*/true,
-                           error_stack);
+                           /*init=*/NULL, /*verbose=*/true, error_stack);
 
     printf("  RESULT p%d spread: A (uniform) %+d  vs  B (inference) %+d  "
            "(delta %+d)\n",
@@ -418,6 +532,97 @@ void test_peginf_benchmark(void) {
     game_destroy(game_b);
   }
 
+  win_pct_destroy(win_pcts);
+  move_list_destroy(move_list);
+  error_stack_destroy(error_stack);
+  config_destroy(config);
+}
+
+// Generate PEG positions and aggregate the A/B (uniform vs inference) playout
+// over them: for each position, play both arms to the end from the identical
+// captured state (same bag order) and tally the inferring player's spread delta,
+// split by inference type. The A/B signal -- whether inference improves play --
+// emerges from this aggregate, not from any single position.
+void test_peginf_benchmark_generate(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW24 -s1 equity -s2 equity -r1 all -r2 all -numplays 15 "
+      "-threads 1");
+  load_and_exec_config_or_die(config, "cgp " EMPTY_CGP);
+  Game *game = config_get_game(config);
+  ThreadControl *thread_control = config_get_thread_control(config);
+  MoveList *move_list = move_list_create(64);
+  ErrorStack *error_stack = error_stack_create();
+  WinPct *win_pcts = win_pct_create(config_get_data_paths(config),
+                                    DEFAULT_WIN_PCT, error_stack);
+  assert(error_stack_is_empty(error_stack));
+
+  PegBenchPosition *positions = malloc_or_die(
+      sizeof(PegBenchPosition) * (PEG_BENCH_MAX_SIM + PEG_BENCH_MAX_PEG));
+  const int n = peg_bench_generate(game, move_list, positions, PEG_BENCH_MAX_SIM,
+                                   PEG_BENCH_MAX_PEG, /*base_seed=*/1,
+                                   PEG_BENCH_GAME_CAP);
+  printf("  PEG A/B aggregation: generated %d positions, budget %.1fs/turn\n", n,
+         PEG_BENCH_TURN_BUDGET_S);
+
+  int b_better = 0;
+  int a_better = 0;
+  int ties = 0;
+  long sum_delta = 0;
+  int sim_n = 0;
+  int peg_n = 0;
+  for (int i = 0; i < n; i++) {
+    PegBenchPosition *p = &positions[i];
+    const bool sim_inf = p->prev_turn_bag >= PEG_BENCH_SIM_INFER_BAG;
+    const PegBenchPrevCtx ctx = {
+        .game_before_prev = p->game_before_prev,
+        .prev_move = &p->prev_move,
+        .prev_player = p->prev_player,
+        .prev_turn_bag = p->prev_turn_bag,
+    };
+
+    Game *game_a = game_duplicate(p->game);
+    const int spread_a = peg_bench_play_out(
+        game_a, move_list, thread_control, win_pcts, p->inferring_player,
+        /*use_inference=*/false, &ctx, /*verbose=*/false, error_stack);
+    Game *game_b = game_duplicate(p->game);
+    const int spread_b = peg_bench_play_out(
+        game_b, move_list, thread_control, win_pcts, p->inferring_player,
+        /*use_inference=*/true, &ctx, /*verbose=*/false, error_stack);
+
+    const int delta = spread_b - spread_a;
+    sum_delta += delta;
+    if (delta > 0) {
+      b_better++;
+    } else if (delta < 0) {
+      a_better++;
+    } else {
+      ties++;
+    }
+    if (sim_inf) {
+      sim_n++;
+    } else {
+      peg_n++;
+    }
+    printf("    pos %2d  infer p%d  opp-bag=%d  %s-inf  A %+d  B %+d  "
+           "delta %+d\n",
+           i, p->inferring_player, p->prev_turn_bag, sim_inf ? "sim" : "peg",
+           spread_a, spread_b, delta);
+
+    assert(game_over(game_a));
+    assert(game_over(game_b));
+    game_destroy(game_a);
+    game_destroy(game_b);
+    peg_bench_position_destroy(p);
+  }
+
+  if (n > 0) {
+    printf("  AGGREGATE over %d positions (%d sim-inf, %d peg-inf): "
+           "B better %d, A better %d, tie %d; mean spread delta %+.1f\n",
+           n, sim_n, peg_n, b_better, a_better, ties, (double)sum_delta / n);
+  }
+  assert(error_stack_is_empty(error_stack));
+
+  free(positions);
   win_pct_destroy(win_pcts);
   move_list_destroy(move_list);
   error_stack_destroy(error_stack);

--- a/test/peginf_benchmark.c
+++ b/test/peginf_benchmark.c
@@ -14,13 +14,16 @@
 #include "../src/def/move_defs.h"
 #include "../src/def/peg_defs.h"
 #include "../src/def/thread_control_defs.h"
+#include "../src/compat/ctime.h"
 #include "../src/ent/bag.h"
+#include "../src/ent/endgame_results.h"
 #include "../src/ent/equity.h"
 #include "../src/ent/game.h"
 #include "../src/ent/move.h"
 #include "../src/ent/player.h"
 #include "../src/ent/thread_control.h"
 #include "../src/impl/config.h"
+#include "../src/impl/endgame.h"
 #include "../src/impl/gameplay.h"
 #include "../src/impl/move_gen.h"
 #include "../src/impl/peg.h"
@@ -38,6 +41,7 @@
 
 #define PEG_BENCH_TURN_BUDGET_S 3.0
 #define PEG_BENCH_MAX_CANDIDATES 20
+#define PEG_BENCH_ENDGAME_PLIES 25
 
 static double peg_bench_now_s(void) {
   struct timespec t;
@@ -45,17 +49,64 @@ static double peg_bench_now_s(void) {
   return (double)t.tv_sec + (double)t.tv_nsec * 1e-9;
 }
 
+// Solve and play the endgame (bag empty), capped to the same per-turn budget as
+// the pre-endgame turns: a depth-25 solve with soft/hard IDS limits and a hard
+// wall-clock deadline all set to budget_s. Returns true if a move was played.
+static bool peg_bench_play_endgame(Game *game, ThreadControl *thread_control,
+                                   double budget_s, ErrorStack *error_stack) {
+  EndgameArgs endgame_args = {0};
+  endgame_args.thread_control = thread_control;
+  endgame_args.game = game;
+  endgame_args.plies = PEG_BENCH_ENDGAME_PLIES;
+  endgame_args.tt_fraction_of_mem = 0.05;
+  endgame_args.initial_small_move_arena_size =
+      DEFAULT_INITIAL_SMALL_MOVE_ARENA_SIZE;
+  endgame_args.num_threads = 1;
+  endgame_args.use_heuristics = true;
+  endgame_args.forced_pass_bypass = true;
+  endgame_args.enable_pv_display = true;
+  endgame_args.num_top_moves = 1;
+  endgame_args.seed = 0;
+  // Same time budget as a pre-endgame turn: stop IDS at the soft limit, don't
+  // start a depth that would blow the hard limit, and bail mid-search at the
+  // wall-clock deadline.
+  endgame_args.soft_time_limit = budget_s;
+  endgame_args.hard_time_limit = budget_s;
+  endgame_args.external_deadline_ns =
+      ctimer_monotonic_ns() + (int64_t)(budget_s * 1.0e9);
+
+  EndgameCtx *ctx = endgame_ctx_create();
+  EndgameResults *results = endgame_results_create();
+  thread_control_set_status(thread_control, THREAD_CONTROL_STATUS_STARTED);
+  endgame_solve(&ctx, &endgame_args, results, error_stack);
+
+  bool played = false;
+  if (error_stack_is_empty(error_stack)) {
+    const PVLine *pv = endgame_results_get_pvline(results, ENDGAME_RESULT_BEST);
+    if (pv != NULL && pv->num_moves > 0) {
+      Move move;
+      small_move_to_move(&move, &pv->moves[0], game_get_board(game));
+      play_move(&move, game, NULL);
+      played = true;
+    }
+  }
+  endgame_results_destroy(results);
+  endgame_ctx_destroy(ctx);
+  return played;
+}
+
 // Choose and play one move for the player on turn. While the bag is in the PEG
-// range, solve it with the greedy pre-endgame seed within budget_s; otherwise
-// play the static best (placeholder for the d25 endgame at bag 0). *elapsed_out
-// is the wall time spent.
+// range, solve it with the greedy pre-endgame seed within budget_s; at bag 0
+// solve the endgame under the same budget. *elapsed_out is the wall time spent.
 static void peg_bench_play_turn(Game *game, MoveList *move_list,
                                 ThreadControl *thread_control, double budget_s,
                                 double *elapsed_out, ErrorStack *error_stack) {
   const double t0 = peg_bench_now_s();
   const int bag = bag_get_letters(game_get_bag(game));
   bool played = false;
-  if (bag >= PEG_MIN_BAG && bag <= PEG_MAX_BAG) {
+  if (bag == 0) {
+    played = peg_bench_play_endgame(game, thread_control, budget_s, error_stack);
+  } else if (bag >= PEG_MIN_BAG && bag <= PEG_MAX_BAG) {
     // Supply the candidate field explicitly: peg_solve's own root move
     // generation is unused by every caller (all pass only_moves) and currently
     // returns just a pass here. Top-N by static equity is a sound field, and
@@ -102,7 +153,8 @@ static void peg_bench_play_turn(Game *game, MoveList *move_list,
     }
   }
   if (!played) {
-    // Endgame (bag 0) or a solve that produced nothing: static best for now.
+    // A solve produced nothing (e.g. a severe budget, or a bag outside the PEG
+    // range that should not occur mid-playout): fall back to the static best.
     const Move *move = get_top_equity_move(game, move_list);
     play_move(move, game, NULL);
   }

--- a/test/peginf_benchmark.c
+++ b/test/peginf_benchmark.c
@@ -60,6 +60,9 @@
 #define PEG_BENCH_MAX_CANDIDATES 20
 #define PEG_BENCH_ENDGAME_PLIES 25
 #define PEG_BENCH_INFERENCE_SAMPLES 200
+// Larger sample counts cut the MC noise in arm B's per-candidate win% estimate
+// (SE ~ sqrt(0.25/N)), so its move choice is driven by the inferred weighting
+// rather than sampling noise.
 // Fraction of the per-turn budget the inference step may use; the rest goes to
 // the PEG solve so the whole turn stays within budget.
 #define PEG_BENCH_INFER_BUDGET_FRAC 0.4
@@ -75,6 +78,10 @@
 // Hardware threads each PEG solve / endgame / inference runs on (all cores, like
 // a real peg run); set once per test from config_get_num_threads.
 static int g_bench_num_threads = 1;
+// Per-turn time budget (s) and arm-B MC sample count; env-overridable per test
+// (PEGBENCH_BUDGET / PEGBENCH_SAMPLES) so a larger-budget run needs no rebuild.
+static double g_bench_budget_s = PEG_BENCH_TURN_BUDGET_S;
+static int g_bench_samples = PEG_BENCH_INFERENCE_SAMPLES;
 
 // Read a positive integer environment override, or fall back to def.
 static int peg_bench_env_int(const char *name, int def) {
@@ -84,6 +91,16 @@ static int peg_bench_env_int(const char *name, int def) {
   }
   const int parsed = atoi(v);
   return parsed > 0 ? parsed : def;
+}
+
+// Read a positive double environment override, or fall back to def.
+static double peg_bench_env_double(const char *name, double def) {
+  const char *v = getenv(name);
+  if (v == NULL) {
+    return def;
+  }
+  const double parsed = atof(v);
+  return parsed > 0.0 ? parsed : def;
 }
 
 static double peg_bench_now_s(void) {
@@ -293,7 +310,7 @@ static void peg_bench_play_turn(Game *game, MoveList *move_list,
       peg_args.only_moves = cands;
       peg_args.n_only_moves = n_cand;
       peg_args.opp_leave_prior = prior;
-      peg_args.inference_samples = prior ? PEG_BENCH_INFERENCE_SAMPLES : 0;
+      peg_args.inference_samples = prior ? g_bench_samples : 0;
       peg_args.inference_seed = seed;
       thread_control_set_status(thread_control, THREAD_CONTROL_STATUS_STARTED);
       PegResult peg_result = {0};
@@ -367,8 +384,7 @@ static int peg_bench_play_out(Game *game, MoveList *move_list,
     if (use_inference && on_turn == inferring_player && prev_inferable &&
         turn_bag >= PEG_MIN_BAG && turn_bag <= PEG_MAX_BAG) {
       const double t0 = peg_bench_now_s();
-      const double infer_budget =
-          PEG_BENCH_TURN_BUDGET_S * PEG_BENCH_INFER_BUDGET_FRAC;
+      const double infer_budget = g_bench_budget_s * PEG_BENCH_INFER_BUDGET_FRAC;
       if (peg_bench_run_inference(game_before_prev, &prev_move, prev_player,
                                   prev_turn_bag, win_pcts, thread_control,
                                   inf_results, infer_budget, error_stack)) {
@@ -377,7 +393,7 @@ static int peg_bench_play_out(Game *game, MoveList *move_list,
       infer_elapsed = peg_bench_now_s() - t0;
     }
 
-    double solve_budget = PEG_BENCH_TURN_BUDGET_S - infer_elapsed;
+    double solve_budget = g_bench_budget_s - infer_elapsed;
     if (solve_budget < 0.5) {
       solve_budget = 0.5;
     }
@@ -397,7 +413,7 @@ static int peg_bench_play_out(Game *game, MoveList *move_list,
           "    turn %2d  p%d  bag=%d  infer=%.2fs solve=%.2fs total=%.2fs%s%s\n",
           turn, on_turn, turn_bag, infer_elapsed, solve_elapsed, turn_total,
           prior != NULL ? "  [inf]" : "",
-          turn_total > PEG_BENCH_TURN_BUDGET_S * 1.5 ? "  *** OVER" : "");
+          turn_total > g_bench_budget_s * 1.5 ? "  *** OVER" : "");
     }
 
     game_copy(game_before_prev, snapshot);
@@ -414,7 +430,7 @@ static int peg_bench_play_out(Game *game, MoveList *move_list,
   }
   if (verbose) {
     printf("    (%d turns, worst turn %.2fs vs %.2fs budget)\n", turn, worst,
-           PEG_BENCH_TURN_BUDGET_S);
+           g_bench_budget_s);
   }
 
   inference_results_destroy(inf_results);
@@ -523,9 +539,13 @@ void test_peginf_benchmark(void) {
                      error_stack);
   assert(error_stack_is_empty(error_stack));
   g_bench_num_threads = config_get_num_threads(config);
+  g_bench_budget_s =
+      peg_bench_env_double("PEGBENCH_BUDGET", PEG_BENCH_TURN_BUDGET_S);
+  g_bench_samples =
+      peg_bench_env_int("PEGBENCH_SAMPLES", PEG_BENCH_INFERENCE_SAMPLES);
 
   printf("  PEG A/B benchmark (4-in-bag CSW24, budget %.1fs/turn, %d threads):\n",
-         PEG_BENCH_TURN_BUDGET_S, g_bench_num_threads);
+         g_bench_budget_s, g_bench_num_threads);
 
   // Run the A/B for each player as the inferring player. In this position p0
   // moves first (no opponent prior move -> inference is a no-op on its only PEG
@@ -639,6 +659,10 @@ void test_peginf_benchmark_generate(void) {
                                     DEFAULT_WIN_PCT, error_stack);
   assert(error_stack_is_empty(error_stack));
   g_bench_num_threads = config_get_num_threads(config);
+  g_bench_budget_s =
+      peg_bench_env_double("PEGBENCH_BUDGET", PEG_BENCH_TURN_BUDGET_S);
+  g_bench_samples =
+      peg_bench_env_int("PEGBENCH_SAMPLES", PEG_BENCH_INFERENCE_SAMPLES);
 
   // Quotas, seed, and game cap are env-overridable (PEGBENCH_SIM / _PEG / _SEED
   // / _GAMECAP) so a large run needs no rebuild.
@@ -655,7 +679,7 @@ void test_peginf_benchmark_generate(void) {
                                    base_seed, game_cap);
   printf("  PEG A/B aggregation: generated %d positions (target %d sim + %d "
          "peg), budget %.1fs/turn, %d threads\n",
-         n, max_sim, max_peg, PEG_BENCH_TURN_BUDGET_S, g_bench_num_threads);
+         n, max_sim, max_peg, g_bench_budget_s, g_bench_num_threads);
 
   // Debug: skip playing positions before this index (generation is
   // deterministic, so this jumps straight to a specific position to reproduce).
@@ -740,6 +764,8 @@ void test_peginf_endgame_repro(void) {
   ThreadControl *thread_control = config_get_thread_control(config);
   ErrorStack *error_stack = error_stack_create();
   g_bench_num_threads = threads;
+  g_bench_budget_s =
+      peg_bench_env_double("PEGBENCH_BUDGET", PEG_BENCH_TURN_BUDGET_S);
 
   printf("  endgame repro: %d threads, %d iters, d%d\n", threads, iters,
          PEG_BENCH_ENDGAME_PLIES);
@@ -747,7 +773,7 @@ void test_peginf_endgame_repro(void) {
     Game *g = game_duplicate(game);
     Move mv;
     const bool played = peg_bench_play_endgame(
-        g, thread_control, PEG_BENCH_TURN_BUDGET_S, &mv, error_stack);
+        g, thread_control, g_bench_budget_s, &mv, error_stack);
     printf("    iter %2d: played=%d err=%d\n", i, played,
            !error_stack_is_empty(error_stack));
     fflush(stdout);

--- a/test/peginf_benchmark.h
+++ b/test/peginf_benchmark.h
@@ -2,5 +2,6 @@
 #define PEGINF_BENCHMARK_H
 
 void test_peginf_benchmark(void);
+void test_peginf_benchmark_generate(void);
 
 #endif

--- a/test/peginf_benchmark.h
+++ b/test/peginf_benchmark.h
@@ -3,5 +3,6 @@
 
 void test_peginf_benchmark(void);
 void test_peginf_benchmark_generate(void);
+void test_peginf_endgame_repro(void);
 
 #endif

--- a/test/peginf_benchmark.h
+++ b/test/peginf_benchmark.h
@@ -3,6 +3,7 @@
 
 void test_peginf_benchmark(void);
 void test_peginf_benchmark_generate(void);
+void test_peginf_benchmark_groundtruth(void);
 void test_peginf_endgame_repro(void);
 
 #endif

--- a/test/peginf_benchmark.h
+++ b/test/peginf_benchmark.h
@@ -1,0 +1,6 @@
+#ifndef PEGINF_BENCHMARK_H
+#define PEGINF_BENCHMARK_H
+
+void test_peginf_benchmark(void);
+
+#endif

--- a/test/peginf_test.c
+++ b/test/peginf_test.c
@@ -137,10 +137,14 @@ static void test_peg_inference_weighted_scenarios(void) {
 
   // Prior pinned to the opponent's (player 1) actual rack, DEIINOS -- a valid
   // subset of the mover's unseen, so every sampled opponent rack is DEIINOS.
+  // Added TWICE so num_items == 2: this exercises the SAMPLING path (a
+  // single-support prior is instead enumerated exactly, see
+  // test_peg_inference_narrows_schedule / peg_prior_point_mass).
   Rack opp_leave;
   rack_set_dist_size_and_reset(&opp_leave, ld_size);
   rack_copy(&opp_leave, player_get_rack(game_get_player(game, 1)));
   AliasMethod *alias = alias_method_create();
+  alias_method_add_rack(alias, &opp_leave, 1);
   alias_method_add_rack(alias, &opp_leave, 1);
   assert(alias_method_generate_tables(alias));
   InferenceResults *prior = inference_results_create(alias);
@@ -186,11 +190,13 @@ static void test_peg_inference_weighted_scenarios(void) {
   assert(uniform.n_top_cands > 0);
   assert(uniform.best_win >= 0.0 && uniform.best_win <= 1.0);
 
-  // Inference-weighted: opponent pinned to DEIINOS via the prior.
-  const int inference_samples = 64;
+  // Inference-weighted: a multi-support prior (DEIINOS added twice, num_items
+  // == 2) is evaluated by EXACTLY enumerating its support (peg_enumerate_support)
+  // -- not by sampling. Confirm the path runs and yields a valid, non-empty
+  // evaluation.
   PegArgs inf_args = base_args;
   inf_args.opp_leave_prior = prior;
-  inf_args.inference_samples = inference_samples;
+  inf_args.inference_samples = 64;
   inf_args.inference_seed = 42;
   thread_control_set_status(thread_control, THREAD_CONTROL_STATUS_STARTED);
   PegResult weighted = {0};
@@ -198,10 +204,34 @@ static void test_peg_inference_weighted_scenarios(void) {
   assert(error_stack_is_empty(error_stack));
   assert(weighted.n_top_cands > 0);
   assert(weighted.best_win >= 0.0 && weighted.best_win <= 1.0);
-  // The sampling path ran exactly inference_samples scenarios per candidate...
-  assert(weighted.top_cands[0].n_scenarios == inference_samples);
-  // ...a distinct path from the uniform enumeration (which sweeps far more).
-  assert(uniform.top_cands[0].n_scenarios != inference_samples);
+  // The support enumeration produced a real (non-empty) scenario set.
+  assert(weighted.top_cands[0].n_scenarios > 0);
+
+  // Normalization correctness: a prior of TWO IDENTICAL DEIINOS leaves must give
+  // the SAME win% as the single point-mass DEIINOS (which uses the pinned
+  // enumeration). This exercises the per-leaf w_i / total_i weighting in
+  // peg_enumerate_support -- the two leaves have equal total_i, so the combined
+  // win% must reduce exactly to the single-leaf conditional win%.
+  AliasMethod *pm_alias = alias_method_create();
+  alias_method_add_rack(pm_alias, &opp_leave, 1);
+  assert(alias_method_generate_tables(pm_alias));
+  InferenceResults *pm_prior = inference_results_create(pm_alias);
+  PegArgs pm_args = base_args;
+  pm_args.opp_leave_prior = pm_prior;
+  pm_args.inference_seed = 42;
+  thread_control_set_status(thread_control, THREAD_CONTROL_STATUS_STARTED);
+  PegResult pm = {0};
+  peg_solve(&pm_args, &pm, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(pm.n_top_cands > 0);
+  double win_gap = pm.best_win - weighted.best_win;
+  if (win_gap < 0.0) {
+    win_gap = -win_gap;
+  }
+  assert(win_gap < 1e-9);
+  peg_result_destroy(&pm);
+  inference_results_destroy(pm_prior);
+  alias_method_destroy(pm_alias);
 
   peg_result_destroy(&uniform);
   peg_result_destroy(&weighted);
@@ -212,7 +242,144 @@ static void test_peg_inference_weighted_scenarios(void) {
   config_destroy(config);
 }
 
+// The inference-mode schedule hook: when opp_leave_prior is set and the caller
+// supplies no stage_top_k, peg_solve auto-narrows the halving field (the sampled
+// deep stages are per-candidate expensive, so a full-width field would stall at
+// the greedy seed and evaluate the opponent info only shallowly). Verify the
+// resolved schedule length (planned_num_stages) for each mode. That count is set
+// at scheduling time, before the stage loop, so these assertions are independent
+// of the time budget -- a small budget keeps the test fast without affecting the
+// scheduled count.
+static void test_peg_inference_narrows_schedule(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW24 -s1 equity -s2 equity -r1 all -r2 all -numplays 15 "
+      "-threads 1");
+  load_and_exec_config_or_die(config, PEG_INFER_4BAG_CGP ";");
+  Game *game = config_get_game(config);
+  const LetterDistribution *ld = game_get_ld(game);
+  const int ld_size = ld_get_size(ld);
+  ErrorStack *error_stack = error_stack_create();
+
+  // Point-mass prior on the opponent's (player 1) actual rack.
+  Rack opp_leave;
+  rack_set_dist_size_and_reset(&opp_leave, ld_size);
+  rack_copy(&opp_leave, player_get_rack(game_get_player(game, 1)));
+  AliasMethod *alias = alias_method_create();
+  alias_method_add_rack(alias, &opp_leave, 1);
+  assert(alias_method_generate_tables(alias));
+  InferenceResults *prior = inference_results_create(alias);
+
+  ThreadControl *thread_control = thread_control_create();
+
+  // Restrict to a few candidates so each solve is cheap.
+  MoveList *move_list = move_list_create(64);
+  const MoveGenArgs gen_args = {
+      .game = game,
+      .move_list = move_list,
+      .move_record_type = MOVE_RECORD_ALL,
+      .move_sort_type = MOVE_SORT_EQUITY,
+      .override_kwg = NULL,
+      .eq_margin_movegen = 0,
+      .target_equity = EQUITY_MAX_VALUE,
+      .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+      .tiles_played_bv = NULL,
+  };
+  generate_moves(&gen_args);
+  move_list_sort_moves(move_list);
+  const int n_only =
+      move_list_get_count(move_list) < 5 ? move_list_get_count(move_list) : 5;
+  const Move *only_moves[5];
+  for (int i = 0; i < n_only; i++) {
+    only_moves[i] = move_list_get_move(move_list, i);
+  }
+
+  PegArgs base = {0};
+  base.game = game;
+  base.thread_control = thread_control;
+  base.num_threads = 1;
+  base.time_budget_seconds = 2.0;
+  base.only_moves = only_moves;
+  base.n_only_moves = n_only;
+
+  // 1. No prior -> the full-width default ramp {32,16,8,4,2} (5 stages).
+  thread_control_set_status(thread_control, THREAD_CONTROL_STATUS_STARTED);
+  PegResult no_prior = {0};
+  peg_solve(&base, &no_prior, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(no_prior.planned_num_stages == 5);
+
+  // 2. POINT-MASS prior, no explicit schedule -> the full default ramp. A point
+  //    mass is enumerated exactly (cheaper than the uniform full-field
+  //    enumeration), so it does not narrow -- it uses all 5 stages.
+  PegArgs inf = base;
+  inf.opp_leave_prior = prior;
+  inf.inference_samples = 16;
+  inf.inference_seed = 7;
+  thread_control_set_status(thread_control, THREAD_CONTROL_STATUS_STARTED);
+  PegResult pointmass = {0};
+  peg_solve(&inf, &pointmass, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(pointmass.planned_num_stages == 5);
+
+  // 2b. MULTI-SUPPORT prior -> the narrowed inference ramp {8,4,2}. A
+  //     multi-leave prior is sampled per candidate (costly), so narrow to reach
+  //     deep fidelity in budget. Adding the same valid leave twice makes
+  //     num_items == 2, so it is not a point mass.
+  AliasMethod *multi_alias = alias_method_create();
+  alias_method_add_rack(multi_alias, &opp_leave, 1);
+  alias_method_add_rack(multi_alias, &opp_leave, 1);
+  assert(alias_method_generate_tables(multi_alias));
+  InferenceResults *multi_prior = inference_results_create(multi_alias);
+  PegArgs inf_multi = base;
+  inf_multi.opp_leave_prior = multi_prior;
+  inf_multi.inference_samples = 16;
+  inf_multi.inference_seed = 7;
+  thread_control_set_status(thread_control, THREAD_CONTROL_STATUS_STARTED);
+  PegResult narrowed = {0};
+  peg_solve(&inf_multi, &narrowed, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(narrowed.planned_num_stages == 3);
+
+  // 3. Prior + explicit stage_top_k -> the caller's schedule wins over the
+  //    inference default.
+  const int caller_sched[] = {16, 8, 4, 2};
+  PegArgs inf_override = inf;
+  inf_override.stage_top_k = caller_sched;
+  inf_override.num_stages = 4;
+  thread_control_set_status(thread_control, THREAD_CONTROL_STATUS_STARTED);
+  PegResult override_res = {0};
+  peg_solve(&inf_override, &override_res, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(override_res.planned_num_stages == 4);
+
+  // 4. Prior + greedy_seed_only -> greedy wins (no halving stages at all).
+  PegArgs inf_greedy = inf;
+  inf_greedy.greedy_seed_only = true;
+  thread_control_set_status(thread_control, THREAD_CONTROL_STATUS_STARTED);
+  PegResult greedy_res = {0};
+  peg_solve(&inf_greedy, &greedy_res, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(greedy_res.planned_num_stages == 0);
+
+  peg_result_destroy(&no_prior);
+  peg_result_destroy(&pointmass);
+  peg_result_destroy(&narrowed);
+  peg_result_destroy(&override_res);
+  peg_result_destroy(&greedy_res);
+  move_list_destroy(move_list);
+  thread_control_destroy(thread_control);
+  inference_results_destroy(prior);
+  inference_results_destroy(multi_prior);
+  // inference_results_create does NOT take ownership of a caller-supplied alias
+  // (alias_method_created_internally stays false), so the caller frees it.
+  alias_method_destroy(alias);
+  alias_method_destroy(multi_alias);
+  error_stack_destroy(error_stack);
+  config_destroy(config);
+}
+
 void test_peginf(void) {
   assert_peginf_tile_placement_no_crash();
   test_peg_inference_weighted_scenarios();
+  test_peg_inference_narrows_schedule();
 }

--- a/test/peginf_test.c
+++ b/test/peginf_test.c
@@ -1,0 +1,119 @@
+// Unit tests for peg_inference.c (pre-endgame inference).
+
+#include "../src/def/letter_distribution_defs.h"
+#include "../src/def/thread_control_defs.h"
+#include "../src/ent/equity.h"
+#include "../src/ent/game.h"
+#include "../src/ent/inference_args.h"
+#include "../src/ent/inference_results.h"
+#include "../src/ent/leave_rack.h"
+#include "../src/ent/letter_distribution.h"
+#include "../src/ent/move.h"
+#include "../src/ent/player.h"
+#include "../src/ent/rack.h"
+#include "../src/ent/thread_control.h"
+#include "../src/impl/config.h"
+#include "../src/impl/gameplay.h"
+#include "../src/impl/peg_inference.h"
+#include "../src/util/io_util.h"
+#include "test_util.h"
+#include <assert.h>
+#include <stddef.h>
+#include <string.h>
+
+// A real 4-in-bag CSW24 pre-endgame: player 0 (ACEINOP) is on turn, bag = 4.
+#define PEG_INFER_4BAG_CGP                                                     \
+  "cgp 3V3W6L/1BEATY1U5GI/2XU3S4FEN/3TA2H4LOY/2GEN1DUCAT1AD1/2O1I1I2WRITE1/"   \
+  "2V1M1ZOAEA4/3JAGER2DRILL/2BOtONE5O1/1FERER7Q1/4S8U1/12NaM/12ATE/13ST/14H "  \
+  "ACEINOP/DEIINOS 361/397 0 -lex CSW24"
+
+static void fill_played_tiles(const Move *move, Rack *out, int ld_size) {
+  rack_set_dist_size_and_reset(out, ld_size);
+  const int n = move_get_tiles_length(move);
+  for (int i = 0; i < n; i++) {
+    MachineLetter tile = move_get_tile(move, i);
+    if (tile == PLAYED_THROUGH_MARKER) {
+      continue;
+    }
+    if (get_is_blanked(tile)) {
+      tile = BLANK_MACHINE_LETTER;
+    }
+    rack_add_letter(out, tile);
+  }
+}
+
+// peg_infer on a real tile-placement observed move must not crash and must
+// leave the error stack empty. The observed move is player 0's top static play
+// from the 4-in-bag position, so this drives move generation, leave
+// enumeration/sampling, and at least one inner PEG solve on a packed board.
+static void assert_peginf_tile_placement_no_crash(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW24 -s1 equity -s2 equity -r1 all -r2 all -numplays 15 "
+      "-threads 4");
+  load_and_exec_config_or_die(config, PEG_INFER_4BAG_CGP ";");
+
+  ErrorStack *error_stack = error_stack_create();
+  Game *game = config_get_game(config);
+  const LetterDistribution *ld = game_get_ld(game);
+  const int ld_size = ld_get_size(ld);
+
+  // Observed move = player 0's top static play; its played tiles are the
+  // target_played and the true leave is ACEINOP minus them.
+  MoveList *move_list = move_list_create(64);
+  const Move *top = get_top_equity_move(game, move_list);
+  assert(move_get_type(top) == GAME_EVENT_TILE_PLACEMENT_MOVE);
+  Move observed_move;
+  move_copy(&observed_move, top);
+
+  Rack target_played_tiles;
+  Rack target_known_rack;
+  Rack nontarget_known_rack;
+  fill_played_tiles(&observed_move, &target_played_tiles, ld_size);
+  rack_set_dist_size_and_reset(&target_known_rack, ld_size);
+  rack_set_dist_size_and_reset(&nontarget_known_rack, ld_size);
+  rack_copy(&nontarget_known_rack, player_get_rack(game_get_player(game, 1)));
+
+  InferenceArgs base_args;
+  infer_args_fill(&base_args, /*leave_list_capacity=*/5, int_to_equity(0), NULL,
+                  game, /*num_threads=*/4, /*parent_worker_thread_index=*/0,
+                  /*print_interval=*/0, config_get_thread_control(config),
+                  /*use_game_history=*/false,
+                  /*use_inference_cutoff_optimization=*/false,
+                  /*target_index=*/0, /*target_score=*/int_to_equity(0),
+                  /*target_num_exch=*/0, &target_played_tiles,
+                  &target_known_rack, &nontarget_known_rack);
+
+  InferenceResults *inference_results = inference_results_create(NULL);
+
+  const PegInferenceArgs peg_args = {
+      .base = &base_args,
+      .observed_move = &observed_move,
+      .num_candidate_plays = 5,
+      .utility_w_winpct = 1.0,
+      .utility_w_spread = 1.0,
+      .utility_spread_scale = 100.0,
+      .greedy_seed_only = true,
+      .exhaustive_max_leave = 2,
+      .time_budget_s = 4.0,
+      .peg_utility_margin = 0.3,
+  };
+
+  thread_control_set_status(config_get_thread_control(config),
+                            THREAD_CONTROL_STATUS_STARTED);
+  peg_infer(&peg_args, inference_results, error_stack);
+  assert(error_stack_is_empty(error_stack));
+
+  // The inference must record a non-empty distribution: the observed move is
+  // the target's own top play, so at least one consistent leave is weighted.
+  const LeaveRackList *lrl =
+      inference_results_get_leave_rack_list(inference_results);
+  assert(lrl != NULL);
+  assert(leave_rack_list_get_count(lrl) > 0);
+
+  move_list_destroy(move_list);
+  inference_results_destroy(inference_results);
+  error_stack_destroy(error_stack);
+  config_destroy(config);
+}
+
+void test_peginf(void) { assert_peginf_tile_placement_no_crash(); }

--- a/test/peginf_test.c
+++ b/test/peginf_test.c
@@ -85,17 +85,15 @@ static void assert_peginf_tile_placement_no_crash(void) {
 
   InferenceResults *inference_results = inference_results_create(NULL);
 
+  // Utility weights, margin, and greedy-seed depth are left at peg_infer's
+  // defaults (blended score+win utility, 0.3 margin, greedy for this 4-in-bag
+  // position), so this also covers the default configuration.
   const PegInferenceArgs peg_args = {
       .base = &base_args,
       .observed_move = &observed_move,
       .num_candidate_plays = 5,
-      .utility_w_winpct = 1.0,
-      .utility_w_spread = 1.0,
-      .utility_spread_scale = 100.0,
-      .greedy_seed_only = true,
       .exhaustive_max_leave = 2,
       .time_budget_s = 4.0,
-      .peg_utility_margin = 0.3,
   };
 
   thread_control_set_status(config_get_thread_control(config),

--- a/test/peginf_test.c
+++ b/test/peginf_test.c
@@ -1,19 +1,24 @@
 // Unit tests for peg_inference.c (pre-endgame inference).
 
+#include "../src/def/equity_defs.h"
 #include "../src/def/letter_distribution_defs.h"
+#include "../src/def/move_defs.h"
 #include "../src/def/thread_control_defs.h"
 #include "../src/ent/equity.h"
 #include "../src/ent/game.h"
 #include "../src/ent/inference_args.h"
+#include "../src/ent/alias_method.h"
 #include "../src/ent/inference_results.h"
 #include "../src/ent/leave_rack.h"
 #include "../src/ent/letter_distribution.h"
+#include "../src/impl/peg.h"
 #include "../src/ent/move.h"
 #include "../src/ent/player.h"
 #include "../src/ent/rack.h"
 #include "../src/ent/thread_control.h"
 #include "../src/impl/config.h"
 #include "../src/impl/gameplay.h"
+#include "../src/impl/move_gen.h"
 #include "../src/impl/peg_inference.h"
 #include "../src/util/io_util.h"
 #include "test_util.h"
@@ -114,4 +119,100 @@ static void assert_peginf_tile_placement_no_crash(void) {
   config_destroy(config);
 }
 
-void test_peginf(void) { assert_peginf_tile_placement_no_crash(); }
+// The PEG solver's inference-weighted scenario sampling: with an opponent-leave
+// prior, PEG must sample the opponent's complete rack from that prior instead
+// of enumerating the uniform unseen. Pin the prior to the opponent's actual
+// rack (a single leave of full size) and confirm (a) the sampling path runs
+// exactly inference_samples scenarios per candidate, and (b) it is a distinct
+// path from the uniform enumeration.
+static void test_peg_inference_weighted_scenarios(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW24 -s1 equity -s2 equity -r1 all -r2 all -numplays 15 "
+      "-threads 1");
+  load_and_exec_config_or_die(config, PEG_INFER_4BAG_CGP ";");
+  Game *game = config_get_game(config);
+  const LetterDistribution *ld = game_get_ld(game);
+  const int ld_size = ld_get_size(ld);
+  ErrorStack *error_stack = error_stack_create();
+
+  // Prior pinned to the opponent's (player 1) actual rack, DEIINOS -- a valid
+  // subset of the mover's unseen, so every sampled opponent rack is DEIINOS.
+  Rack opp_leave;
+  rack_set_dist_size_and_reset(&opp_leave, ld_size);
+  rack_copy(&opp_leave, player_get_rack(game_get_player(game, 1)));
+  AliasMethod *alias = alias_method_create();
+  alias_method_add_rack(alias, &opp_leave, 1);
+  assert(alias_method_generate_tables(alias));
+  InferenceResults *prior = inference_results_create(alias);
+
+  ThreadControl *thread_control = thread_control_create();
+
+  // Restrict both solves to the mover's top few plays so the test is fast; the
+  // hook under test is orthogonal to the candidate field.
+  MoveList *move_list = move_list_create(64);
+  const MoveGenArgs gen_args = {
+      .game = game,
+      .move_list = move_list,
+      .move_record_type = MOVE_RECORD_ALL,
+      .move_sort_type = MOVE_SORT_EQUITY,
+      .override_kwg = NULL,
+      .eq_margin_movegen = 0,
+      .target_equity = EQUITY_MAX_VALUE,
+      .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+      .tiles_played_bv = NULL,
+  };
+  generate_moves(&gen_args);
+  move_list_sort_moves(move_list);
+  const int n_only =
+      move_list_get_count(move_list) < 5 ? move_list_get_count(move_list) : 5;
+  const Move *only_moves[5];
+  for (int i = 0; i < n_only; i++) {
+    only_moves[i] = move_list_get_move(move_list, i);
+  }
+
+  // Baseline: uniform opponent (no prior).
+  PegArgs base_args = {0};
+  base_args.game = game;
+  base_args.thread_control = thread_control;
+  base_args.num_threads = 1;
+  base_args.greedy_seed_only = true;
+  base_args.time_budget_seconds = 30.0;
+  base_args.only_moves = only_moves;
+  base_args.n_only_moves = n_only;
+  thread_control_set_status(thread_control, THREAD_CONTROL_STATUS_STARTED);
+  PegResult uniform = {0};
+  peg_solve(&base_args, &uniform, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(uniform.n_top_cands > 0);
+  assert(uniform.best_win >= 0.0 && uniform.best_win <= 1.0);
+
+  // Inference-weighted: opponent pinned to DEIINOS via the prior.
+  const int inference_samples = 64;
+  PegArgs inf_args = base_args;
+  inf_args.opp_leave_prior = prior;
+  inf_args.inference_samples = inference_samples;
+  inf_args.inference_seed = 42;
+  thread_control_set_status(thread_control, THREAD_CONTROL_STATUS_STARTED);
+  PegResult weighted = {0};
+  peg_solve(&inf_args, &weighted, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(weighted.n_top_cands > 0);
+  assert(weighted.best_win >= 0.0 && weighted.best_win <= 1.0);
+  // The sampling path ran exactly inference_samples scenarios per candidate...
+  assert(weighted.top_cands[0].n_scenarios == inference_samples);
+  // ...a distinct path from the uniform enumeration (which sweeps far more).
+  assert(uniform.top_cands[0].n_scenarios != inference_samples);
+
+  peg_result_destroy(&uniform);
+  peg_result_destroy(&weighted);
+  move_list_destroy(move_list);
+  thread_control_destroy(thread_control);
+  inference_results_destroy(prior);
+  error_stack_destroy(error_stack);
+  config_destroy(config);
+}
+
+void test_peginf(void) {
+  assert_peginf_tile_placement_no_crash();
+  test_peg_inference_weighted_scenarios();
+}

--- a/test/peginf_test.h
+++ b/test/peginf_test.h
@@ -1,0 +1,6 @@
+#ifndef PEGINF_TEST_H
+#define PEGINF_TEST_H
+
+void test_peginf(void);
+
+#endif

--- a/test/simmedinf_benchmark.c
+++ b/test/simmedinf_benchmark.c
@@ -1,0 +1,604 @@
+// Simmed-inference benchmark: SIM vs SIMMEDINF game pairs.
+//
+// Usage: ./bin/magpie_test simmedinf
+//
+// Two player types compete in game pairs at the same total per-turn budget
+// (SIM_BUDGET_S) on NUM_THREADS threads:
+//   SIM        — 4-ply simulation, uniform rack sampling (no inference).
+//   SIMMEDINF  — 4-ply simulation + simmed inference.
+//                Before each sim turn, runs simmed_infer() on the opponent's
+//                previous move to build a weighted leave distribution.
+//                The outer sim then uses this precomputed distribution instead
+//                of re-running static inference.
+//
+// Time budget per turn (approximate):
+//   SIM:        SIM_BUDGET_S seconds of outer sim.
+//   SIMMEDINF:  up to SIMMED_INFER_BUDGET_S seconds for simmed inference,
+//               then SIM_BUDGET_S minus the inference's actual elapsed time
+//               for the outer sim (so both arms get the same total).
+//
+// Results are printed after every game.
+
+#include "../src/def/bai_defs.h"
+#include "../src/def/game_history_defs.h"
+#include "../src/def/letter_distribution_defs.h"
+#include "../src/def/move_defs.h"
+#include "../src/def/rack_defs.h"
+#include "../src/def/thread_control_defs.h"
+#include "../src/ent/bag.h"
+#include "../src/ent/bai_result.h"
+#include "../src/ent/equity.h"
+#include "../src/ent/game.h"
+#include "../src/ent/inference_args.h"
+#include "../src/ent/inference_results.h"
+#include "../src/ent/letter_distribution.h"
+#include "../src/ent/move.h"
+#include "../src/ent/player.h"
+#include "../src/ent/rack.h"
+#include "../src/ent/sim_args.h"
+#include "../src/ent/sim_results.h"
+#include "../src/ent/thread_control.h"
+#include "../src/ent/win_pct.h"
+#include "../src/impl/config.h"
+#include "../src/impl/gameplay.h"
+#include "../src/impl/move_gen.h"
+#include "../src/impl/simmed_inference.h"
+#include "../src/impl/simmer.h"
+#include "../src/str/move_string.h"
+#include "../src/util/io_util.h"
+#include "../src/util/string_util.h"
+#include "test_constants.h"
+#include "test_util.h"
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// ── Configuration ──────────────────────────────────────────────────────────
+
+#define NUM_SEEDS 200
+#define NUM_PLAYS 15
+#define NUM_PLIES 4
+#define NUM_THREADS 10
+
+// Outer sim time budget (seconds)
+#define SIM_BUDGET_S 30.0
+
+// Simmed-inference time budget (seconds).  Must leave enough time for outer
+// sim.  The outer sim receives at least MIN_SIM_BUDGET_S seconds.
+#define SIMMED_INFER_BUDGET_S 10.0
+#define MIN_SIM_BUDGET_S 5.0
+
+// Inner sim parameters (used by simmed_infer).
+// INNER_NUM_PLAYS: top-N static-equity candidates generated per rack.
+// simmed_inference.c always appends the observed move if it isn't in those N,
+// giving ≤ N+1 arms.  Probe/full iterations are divided among those arms.
+#define INNER_NUM_PLAYS 5
+#define INNER_SIM_PLIES 2
+#define INNER_PROBE_ITERS 120
+#define INNER_FULL_ITERS 600
+#define INNER_SIM_EQUITY_MARGIN 3.0
+
+// Late-game: switch to many-ply sims when few tiles unseen
+#define LATE_GAME_TILE_THRESHOLD 14
+#define LATE_GAME_PLIES 99
+
+// Log file
+#define LOG_FILENAME "simmedinf_vs_sim4_log.csv"
+
+// ── Player identity ────────────────────────────────────────────────────────
+
+typedef enum {
+  PLAYER_SIM4,       // 4-ply sim, uniform rack sampling
+  PLAYER_SIMMEDINF4, // 4-ply sim + simmed inference (precomputed)
+  NUM_PLAYER_TYPES,
+} player_type_t;
+
+static const char *player_label(player_type_t type) {
+  switch (type) {
+  case PLAYER_SIM4:
+    return "SIM4";
+  case PLAYER_SIMMEDINF4:
+    return "SIMINF4";
+  default:
+    return "?????";
+  }
+}
+
+// ── Per-game results ───────────────────────────────────────────────────────
+
+typedef struct {
+  int a_wins;
+  int b_wins;
+  int ties;
+  int a_total_score;
+  int b_total_score;
+} MatchResults;
+
+// ── Timer thread (fires USER_INTERRUPT after a delay) ──────────────────────
+
+typedef struct {
+  ThreadControl *tc;
+  double seconds;
+  volatile bool done;
+} TimerArgs;
+
+static void *timer_thread_func(void *arg) {
+  TimerArgs *ta = (TimerArgs *)arg;
+  double remaining = ta->seconds;
+  while (remaining > 0 && !ta->done) {
+    double sleep_time = remaining > 0.05 ? 0.05 : remaining;
+    struct timespec ts;
+    ts.tv_sec = (time_t)sleep_time;
+    ts.tv_nsec = (long)((sleep_time - (double)ts.tv_sec) * 1e9);
+    nanosleep(&ts, NULL);
+    remaining -= sleep_time;
+  }
+  if (!ta->done) {
+    thread_control_set_status(ta->tc, THREAD_CONTROL_STATUS_USER_INTERRUPT);
+  }
+  return NULL;
+}
+
+// ── Elapsed time helper ────────────────────────────────────────────────────
+
+static double timespec_diff_s(const struct timespec *start,
+                              const struct timespec *end) {
+  return (double)(end->tv_sec - start->tv_sec) +
+         (double)(end->tv_nsec - start->tv_nsec) / 1e9;
+}
+
+// ── Tiles unseen by the player on turn ────────────────────────────────────
+
+static int tiles_unseen(const Game *game) {
+  return bag_get_letters(game_get_bag(game)) +
+         rack_get_total_letters(player_get_rack(
+             game_get_player(game, 1 - game_get_player_on_turn_index(game))));
+}
+
+// ── Build target_played_tiles from a tile-placement move ──────────────────
+
+static void extract_played_tiles(const Move *move, int ld_size,
+                                 Rack *target_played_tiles) {
+  rack_set_dist_size_and_reset(target_played_tiles, ld_size);
+  const int tiles_length = move_get_tiles_length(move);
+  for (int i = 0; i < tiles_length; i++) {
+    const MachineLetter ml = move_get_tile(move, i);
+    if (ml != PLAYED_THROUGH_MARKER) {
+      rack_add_letter(target_played_tiles,
+                      get_is_blanked(ml) ? BLANK_MACHINE_LETTER : ml);
+    }
+  }
+}
+
+// ── Run simmed inference on the opponent's previous move ──────────────────
+//
+// Populates inference_results with a weighted leave distribution based on
+// inner sims. Returns the elapsed time and whether it completed (vs interrupt).
+
+static bool run_simmed_inference(const Game *game_before_prev, WinPct *win_pcts,
+                                 ThreadControl *tc, const Move *prev_move,
+                                 int prev_player_index,
+                                 InferenceResults *inference_results,
+                                 ErrorStack *error_stack, double *elapsed_out) {
+  const LetterDistribution *ld = game_get_ld(game_before_prev);
+  const int ld_size = ld_get_size(ld);
+
+  const game_event_t move_type = move_get_type(prev_move);
+
+  Rack target_played_tiles;
+  Rack target_known_rack;
+  Rack nontarget_known_rack;
+  rack_set_dist_size_and_reset(&target_known_rack, ld_size);
+  rack_set_dist_size_and_reset(&nontarget_known_rack, ld_size);
+
+  int target_num_exch = 0;
+  if (move_type == GAME_EVENT_EXCHANGE) {
+    target_num_exch = move_get_tiles_played(prev_move);
+    rack_set_dist_size_and_reset(&target_played_tiles, ld_size);
+  } else {
+    extract_played_tiles(prev_move, ld_size, &target_played_tiles);
+  }
+
+  // Our rack (nontarget) is known to us
+  const int nontarget_index = 1 - prev_player_index;
+  rack_copy(&nontarget_known_rack, player_get_rack(game_get_player(
+                                       game_before_prev, nontarget_index)));
+
+  InferenceArgs base_args;
+  infer_args_fill(
+      &base_args, NUM_PLAYS, int_to_equity(0), NULL, game_before_prev,
+      NUM_THREADS, /*parent_worker_thread_index=*/0,
+      /*print_interval=*/0, tc,
+      /*use_game_history=*/false,
+      /*use_inference_cutoff_optimization=*/true, prev_player_index,
+      move_get_score(prev_move), target_num_exch, &target_played_tiles,
+      &target_known_rack, &nontarget_known_rack);
+
+  SimmedInferenceArgs si_args = {
+      .base = &base_args,
+      .observed_move = prev_move,
+      .win_pcts = win_pcts,
+      .num_candidate_plays = INNER_NUM_PLAYS,
+      .num_inner_sim_plies = INNER_SIM_PLIES,
+      .probe_iterations = INNER_PROBE_ITERS,
+      .full_iterations = INNER_FULL_ITERS,
+      .time_budget_s = SIMMED_INFER_BUDGET_S,
+      .sim_equity_margin = INNER_SIM_EQUITY_MARGIN,
+  };
+
+  struct timespec t0, t1;
+  clock_gettime(CLOCK_MONOTONIC, &t0);
+
+  thread_control_set_status(tc, THREAD_CONTROL_STATUS_STARTED);
+
+  TimerArgs ta = {.tc = tc, .seconds = SIMMED_INFER_BUDGET_S, .done = false};
+  pthread_t timer_tid;
+  pthread_create(&timer_tid, NULL, timer_thread_func, &ta);
+
+  simmed_infer(&si_args, inference_results, error_stack);
+
+  ta.done = true;
+  pthread_join(timer_tid, NULL);
+
+  clock_gettime(CLOCK_MONOTONIC, &t1);
+  *elapsed_out = timespec_diff_s(&t0, &t1);
+
+  if (!error_stack_is_empty(error_stack)) {
+    error_stack_print_and_reset(error_stack);
+    return false;
+  }
+
+  return true;
+}
+
+// ── Play one simmed turn ───────────────────────────────────────────────────
+//
+// Generates moves, runs the outer sim for budget_s seconds, and plays the
+// sim-best move. If precomputed_inference_results is non-NULL, uses those
+// results (skipping internal infer()) to bias rack sampling.
+
+static const Move *play_sim_turn(
+    Game *game, MoveList *move_list, SimResults *sim_results, SimCtx **sim_ctx,
+    WinPct *win_pcts, ThreadControl *tc, int num_plies, double budget_s,
+    InferenceResults *precomputed_inference_results, ErrorStack *error_stack) {
+  const MoveGenArgs gen_args = {
+      .game = game,
+      .move_list = move_list,
+      .move_record_type = MOVE_RECORD_ALL,
+      .move_sort_type = MOVE_SORT_EQUITY,
+      .override_kwg = NULL,
+      .eq_margin_movegen = 0,
+      .target_equity = EQUITY_MAX_VALUE,
+      .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+      .tiles_played_bv = NULL,
+  };
+  generate_moves(&gen_args);
+
+  const int num_moves = move_list_get_count(move_list);
+  if (num_moves <= 1) {
+    const Move *move = move_list_get_move(move_list, 0);
+    play_move(move, game, NULL);
+    return move;
+  }
+
+  bool use_inference = (precomputed_inference_results != NULL);
+
+  // When precomputed_inference_results is provided, we pass use_inference=true
+  // but set inference_results_precomputed=true so simulate() skips infer().
+  // We need a valid InferenceArgs when use_inference=true (sim_args_fill
+  // dereferences it), even though simulate() won't call infer().
+  InferenceArgs dummy_infer_args;
+  memset(&dummy_infer_args, 0, sizeof(dummy_infer_args));
+
+  SimArgs sim_args;
+  sim_args_fill(num_plies, move_list, /*num_plays=*/NUM_PLAYS,
+                /*known_opp_rack=*/NULL, win_pcts,
+                precomputed_inference_results, tc, game, use_inference,
+                /*use_heat_map=*/false, NUM_THREADS, /*print_interval=*/0,
+                NUM_PLAYS, num_plies, /*seed=*/0, UINT64_MAX,
+                /*min_play_iterations=*/50, /*scond=*/101.0, BAI_THRESHOLD_NONE,
+                /*time_limit_seconds=*/9999, BAI_SAMPLING_RULE_TOP_TWO_IDS,
+                /*cutoff=*/-1.0, use_inference ? &dummy_infer_args : NULL,
+                &sim_args);
+
+  if (use_inference) {
+    sim_args.inference_results_precomputed = true;
+  }
+
+  thread_control_set_status(tc, THREAD_CONTROL_STATUS_STARTED);
+
+  TimerArgs ta = {.tc = tc, .seconds = budget_s, .done = false};
+  pthread_t timer_tid;
+  pthread_create(&timer_tid, NULL, timer_thread_func, &ta);
+
+  simulate(&sim_args, sim_ctx, sim_results, error_stack);
+
+  ta.done = true;
+  pthread_join(timer_tid, NULL);
+
+  if (!error_stack_is_empty(error_stack)) {
+    error_stack_print_and_reset(error_stack);
+    printf("    *** SIM FAILED, falling back to equity-best ***\n");
+    const Move *move = move_list_get_move(move_list, 0);
+    play_move(move, game, NULL);
+    return move;
+  }
+
+  const BAIResult *bai_result = sim_results_get_bai_result(sim_results);
+  int best_arm = bai_result_get_best_arm(bai_result);
+  if (best_arm < 0) {
+    best_arm = 0;
+  }
+
+  const Move *best_move =
+      simmed_play_get_move(sim_results_get_simmed_play(sim_results, best_arm));
+  play_move(best_move, game, NULL);
+  return best_move;
+}
+
+// ── Play a full game ───────────────────────────────────────────────────────
+// Returns: +1 if p0 wins, -1 if p1 wins, 0 if tie.
+
+static int play_game(Game *game, MoveList *move_list, SimResults *sim_results,
+                     SimCtx **sim_ctx, WinPct *win_pcts, ThreadControl *tc,
+                     InferenceResults *inference_results, player_type_t p0_type,
+                     player_type_t p1_type, uint64_t seed, int *p0_score_out,
+                     int *p1_score_out, int *turns_out, double *elapsed_out) {
+  game_reset(game);
+  game_seed(game, seed);
+  draw_starting_racks(game);
+
+  ErrorStack *error_stack = error_stack_create();
+  StringBuilder *sb = string_builder_create();
+
+  struct timespec game_start, game_end;
+  clock_gettime(CLOCK_MONOTONIC, &game_start);
+
+  // Track the previous player's move for inference.
+  game_event_t prev_move_type = GAME_EVENT_TILE_PLACEMENT_MOVE;
+  int prev_player_index = -1;
+  Move saved_prev_move;
+  memset(&saved_prev_move, 0, sizeof(saved_prev_move));
+
+  // Copy of the game state just before the previous player's move.
+  Game *game_before_prev_move = game_duplicate(game);
+
+  int turn = 0;
+  while (!game_over(game)) {
+    const int player_idx = game_get_player_on_turn_index(game);
+    const player_type_t player_type = (player_idx == 0) ? p0_type : p1_type;
+    const char *label = player_label(player_type);
+    const Bag *bag = game_get_bag(game);
+    const int bag_tiles = bag_get_letters(bag);
+    int unseen = tiles_unseen(game);
+
+    int effective_plies = NUM_PLIES;
+    if (!bag_is_empty(bag) && unseen < LATE_GAME_TILE_THRESHOLD) {
+      effective_plies = LATE_GAME_PLIES;
+    }
+
+    struct timespec turn_start, turn_end;
+    clock_gettime(CLOCK_MONOTONIC, &turn_start);
+
+    const Move *move = NULL;
+    double simmed_infer_elapsed = 0.0;
+    bool did_simmed_infer = false;
+    bool simmed_infer_ok = false;
+
+    // Simmed inference: run before choosing our move, based on opponent's
+    // previous move.
+    InferenceResults *precomputed = NULL;
+
+    if (player_type == PLAYER_SIMMEDINF4 && prev_player_index >= 0 &&
+        (prev_move_type == GAME_EVENT_TILE_PLACEMENT_MOVE ||
+         prev_move_type == GAME_EVENT_EXCHANGE) &&
+        bag_tiles >= RACK_SIZE) {
+      did_simmed_infer = true;
+      simmed_infer_ok = run_simmed_inference(
+          game_before_prev_move, win_pcts, tc, &saved_prev_move,
+          prev_player_index, inference_results, error_stack,
+          &simmed_infer_elapsed);
+      if (simmed_infer_ok) {
+        precomputed = inference_results;
+      } else {
+        printf("    *** SIMMED INFERENCE FAILED after %.2fs ***\n",
+               simmed_infer_elapsed);
+      }
+    }
+
+    double sim_budget = SIM_BUDGET_S - simmed_infer_elapsed;
+    if (sim_budget < MIN_SIM_BUDGET_S) {
+      sim_budget = MIN_SIM_BUDGET_S;
+    }
+
+    // Save game state BEFORE play_sim_turn modifies it.
+    Game *game_snapshot = game_duplicate(game);
+
+    move = play_sim_turn(game, move_list, sim_results, sim_ctx, win_pcts, tc,
+                         effective_plies, sim_budget, precomputed, error_stack);
+
+    game_copy(game_before_prev_move, game_snapshot);
+    game_destroy(game_snapshot);
+
+    clock_gettime(CLOCK_MONOTONIC, &turn_end);
+    double turn_elapsed = timespec_diff_s(&turn_start, &turn_end);
+    turn++;
+
+    string_builder_clear(sb);
+    string_builder_add_move(sb, game_get_board(game), move, game_get_ld(game),
+                            true);
+
+    uint64_t iters = sim_results_get_iteration_count(sim_results);
+    uint64_t num_infer_leaves = sim_results_get_num_infer_leaves(sim_results);
+    if (did_simmed_infer) {
+      printf("    Turn %2d (%-7s p%d): %s  [%.1fs, %" PRIu64
+             " iters, siminf=%.2fs %" PRIu64 " racks%s]\n",
+             turn, label, player_idx, string_builder_peek(sb), turn_elapsed,
+             iters, simmed_infer_elapsed, num_infer_leaves,
+             simmed_infer_ok ? "" : " FAILED");
+    } else {
+      printf("    Turn %2d (%-7s p%d): %s  [%.1fs, %" PRIu64 " iters]\n", turn,
+             label, player_idx, string_builder_peek(sb), turn_elapsed, iters);
+    }
+
+    if (!error_stack_is_empty(error_stack)) {
+      printf("  ERROR on turn %d: ", turn);
+      error_stack_print_and_reset(error_stack);
+    }
+
+    prev_move_type = move_get_type(move);
+    prev_player_index = player_idx;
+    saved_prev_move = *move;
+  }
+
+  clock_gettime(CLOCK_MONOTONIC, &game_end);
+  *elapsed_out = timespec_diff_s(&game_start, &game_end);
+  *turns_out = turn;
+
+  *p0_score_out = equity_to_int(player_get_score(game_get_player(game, 0)));
+  *p1_score_out = equity_to_int(player_get_score(game_get_player(game, 1)));
+
+  game_destroy(game_before_prev_move);
+  string_builder_destroy(sb);
+  error_stack_destroy(error_stack);
+
+  if (*p0_score_out > *p1_score_out)
+    return 1;
+  if (*p1_score_out > *p0_score_out)
+    return -1;
+  return 0;
+}
+
+// ── Print running summary ──────────────────────────────────────────────────
+
+static void print_summary(int seeds_done, const MatchResults *results) {
+  printf("\n==== Results after %d seed(s) (%d games) ====\n", seeds_done,
+         seeds_done * 2);
+  int total = results->a_wins + results->b_wins + results->ties;
+  printf("  %-7s: %3d wins / %3d games (%.1f%%), avg score %.1f\n",
+         player_label(PLAYER_SIM4), results->a_wins, total,
+         total > 0 ? 100.0 * results->a_wins / total : 0.0,
+         total > 0 ? (double)results->a_total_score / total : 0.0);
+  printf("  %-7s: %3d wins / %3d games (%.1f%%), avg score %.1f\n",
+         player_label(PLAYER_SIMMEDINF4), results->b_wins, total,
+         total > 0 ? 100.0 * results->b_wins / total : 0.0,
+         total > 0 ? (double)results->b_total_score / total : 0.0);
+  printf("  Ties: %d\n", results->ties);
+  printf("  Spread: %+d\n\n", results->b_total_score - results->a_total_score);
+}
+
+// ── Entry point ────────────────────────────────────────────────────────────
+
+void test_simmedinf_benchmark(void) {
+  setbuf(stdout, NULL);
+  printf("\n");
+  printf("========================================================\n");
+  printf("  Simmed-Inference Benchmark: SIM4 vs SIMMEDINF4\n");
+  printf("  %d seeds × 2 (game pairs) = %d games\n", NUM_SEEDS, NUM_SEEDS * 2);
+  printf("  %d threads, %d candidates, %d-ply outer sims\n", NUM_THREADS,
+         NUM_PLAYS, NUM_PLIES);
+  printf("  SIM4:      %.0fs outer sim budget\n", SIM_BUDGET_S);
+  printf("  SIMMEDINF4: %.0fs simmed-infer + remaining for outer sim\n",
+         SIMMED_INFER_BUDGET_S);
+  printf("  Inner sim: %d-ply, %d arms, probe=%d, full=%d, margin=%.1f\n",
+         INNER_SIM_PLIES, INNER_NUM_PLAYS, INNER_PROBE_ITERS, INNER_FULL_ITERS,
+         INNER_SIM_EQUITY_MARGIN);
+  printf("  Late game: %d-ply when unseen < %d tiles\n", LATE_GAME_PLIES,
+         LATE_GAME_TILE_THRESHOLD);
+  printf("  Log: %s\n", LOG_FILENAME);
+  printf("========================================================\n\n");
+
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -wmp true -s1 equity -s2 equity -r1 all -r2 all "
+      "-numplays 1 -threads 10");
+  load_and_exec_config_or_die(config, "cgp " EMPTY_CGP);
+
+  ErrorStack *wp_err = error_stack_create();
+  WinPct *win_pcts =
+      win_pct_create(config_get_data_paths(config), DEFAULT_WIN_PCT, wp_err);
+  if (!error_stack_is_empty(wp_err)) {
+    error_stack_print_and_reset(wp_err);
+    log_fatal("failed to load win_pcts");
+  }
+  error_stack_destroy(wp_err);
+
+  Game *game = config_get_game(config);
+  MoveList *move_list = move_list_create(NUM_PLAYS);
+  SimResults *sim_results = sim_results_create(0.0);
+  SimCtx *sim_ctx = NULL;
+  ThreadControl *tc = config_get_thread_control(config);
+  InferenceResults *inference_results = inference_results_create(NULL);
+
+  MatchResults results = {0};
+
+  FILE *log_file = fopen(LOG_FILENAME, "w");
+  if (log_file) {
+    fprintf(log_file, "seed,game_pair,p0_type,p1_type,p0_score,p1_score,turns,"
+                      "elapsed_s,winner\n");
+  }
+
+  for (int seed_idx = 0; seed_idx < NUM_SEEDS; seed_idx++) {
+    const uint64_t seed = (uint64_t)(seed_idx + 1);
+
+    // Game pair: swap player positions to cancel first-mover advantage
+    for (int swap = 0; swap < 2; swap++) {
+      player_type_t p0 = (swap == 0) ? PLAYER_SIM4 : PLAYER_SIMMEDINF4;
+      player_type_t p1 = (swap == 0) ? PLAYER_SIMMEDINF4 : PLAYER_SIM4;
+
+      printf("  Game %3d (seed=%3" PRIu64 ", %s vs %s):\n",
+             seed_idx * 2 + swap + 1, seed, player_label(p0), player_label(p1));
+
+      int p0_score = 0, p1_score = 0, turns = 0;
+      double elapsed = 0.0;
+
+      int outcome = play_game(game, move_list, sim_results, &sim_ctx, win_pcts,
+                              tc, inference_results, p0, p1, seed, &p0_score,
+                              &p1_score, &turns, &elapsed);
+
+      // Attribute win to the right player type
+      player_type_t winner_type = (outcome == 0)   ? NUM_PLAYER_TYPES // tie
+                                  : (outcome == 1) ? p0
+                                                   : p1;
+
+      if (winner_type == PLAYER_SIM4) {
+        results.a_wins++;
+      } else if (winner_type == PLAYER_SIMMEDINF4) {
+        results.b_wins++;
+      } else {
+        results.ties++;
+      }
+
+      // Accumulate scores per player type
+      int sim4_score = (p0 == PLAYER_SIM4) ? p0_score : p1_score;
+      int siminf_score = (p0 == PLAYER_SIMMEDINF4) ? p0_score : p1_score;
+      results.a_total_score += sim4_score;
+      results.b_total_score += siminf_score;
+
+      printf("    Final: %s %d - %s %d (%d turns, %.1fs)\n", player_label(p0),
+             p0_score, player_label(p1), p1_score, turns, elapsed);
+
+      if (log_file) {
+        const char *winner_str = (outcome == 0)   ? "tie"
+                                 : (outcome == 1) ? player_label(p0)
+                                                  : player_label(p1);
+        fprintf(log_file, "%" PRIu64 ",%d,%s,%s,%d,%d,%d,%.2f,%s\n", seed, swap,
+                player_label(p0), player_label(p1), p0_score, p1_score, turns,
+                elapsed, winner_str);
+        fflush(log_file);
+      }
+    }
+
+    print_summary(seed_idx + 1, &results);
+  }
+
+  if (log_file) {
+    fclose(log_file);
+  }
+
+  sim_ctx_destroy(sim_ctx);
+  sim_results_destroy(sim_results);
+  move_list_destroy(move_list);
+  inference_results_destroy(inference_results);
+  win_pct_destroy(win_pcts);
+  config_destroy(config);
+}

--- a/test/simmedinf_benchmark.c
+++ b/test/simmedinf_benchmark.c
@@ -88,30 +88,40 @@
 // ── Player identity ────────────────────────────────────────────────────────
 
 typedef enum {
-  PLAYER_SIM4,       // 4-ply sim, uniform rack sampling
-  PLAYER_SIMMEDINF4, // 4-ply sim + simmed inference (precomputed)
+  PLAYER_NOINF,     // sim, uniform rack sampling (no inference)
+  PLAYER_STATICINF, // sim + static (KLV leave-value) inference
+  PLAYER_SIMMEDINF, // sim + simmed inference (precomputed distribution)
   NUM_PLAYER_TYPES,
 } player_type_t;
 
 static const char *player_label(player_type_t type) {
   switch (type) {
-  case PLAYER_SIM4:
-    return "SIM4";
-  case PLAYER_SIMMEDINF4:
-    return "SIMINF4";
+  case PLAYER_NOINF:
+    return "NOINF";
+  case PLAYER_STATICINF:
+    return "STATINF";
+  case PLAYER_SIMMEDINF:
+    return "SIMINF";
   default:
     return "?????";
   }
 }
 
-// ── Per-game results ───────────────────────────────────────────────────────
+// Static inference accept window (display points): mirrors mainline's
+// default -ima 5 for sims with inference.
+#define STATIC_INFER_EQ_MARGIN 5
+
+// ── Round-robin results ────────────────────────────────────────────────────
+//
+// wins[i][j] = games player type i won against player type j. Ties and the
+// summed spread (i's score minus j's, over their games) are stored in the
+// upper triangle (i < j).
 
 typedef struct {
-  int a_wins;
-  int b_wins;
-  int ties;
-  int a_total_score;
-  int b_total_score;
+  int wins[NUM_PLAYER_TYPES][NUM_PLAYER_TYPES];
+  int ties[NUM_PLAYER_TYPES][NUM_PLAYER_TYPES];
+  long spread[NUM_PLAYER_TYPES][NUM_PLAYER_TYPES];
+  int games[NUM_PLAYER_TYPES][NUM_PLAYER_TYPES];
 } MatchResults;
 
 // ── Timer thread (fires USER_INTERRUPT after a delay) ──────────────────────
@@ -170,6 +180,55 @@ static void extract_played_tiles(const Move *move, int ld_size,
   }
 }
 
+// ── Previous-move inference setup ──────────────────────────────────────────
+//
+// Rack storage plus the InferenceArgs that reference it, for inferring the
+// opponent's previous move. The setup must outlive any simmed_infer() or
+// simulate() call that uses its args (the args hold pointers into it).
+
+typedef struct {
+  Rack target_played_tiles;
+  Rack target_known_rack;
+  Rack nontarget_known_rack;
+  InferenceArgs args;
+} PrevMoveInferSetup;
+
+static void fill_prev_move_infer_args(PrevMoveInferSetup *setup,
+                                      const Game *game_before_prev,
+                                      const Move *prev_move,
+                                      int prev_player_index,
+                                      Equity equity_margin, ThreadControl *tc) {
+  const LetterDistribution *ld = game_get_ld(game_before_prev);
+  const int ld_size = ld_get_size(ld);
+
+  rack_set_dist_size_and_reset(&setup->target_known_rack, ld_size);
+  rack_set_dist_size_and_reset(&setup->nontarget_known_rack, ld_size);
+
+  int target_num_exch = 0;
+  if (move_get_type(prev_move) == GAME_EVENT_EXCHANGE) {
+    target_num_exch = move_get_tiles_played(prev_move);
+    rack_set_dist_size_and_reset(&setup->target_played_tiles, ld_size);
+  } else {
+    extract_played_tiles(prev_move, ld_size, &setup->target_played_tiles);
+  }
+
+  // Our rack (nontarget) is known to us.
+  const int nontarget_index = 1 - prev_player_index;
+  rack_copy(
+      &setup->nontarget_known_rack,
+      player_get_rack(game_get_player(game_before_prev, nontarget_index)));
+
+  infer_args_fill(&setup->args, NUM_PLAYS, equity_margin, NULL,
+                  game_before_prev, NUM_THREADS,
+                  /*parent_worker_thread_index=*/0,
+                  /*print_interval=*/0, tc,
+                  /*use_game_history=*/false,
+                  /*use_inference_cutoff_optimization=*/true, prev_player_index,
+                  move_get_score(prev_move), target_num_exch,
+                  &setup->target_played_tiles, &setup->target_known_rack,
+                  &setup->nontarget_known_rack);
+}
+
 // ── Run simmed inference on the opponent's previous move ──────────────────
 //
 // Populates inference_results with a weighted leave distribution based on
@@ -180,42 +239,12 @@ static bool run_simmed_inference(const Game *game_before_prev, WinPct *win_pcts,
                                  int prev_player_index,
                                  InferenceResults *inference_results,
                                  ErrorStack *error_stack, double *elapsed_out) {
-  const LetterDistribution *ld = game_get_ld(game_before_prev);
-  const int ld_size = ld_get_size(ld);
-
-  const game_event_t move_type = move_get_type(prev_move);
-
-  Rack target_played_tiles;
-  Rack target_known_rack;
-  Rack nontarget_known_rack;
-  rack_set_dist_size_and_reset(&target_known_rack, ld_size);
-  rack_set_dist_size_and_reset(&nontarget_known_rack, ld_size);
-
-  int target_num_exch = 0;
-  if (move_type == GAME_EVENT_EXCHANGE) {
-    target_num_exch = move_get_tiles_played(prev_move);
-    rack_set_dist_size_and_reset(&target_played_tiles, ld_size);
-  } else {
-    extract_played_tiles(prev_move, ld_size, &target_played_tiles);
-  }
-
-  // Our rack (nontarget) is known to us
-  const int nontarget_index = 1 - prev_player_index;
-  rack_copy(&nontarget_known_rack, player_get_rack(game_get_player(
-                                       game_before_prev, nontarget_index)));
-
-  InferenceArgs base_args;
-  infer_args_fill(
-      &base_args, NUM_PLAYS, int_to_equity(0), NULL, game_before_prev,
-      NUM_THREADS, /*parent_worker_thread_index=*/0,
-      /*print_interval=*/0, tc,
-      /*use_game_history=*/false,
-      /*use_inference_cutoff_optimization=*/true, prev_player_index,
-      move_get_score(prev_move), target_num_exch, &target_played_tiles,
-      &target_known_rack, &nontarget_known_rack);
+  PrevMoveInferSetup setup;
+  fill_prev_move_infer_args(&setup, game_before_prev, prev_move,
+                            prev_player_index, int_to_equity(0), tc);
 
   SimmedInferenceArgs si_args = {
-      .base = &base_args,
+      .base = &setup.args,
       .observed_move = prev_move,
       .win_pcts = win_pcts,
       .num_candidate_plays = INNER_NUM_PLAYS,
@@ -251,16 +280,26 @@ static bool run_simmed_inference(const Game *game_before_prev, WinPct *win_pcts,
   return true;
 }
 
-// ── Play one simmed turn ───────────────────────────────────────────────────
+// ── Play one sim turn ──────────────────────────────────────────────────────
 //
 // Generates moves, runs the outer sim for budget_s seconds, and plays the
-// sim-best move. If precomputed_inference_results is non-NULL, uses those
-// results (skipping internal infer()) to bias rack sampling.
+// sim-best move. Three inference modes:
+//   - inference_results == NULL:  plain sim, uniform rack sampling.
+//   - results_precomputed true:   inference_results already holds a (simmed)
+//                                 leave distribution; simulate() skips its
+//                                 internal infer().
+//   - static_infer_args non-NULL: simulate() runs static inference itself
+//                                 into inference_results (the mainline
+//                                 sim-with-inference path).
+// If a sim WITH inference fails, it is retried once without inference so an
+// inference edge case doesn't degrade the arm to equity-best play.
 
-static const Move *play_sim_turn(
-    Game *game, MoveList *move_list, SimResults *sim_results, SimCtx **sim_ctx,
-    WinPct *win_pcts, ThreadControl *tc, int num_plies, double budget_s,
-    InferenceResults *precomputed_inference_results, ErrorStack *error_stack) {
+static const Move *
+play_sim_turn(Game *game, MoveList *move_list, SimResults *sim_results,
+              SimCtx **sim_ctx, WinPct *win_pcts, ThreadControl *tc,
+              int num_plies, double budget_s,
+              InferenceResults *inference_results, bool results_precomputed,
+              const InferenceArgs *static_infer_args, ErrorStack *error_stack) {
   const MoveGenArgs gen_args = {
       .game = game,
       .move_list = move_list,
@@ -281,43 +320,56 @@ static const Move *play_sim_turn(
     return move;
   }
 
-  bool use_inference = (precomputed_inference_results != NULL);
-
-  // When precomputed_inference_results is provided, we pass use_inference=true
-  // but set inference_results_precomputed=true so simulate() skips infer().
-  // We need a valid InferenceArgs when use_inference=true (sim_args_fill
-  // dereferences it), even though simulate() won't call infer().
+  // A zeroed InferenceArgs stands in when the distribution is precomputed:
+  // sim_args_fill dereferences the pointer but simulate() never runs infer().
   InferenceArgs dummy_infer_args;
   memset(&dummy_infer_args, 0, sizeof(dummy_infer_args));
 
-  SimArgs sim_args;
-  sim_args_fill(num_plies, move_list, /*num_plays=*/NUM_PLAYS,
-                /*known_opp_rack=*/NULL, win_pcts,
-                precomputed_inference_results, tc, game, use_inference,
-                /*use_heat_map=*/false, NUM_THREADS, /*print_interval=*/0,
-                NUM_PLAYS, num_plies, /*seed=*/0, UINT64_MAX,
-                /*min_play_iterations=*/50, /*scond=*/101.0, BAI_THRESHOLD_NONE,
-                /*time_limit_seconds=*/9999, BAI_SAMPLING_RULE_TOP_TWO_IDS,
-                /*cutoff=*/-1.0, use_inference ? &dummy_infer_args : NULL,
-                &sim_args);
+  bool sim_ok = false;
+  for (int attempt = 0; attempt < 2 && !sim_ok; attempt++) {
+    const bool with_inference = (attempt == 0) && (inference_results != NULL);
+    // Non-inference attempts still pass the (ignored) dummy args so
+    // sim_args_fill never sees a null pointer.
+    const InferenceArgs *infer_args = &dummy_infer_args;
+    if (with_inference && static_infer_args != NULL) {
+      infer_args = static_infer_args;
+    }
 
-  if (use_inference) {
-    sim_args.inference_results_precomputed = true;
+    SimArgs sim_args;
+    // The budget is enforced with BAI's own time limit (which starts after
+    // any internal inference), NOT an external interrupt timer: an interrupt
+    // that fires while simulate() is still inside infer() would make it
+    // return before resetting sim_results, and the caller would then read a
+    // stale best move from the PREVIOUS turn (whose tiles may no longer be
+    // on the rack).
+    sim_args_fill(
+        num_plies, move_list, /*num_plays=*/NUM_PLAYS,
+        /*known_opp_rack=*/NULL, win_pcts,
+        with_inference ? inference_results : NULL, tc, game, with_inference,
+        /*use_heat_map=*/false, NUM_THREADS, /*print_interval=*/0, NUM_PLAYS,
+        num_plies, /*seed=*/0, UINT64_MAX,
+        /*min_play_iterations=*/50, /*scond=*/101.0, BAI_THRESHOLD_NONE,
+        /*time_limit_seconds=*/budget_s, BAI_SAMPLING_RULE_TOP_TWO_IDS,
+        /*cutoff=*/-1.0, infer_args, &sim_args);
+    if (with_inference && results_precomputed) {
+      sim_args.inference_results_precomputed = true;
+    }
+
+    thread_control_set_status(tc, THREAD_CONTROL_STATUS_STARTED);
+
+    simulate(&sim_args, sim_ctx, sim_results, error_stack);
+
+    if (error_stack_is_empty(error_stack)) {
+      sim_ok = true;
+    } else {
+      error_stack_print_and_reset(error_stack);
+      if (with_inference) {
+        printf("    *** SIM WITH INFERENCE FAILED, retrying plain ***\n");
+      }
+    }
   }
 
-  thread_control_set_status(tc, THREAD_CONTROL_STATUS_STARTED);
-
-  TimerArgs ta = {.tc = tc, .seconds = budget_s, .done = false};
-  pthread_t timer_tid;
-  pthread_create(&timer_tid, NULL, timer_thread_func, &ta);
-
-  simulate(&sim_args, sim_ctx, sim_results, error_stack);
-
-  ta.done = true;
-  pthread_join(timer_tid, NULL);
-
-  if (!error_stack_is_empty(error_stack)) {
-    error_stack_print_and_reset(error_stack);
+  if (!sim_ok) {
     printf("    *** SIM FAILED, falling back to equity-best ***\n");
     const Move *move = move_list_get_move(move_list, 0);
     play_move(move, game, NULL);
@@ -326,7 +378,7 @@ static const Move *play_sim_turn(
 
   const BAIResult *bai_result = sim_results_get_bai_result(sim_results);
   int best_arm = bai_result_get_best_arm(bai_result);
-  if (best_arm < 0) {
+  if (best_arm < 0 || best_arm >= num_moves) {
     best_arm = 0;
   }
 
@@ -385,25 +437,40 @@ static int play_game(Game *game, MoveList *move_list, SimResults *sim_results,
     bool did_simmed_infer = false;
     bool simmed_infer_ok = false;
 
-    // Simmed inference: run before choosing our move, based on opponent's
-    // previous move.
-    InferenceResults *precomputed = NULL;
+    // Inference (either kind) requires an inferable previous move and a
+    // non-endgame bag.
+    const bool can_infer = prev_player_index >= 0 &&
+                           (prev_move_type == GAME_EVENT_TILE_PLACEMENT_MOVE ||
+                            prev_move_type == GAME_EVENT_EXCHANGE) &&
+                           bag_tiles >= RACK_SIZE;
 
-    if (player_type == PLAYER_SIMMEDINF4 && prev_player_index >= 0 &&
-        (prev_move_type == GAME_EVENT_TILE_PLACEMENT_MOVE ||
-         prev_move_type == GAME_EVENT_EXCHANGE) &&
-        bag_tiles >= RACK_SIZE) {
+    // Simmed inference runs BEFORE the outer sim and its elapsed time is
+    // deducted from the sim budget; static inference runs INSIDE simulate()
+    // (the mainline path) so it spends from the same budget automatically.
+    InferenceResults *turn_inference_results = NULL;
+    bool results_precomputed = false;
+    PrevMoveInferSetup static_setup;
+    const InferenceArgs *static_infer_args = NULL;
+
+    if (player_type == PLAYER_SIMMEDINF && can_infer) {
       did_simmed_infer = true;
       simmed_infer_ok = run_simmed_inference(
           game_before_prev_move, win_pcts, tc, &saved_prev_move,
           prev_player_index, inference_results, error_stack,
           &simmed_infer_elapsed);
       if (simmed_infer_ok) {
-        precomputed = inference_results;
+        turn_inference_results = inference_results;
+        results_precomputed = true;
       } else {
         printf("    *** SIMMED INFERENCE FAILED after %.2fs ***\n",
                simmed_infer_elapsed);
       }
+    } else if (player_type == PLAYER_STATICINF && can_infer) {
+      fill_prev_move_infer_args(&static_setup, game_before_prev_move,
+                                &saved_prev_move, prev_player_index,
+                                int_to_equity(STATIC_INFER_EQ_MARGIN), tc);
+      static_infer_args = &static_setup.args;
+      turn_inference_results = inference_results;
     }
 
     double sim_budget = SIM_BUDGET_S - simmed_infer_elapsed;
@@ -415,7 +482,8 @@ static int play_game(Game *game, MoveList *move_list, SimResults *sim_results,
     Game *game_snapshot = game_duplicate(game);
 
     move = play_sim_turn(game, move_list, sim_results, sim_ctx, win_pcts, tc,
-                         effective_plies, sim_budget, precomputed, error_stack);
+                         effective_plies, sim_budget, turn_inference_results,
+                         results_precomputed, static_infer_args, error_stack);
 
     game_copy(game_before_prev_move, game_snapshot);
     game_destroy(game_snapshot);
@@ -430,7 +498,12 @@ static int play_game(Game *game, MoveList *move_list, SimResults *sim_results,
 
     uint64_t iters = sim_results_get_iteration_count(sim_results);
     uint64_t num_infer_leaves = sim_results_get_num_infer_leaves(sim_results);
-    if (did_simmed_infer) {
+    if (static_infer_args != NULL) {
+      printf("    Turn %2d (%-7s p%d): %s  [%.1fs, %" PRIu64
+             " iters, statinf %" PRIu64 " leaves]\n",
+             turn, label, player_idx, string_builder_peek(sb), turn_elapsed,
+             iters, num_infer_leaves);
+    } else if (did_simmed_infer) {
       printf("    Turn %2d (%-7s p%d): %s  [%.1fs, %" PRIu64
              " iters, siminf=%.2fs %" PRIu64 " racks%s]\n",
              turn, label, player_idx, string_builder_peek(sb), turn_elapsed,
@@ -471,20 +544,65 @@ static int play_game(Game *game, MoveList *move_list, SimResults *sim_results,
 
 // ── Print running summary ──────────────────────────────────────────────────
 
+static void print_pairing_line(const MatchResults *results, player_type_t a,
+                               player_type_t b) {
+  const int games = results->games[a][b];
+  if (games == 0) {
+    return;
+  }
+  printf("  %-7s vs %-7s: %3d - %3d (%d ties) in %3d games | %s spread "
+         "%+ld (%+.1f/g)\n",
+         player_label(a), player_label(b), results->wins[a][b],
+         results->wins[b][a], results->ties[a][b], games, player_label(a),
+         results->spread[a][b], (double)results->spread[a][b] / games);
+}
+
 static void print_summary(int seeds_done, const MatchResults *results) {
   printf("\n==== Results after %d seed(s) (%d games) ====\n", seeds_done,
-         seeds_done * 2);
-  int total = results->a_wins + results->b_wins + results->ties;
-  printf("  %-7s: %3d wins / %3d games (%.1f%%), avg score %.1f\n",
-         player_label(PLAYER_SIM4), results->a_wins, total,
-         total > 0 ? 100.0 * results->a_wins / total : 0.0,
-         total > 0 ? (double)results->a_total_score / total : 0.0);
-  printf("  %-7s: %3d wins / %3d games (%.1f%%), avg score %.1f\n",
-         player_label(PLAYER_SIMMEDINF4), results->b_wins, total,
-         total > 0 ? 100.0 * results->b_wins / total : 0.0,
-         total > 0 ? (double)results->b_total_score / total : 0.0);
-  printf("  Ties: %d\n", results->ties);
-  printf("  Spread: %+d\n\n", results->b_total_score - results->a_total_score);
+         seeds_done * 6);
+  print_pairing_line(results, PLAYER_SIMMEDINF, PLAYER_STATICINF);
+  print_pairing_line(results, PLAYER_SIMMEDINF, PLAYER_NOINF);
+  print_pairing_line(results, PLAYER_STATICINF, PLAYER_NOINF);
+  // Overall per-player records across both pairings.
+  for (int player = 0; player < NUM_PLAYER_TYPES; player++) {
+    int wins = 0;
+    int games = 0;
+    for (int opp = 0; opp < NUM_PLAYER_TYPES; opp++) {
+      wins += results->wins[player][opp];
+      games += results->games[player][opp];
+    }
+    printf("  %-7s overall: %3d wins / %3d games (%.1f%%)\n",
+           player_label((player_type_t)player), wins, games,
+           games > 0 ? 100.0 * wins / games : 0.0);
+  }
+  printf("\n");
+}
+
+// Records one game's outcome into the crosstable. outcome is +1/-1/0 from
+// p0's perspective.
+static void record_game(MatchResults *results, player_type_t p0,
+                        player_type_t p1, int outcome, int p0_score,
+                        int p1_score) {
+  // Normalize so the pair key is (lo, hi) with lo < hi; spread/ties/games are
+  // stored at [hi][lo]... store spread and ties keyed by (a, b) where a is
+  // the pairing's first-listed player: use (min, max) consistently.
+  const player_type_t a = (p0 < p1) ? p0 : p1;
+  const player_type_t b = (p0 < p1) ? p1 : p0;
+  const int a_score = (a == p0) ? p0_score : p1_score;
+  const int b_score = (a == p0) ? p1_score : p0_score;
+  const int a_outcome = (a == p0) ? outcome : -outcome;
+  results->games[a][b]++;
+  results->games[b][a]++;
+  results->spread[a][b] += a_score - b_score;
+  results->spread[b][a] += b_score - a_score;
+  if (a_outcome > 0) {
+    results->wins[a][b]++;
+  } else if (a_outcome < 0) {
+    results->wins[b][a]++;
+  } else {
+    results->ties[a][b]++;
+    results->ties[b][a]++;
+  }
 }
 
 // ── Entry point ────────────────────────────────────────────────────────────
@@ -493,13 +611,14 @@ void test_simmedinf_benchmark(void) {
   setbuf(stdout, NULL);
   printf("\n");
   printf("========================================================\n");
-  printf("  Simmed-Inference Benchmark: SIM4 vs SIMMEDINF4\n");
-  printf("  %d seeds × 2 (game pairs) = %d games\n", NUM_SEEDS, NUM_SEEDS * 2);
+  printf("  Inference round robin: NOINF / STATINF / SIMINF\n");
+  printf("  %d seeds x 3 pairings x 2 seats = %d games\n", NUM_SEEDS,
+         NUM_SEEDS * 6);
   printf("  %d threads, %d candidates, %d-ply outer sims\n", NUM_THREADS,
          NUM_PLAYS, NUM_PLIES);
-  printf("  SIM4:      %.0fs outer sim budget\n", SIM_BUDGET_S);
-  printf("  SIMMEDINF4: %.0fs simmed-infer + remaining for outer sim\n",
-         SIMMED_INFER_BUDGET_S);
+  printf("  Turn budget: %.0fs (SIMINF: up to %.0fs simmed-infer deducted; "
+         "STATINF margin %d)\n",
+         SIM_BUDGET_S, SIMMED_INFER_BUDGET_S, STATIC_INFER_EQ_MARGIN);
   printf("  Inner sim: %d-ply, %d arms, probe=%d, full=%d, margin=%.1f\n",
          INNER_SIM_PLIES, INNER_NUM_PLAYS, INNER_PROBE_ITERS, INNER_FULL_ITERS,
          INNER_SIM_EQUITY_MARGIN);
@@ -529,62 +648,59 @@ void test_simmedinf_benchmark(void) {
   ThreadControl *tc = config_get_thread_control(config);
   InferenceResults *inference_results = inference_results_create(NULL);
 
-  MatchResults results = {0};
+  MatchResults results;
+  memset(&results, 0, sizeof(results));
+
+  static const player_type_t pairings[3][2] = {
+      {PLAYER_SIMMEDINF, PLAYER_STATICINF},
+      {PLAYER_SIMMEDINF, PLAYER_NOINF},
+      {PLAYER_STATICINF, PLAYER_NOINF},
+  };
 
   FILE *log_file = fopen(LOG_FILENAME, "w");
   if (log_file) {
-    fprintf(log_file, "seed,game_pair,p0_type,p1_type,p0_score,p1_score,turns,"
-                      "elapsed_s,winner\n");
+    fprintf(log_file, "seed,pairing,seat_swap,p0_type,p1_type,p0_score,"
+                      "p1_score,turns,elapsed_s,winner\n");
   }
 
+  int game_number = 0;
   for (int seed_idx = 0; seed_idx < NUM_SEEDS; seed_idx++) {
     const uint64_t seed = (uint64_t)(seed_idx + 1);
 
-    // Game pair: swap player positions to cancel first-mover advantage
-    for (int swap = 0; swap < 2; swap++) {
-      player_type_t p0 = (swap == 0) ? PLAYER_SIM4 : PLAYER_SIMMEDINF4;
-      player_type_t p1 = (swap == 0) ? PLAYER_SIMMEDINF4 : PLAYER_SIM4;
+    for (int pairing_idx = 0; pairing_idx < 3; pairing_idx++) {
+      // Game pair: swap seats to cancel first-mover and draw advantage.
+      for (int swap = 0; swap < 2; swap++) {
+        const player_type_t p0 = pairings[pairing_idx][swap == 0 ? 0 : 1];
+        const player_type_t p1 = pairings[pairing_idx][swap == 0 ? 1 : 0];
 
-      printf("  Game %3d (seed=%3" PRIu64 ", %s vs %s):\n",
-             seed_idx * 2 + swap + 1, seed, player_label(p0), player_label(p1));
+        game_number++;
+        printf("  Game %3d (seed=%3" PRIu64 ", %s vs %s):\n", game_number, seed,
+               player_label(p0), player_label(p1));
 
-      int p0_score = 0, p1_score = 0, turns = 0;
-      double elapsed = 0.0;
+        int p0_score = 0;
+        int p1_score = 0;
+        int turns = 0;
+        double elapsed = 0.0;
 
-      int outcome = play_game(game, move_list, sim_results, &sim_ctx, win_pcts,
-                              tc, inference_results, p0, p1, seed, &p0_score,
-                              &p1_score, &turns, &elapsed);
+        const int outcome =
+            play_game(game, move_list, sim_results, &sim_ctx, win_pcts, tc,
+                      inference_results, p0, p1, seed, &p0_score, &p1_score,
+                      &turns, &elapsed);
 
-      // Attribute win to the right player type
-      player_type_t winner_type = (outcome == 0)   ? NUM_PLAYER_TYPES // tie
-                                  : (outcome == 1) ? p0
-                                                   : p1;
+        record_game(&results, p0, p1, outcome, p0_score, p1_score);
 
-      if (winner_type == PLAYER_SIM4) {
-        results.a_wins++;
-      } else if (winner_type == PLAYER_SIMMEDINF4) {
-        results.b_wins++;
-      } else {
-        results.ties++;
-      }
+        printf("    Final: %s %d - %s %d (%d turns, %.1fs)\n", player_label(p0),
+               p0_score, player_label(p1), p1_score, turns, elapsed);
 
-      // Accumulate scores per player type
-      int sim4_score = (p0 == PLAYER_SIM4) ? p0_score : p1_score;
-      int siminf_score = (p0 == PLAYER_SIMMEDINF4) ? p0_score : p1_score;
-      results.a_total_score += sim4_score;
-      results.b_total_score += siminf_score;
-
-      printf("    Final: %s %d - %s %d (%d turns, %.1fs)\n", player_label(p0),
-             p0_score, player_label(p1), p1_score, turns, elapsed);
-
-      if (log_file) {
-        const char *winner_str = (outcome == 0)   ? "tie"
-                                 : (outcome == 1) ? player_label(p0)
-                                                  : player_label(p1);
-        fprintf(log_file, "%" PRIu64 ",%d,%s,%s,%d,%d,%d,%.2f,%s\n", seed, swap,
-                player_label(p0), player_label(p1), p0_score, p1_score, turns,
-                elapsed, winner_str);
-        fflush(log_file);
+        if (log_file) {
+          const char *winner_str = (outcome == 0)   ? "tie"
+                                   : (outcome == 1) ? player_label(p0)
+                                                    : player_label(p1);
+          fprintf(log_file, "%" PRIu64 ",%d,%d,%s,%s,%d,%d,%d,%.2f,%s\n", seed,
+                  pairing_idx, swap, player_label(p0), player_label(p1),
+                  p0_score, p1_score, turns, elapsed, winner_str);
+          fflush(log_file);
+        }
       }
     }
 

--- a/test/simmedinf_benchmark.h
+++ b/test/simmedinf_benchmark.h
@@ -1,0 +1,6 @@
+#ifndef SIMMEDINF_BENCHMARK_H
+#define SIMMEDINF_BENCHMARK_H
+
+void test_simmedinf_benchmark(void);
+
+#endif

--- a/test/simmedinf_test.c
+++ b/test/simmedinf_test.c
@@ -1,0 +1,1288 @@
+// Unit tests for simmed_inference.c.
+//
+// Regression tests for bugs found during SIM4 vs SIMMEDINF4 benchmarking.
+
+#include "../src/def/config_defs.h"
+#include "../src/def/game_history_defs.h"
+#include "../src/def/letter_distribution_defs.h"
+#include "../src/def/move_defs.h"
+#include "../src/def/thread_control_defs.h"
+#include "../src/ent/board.h"
+#include "../src/ent/equity.h"
+#include "../src/ent/game.h"
+#include "../src/ent/inference_args.h"
+#include "../src/ent/inference_results.h"
+#include "../src/ent/klv.h"
+#include "../src/ent/leave_rack.h"
+#include "../src/ent/letter_distribution.h"
+#include "../src/ent/move.h"
+#include "../src/ent/player.h"
+#include "../src/ent/rack.h"
+#include "../src/ent/sim_results.h"
+#include "../src/ent/stats.h"
+#include "../src/ent/thread_control.h"
+#include "../src/ent/validated_move.h"
+#include "../src/ent/win_pct.h"
+#include "../src/impl/config.h"
+#include "../src/impl/inference.h"
+#include "../src/impl/simmed_inference.h"
+#include "../src/str/move_string.h"
+#include "../src/str/rack_string.h"
+#include "../src/util/io_util.h"
+#include "../src/util/string_util.h"
+#include "test_constants.h"
+#include "test_util.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+// Call simmed_infer for a given exchange count from the OPENING_CGP game state
+// (player 0 has ABCDEFG). Verifies no crash and no error on the error stack.
+static void assert_simmedinf_exchange_no_crash(int exch_count,
+                                               int num_threads) {
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -wmp true -s1 equity -s2 equity -r1 all -r2 all "
+      "-numplays 1 -threads 4");
+  load_and_exec_config_or_die(config, "cgp " OPENING_CGP);
+
+  ErrorStack *error_stack = error_stack_create();
+  WinPct *win_pcts = win_pct_create(config_get_data_paths(config),
+                                    DEFAULT_WIN_PCT, error_stack);
+  assert(error_stack_is_empty(error_stack));
+
+  const Game *game = config_get_game(config);
+  const LetterDistribution *ld = game_get_ld(game);
+  const int ld_size = ld_get_size(ld);
+
+  Rack target_played_tiles;
+  Rack target_known_rack;
+  Rack nontarget_known_rack;
+  rack_set_dist_size_and_reset(&target_played_tiles, ld_size);
+  rack_set_dist_size_and_reset(&target_known_rack, ld_size);
+  rack_set_dist_size_and_reset(&nontarget_known_rack, ld_size);
+
+  // Player 1 (nontarget) knows their own rack.
+  rack_copy(&nontarget_known_rack, player_get_rack(game_get_player(game, 1)));
+
+  // Build a minimal exchange move: only the count matters for inference
+  // matching; specific tiles are irrelevant for exchange inference.
+  Move observed_move;
+  memset(&observed_move, 0, sizeof(observed_move));
+  move_set_type(&observed_move, GAME_EVENT_EXCHANGE);
+  move_set_tiles_played(&observed_move, exch_count);
+  move_set_score(&observed_move, int_to_equity(0));
+
+  InferenceArgs base_args;
+  infer_args_fill(&base_args, /*num_plays=*/5, int_to_equity(0), NULL, game,
+                  num_threads, /*parent_worker_thread_index=*/0,
+                  /*print_interval=*/0, config_get_thread_control(config),
+                  /*use_game_history=*/false,
+                  /*use_inference_cutoff_optimization=*/true,
+                  /*target_index=*/0, /*target_score=*/int_to_equity(0),
+                  exch_count, &target_played_tiles, &target_known_rack,
+                  &nontarget_known_rack);
+
+  InferenceResults *inference_results = inference_results_create(NULL);
+
+  SimmedInferenceArgs si_args = {
+      .base = &base_args,
+      .observed_move = &observed_move,
+      .win_pcts = win_pcts,
+      .num_candidate_plays = 5,
+      .num_inner_sim_plies = 2,
+      .probe_iterations = 20,
+      .full_iterations = 40,
+      .time_budget_s = 0.3,
+      .sim_equity_margin = 3.0,
+  };
+
+  thread_control_set_status(config_get_thread_control(config),
+                            THREAD_CONTROL_STATUS_STARTED);
+  simmed_infer(&si_args, inference_results, error_stack);
+  assert(error_stack_is_empty(error_stack));
+
+  inference_results_destroy(inference_results);
+  error_stack_destroy(error_stack);
+  win_pct_destroy(win_pcts);
+  config_destroy(config);
+}
+
+// Regression test: simmed_infer with a 5-tile exchange must not crash.
+//
+// Bug: when the generated candidate list had no exchange in the top-N
+// (all tile placements), the code force-inserted observed_move_copy which
+// had specific exchange tiles not present in the candidate leave, causing
+// rack_take_letter underflow in execute_exchange_move.
+//
+// Fix: before trimming the generated list, scan beyond the top-N for any
+// exchange of the right count and pre-save it, avoiding force-insertion
+// of observed_move_copy with mismatched tiles.
+void test_simmedinf_exchange_no_crash(void) {
+  // 5-tile exchange: the case that originally triggered the crash.
+  assert_simmedinf_exchange_no_crash(5, 4);
+  // Also check 1-tile and 7-tile (full rack) exchanges.
+  assert_simmedinf_exchange_no_crash(1, 4);
+  assert_simmedinf_exchange_no_crash(7, 4);
+}
+
+void test_simmedinf(void) { test_simmedinf_exchange_no_crash(); }
+
+// ── Leave callback: prints per-leave inner-sim detail to a FILE* ─────────────
+
+// Top-K unique leaves tracked by accumulated posterior score (raw * weight).
+// Streaming top-K: when full, evict the minimum if the new leaf's current
+// contribution exceeds it.  Works well because MC sampling is proportional
+// to the prior, so high-posterior leaves are visited frequently.
+#define MAX_SUMMARY_LEAVES 100
+
+typedef struct {
+  Rack leave;
+  double posterior; // accumulated raw * weight across all callbacks
+  double klv;       // leave KLV equity (set on first insertion, deterministic)
+} LeafSummaryEntry;
+
+typedef struct {
+  FILE *f;
+  const LetterDistribution *ld;
+  int ld_size;
+  int target_index;
+  // Only print per-leave detail when weight >= this threshold (0.0 = print
+  // all).
+  double min_weight_to_print;
+  // Running accumulators for distributional stats (all leaves, no size limit).
+  double total_raw;       // sum of raw combinatorial draw counts
+  double total_posterior; // sum of raw * sim_weight
+  double raw_sum_score, post_sum_score;
+  double raw_sum_vow, post_sum_vow;
+  double raw_sum_con, post_sum_con;
+  double raw_sum_bl, post_sum_bl;
+  // Per-letter expected count in leave (prior and posterior).
+  double raw_sum_letter[MAX_ALPHABET_SIZE];
+  double post_sum_letter[MAX_ALPHABET_SIZE];
+  // Leave value (KLV) distributional shift.
+  double raw_sum_klv, post_sum_klv;
+  int total_leaves_seen;
+  int static_eval_count; // leaves rejected by static eval (no inner sim)
+  // Minimum-gap leave (most plausible rack even if all were rejected).
+  double min_gap;
+  Rack min_gap_leave;
+  // Top-K unique leaves by accumulated posterior (for summary table).
+  LeafSummaryEntry top_leaves[MAX_SUMMARY_LEAVES];
+  int top_count;
+  int top_min_idx; // index of the current minimum-posterior slot
+} LeafCallbackCtx;
+
+static void qintar_leave_callback(const Rack *leave, const MoveList *ml,
+                                  const SimResults *sr, int obs_idx, double gap,
+                                  double weight, const Game *inner_game,
+                                  void *user_data) {
+  LeafCallbackCtx *cb = (LeafCallbackCtx *)user_data;
+  const LetterDistribution *ld = cb->ld;
+  const int n = move_list_get_count(ml);
+  const uint64_t iters = sim_results_get_iteration_count(sr);
+  const Board *board = game_get_board(inner_game);
+
+  // Build descending sort order by win% (sim) or static equity (no sim).
+  int order[RACK_SIZE + 8]; // generous upper bound
+  for (int i = 0; i < n; i++)
+    order[i] = i;
+  // Insertion sort descending.
+  for (int i = 1; i < n; i++) {
+    int key = order[i];
+    double key_val;
+    if (iters > 0) {
+      key_val = stat_get_mean(
+          simmed_play_get_win_pct_stat(sim_results_get_simmed_play(sr, key)));
+    } else {
+      key_val = equity_to_double(move_get_equity(move_list_get_move(ml, key)));
+    }
+    int j = i - 1;
+    while (j >= 0) {
+      double cmp;
+      if (iters > 0) {
+        cmp = stat_get_mean(simmed_play_get_win_pct_stat(
+            sim_results_get_simmed_play(sr, order[j])));
+      } else {
+        cmp =
+            equity_to_double(move_get_equity(move_list_get_move(ml, order[j])));
+      }
+      if (cmp > key_val)
+        break;
+      order[j + 1] = order[j];
+      j--;
+    }
+    order[j + 1] = key;
+  }
+
+  // Header: leave rack + summary.
+  // gap is in bogopoints when sim ran, equity points when statically rejected.
+  StringBuilder *sb = string_builder_create();
+  string_builder_add_rack(sb, leave, ld, /*blanks_first=*/false);
+  const bool print_detail = (weight >= cb->min_weight_to_print);
+  if (print_detail) {
+    fprintf(cb->f,
+            "\n=== Leave: %-6s  gap=%.2f(%s)  weight=%.3f  iters=%llu ===\n",
+            string_builder_peek(sb), gap, (iters > 0) ? "bogo" : "pts", weight,
+            (unsigned long long)iters);
+  }
+
+  // Compute the target's full rack (known_combined + current_leave) from
+  // inner_game; we'll subtract each move's tiles to show the resulting leave.
+  const Rack *target_rack =
+      player_get_rack(game_get_player(inner_game, cb->target_index));
+
+  // One line per candidate move, descending by win%:
+  //   move, leave, win%, sim equity (or static equity), marked * for observed.
+  Rack arm_leave;
+  rack_set_dist_size_and_reset(&arm_leave, cb->ld_size);
+  if (print_detail)
+    for (int i = 0; i < n; i++) {
+      const int idx = order[i];
+      const Move *m = move_list_get_move(ml, idx);
+
+      // Compute the leave for this arm.
+      rack_copy(&arm_leave, target_rack);
+      const game_event_t mtype = move_get_type(m);
+      if (mtype == GAME_EVENT_TILE_PLACEMENT_MOVE) {
+        const int tlen = move_get_tiles_length(m);
+        for (int t = 0; t < tlen; t++) {
+          const MachineLetter ml_tile = move_get_tile(m, t);
+          if (ml_tile != PLAYED_THROUGH_MARKER) {
+            rack_take_letter(&arm_leave, get_is_blanked(ml_tile)
+                                             ? BLANK_MACHINE_LETTER
+                                             : ml_tile);
+          }
+        }
+      } else if (mtype == GAME_EVENT_EXCHANGE) {
+        const int tlen = move_get_tiles_length(m);
+        for (int t = 0; t < tlen; t++) {
+          rack_take_letter(&arm_leave, move_get_tile(m, t));
+        }
+      }
+      // For pass, arm_leave == full rack (nothing played).
+
+      string_builder_clear(sb);
+      string_builder_add_move(sb, board, m, ld, /*add_score=*/true);
+      const char *move_str = string_builder_peek(sb);
+
+      StringBuilder *leave_sb = string_builder_create();
+      string_builder_add_rack(leave_sb, &arm_leave, ld, /*blanks_first=*/false);
+      const char *leave_str = string_builder_peek(leave_sb);
+
+      if (iters > 0) {
+        const double sim_eq = stat_get_mean(
+            simmed_play_get_equity_stat(sim_results_get_simmed_play(sr, idx)));
+        const double wp_pct =
+            100.0 * stat_get_mean(simmed_play_get_win_pct_stat(
+                        sim_results_get_simmed_play(sr, idx)));
+        fprintf(cb->f, "  %s %-32s  %-6s  wp=%5.1f%%  eq=%7.2f\n",
+                (idx == obs_idx) ? "*" : " ", move_str, leave_str, wp_pct,
+                sim_eq);
+      } else {
+        const double sim_eq = equity_to_double(move_get_equity(m));
+        fprintf(cb->f, "  %s %-32s  %-6s  static=%7.2f\n",
+                (idx == obs_idx) ? "*" : " ", move_str, leave_str, sim_eq);
+      }
+      string_builder_destroy(leave_sb);
+    }
+  string_builder_destroy(sb);
+
+  // Track static-eval-only leaves (no inner sim ran).
+  if (iters == 0)
+    cb->static_eval_count++;
+
+  // Track the minimum-gap leave (most plausible rack).
+  if (cb->total_leaves_seen == 0 || gap < cb->min_gap) {
+    cb->min_gap = gap;
+    rack_copy(&cb->min_gap_leave, leave);
+  }
+
+  // Compute KLV for this leave (deterministic lookup, same result every call).
+  const KLV *klv_data =
+      player_get_klv(game_get_player(inner_game, cb->target_index));
+  const double klv_val = equity_to_double(klv_get_leave_value(klv_data, leave));
+
+  // Accumulate running stats for distributional shift (all leaves, no limit).
+  {
+    Rack pool;
+    rack_set_dist_size_and_reset(&pool, cb->ld_size);
+    int bag_counts[MAX_ALPHABET_SIZE];
+    memset(bag_counts, 0, sizeof(bag_counts));
+    bag_increment_unseen_count(game_get_bag(inner_game), bag_counts);
+    for (int l = 0; l < cb->ld_size; l++) {
+      rack_add_letters(&pool, l, bag_counts[l]);
+    }
+    rack_union(&pool, leave);
+    const double raw = (double)get_number_of_draws_for_rack(&pool, leave);
+
+    double score = 0.0, vow = 0.0, con = 0.0, bl = 0.0;
+    for (int l = 0; l < cb->ld_size; l++) {
+      const int cnt = (int)rack_get_letter(leave, l);
+      if (cnt == 0)
+        continue;
+      if (l == BLANK_MACHINE_LETTER) {
+        bl += cnt;
+      } else if (ld_get_is_vowel(cb->ld, l)) {
+        vow += cnt;
+        score += cnt * equity_to_double(ld_get_score(cb->ld, l));
+      } else {
+        con += cnt;
+        score += cnt * equity_to_double(ld_get_score(cb->ld, l));
+      }
+    }
+    // Per-letter accumulation.
+    for (int l = 0; l < cb->ld_size; l++) {
+      const int cnt = (int)rack_get_letter(leave, l);
+      if (cnt == 0)
+        continue;
+      cb->raw_sum_letter[l] += raw * cnt;
+      cb->post_sum_letter[l] += raw * weight * cnt;
+    }
+
+    cb->total_raw += raw;
+    cb->total_posterior += raw * weight;
+    cb->raw_sum_klv += raw * klv_val;
+    cb->post_sum_klv += raw * weight * klv_val;
+    cb->raw_sum_score += raw * score;
+    cb->post_sum_score += raw * weight * score;
+    cb->raw_sum_vow += raw * vow;
+    cb->post_sum_vow += raw * weight * vow;
+    cb->raw_sum_con += raw * con;
+    cb->post_sum_con += raw * weight * con;
+    cb->raw_sum_bl += raw * bl;
+    cb->post_sum_bl += raw * weight * bl;
+    cb->total_leaves_seen++;
+
+    // Update top-K unique leaves by accumulated posterior.
+    const double ps = raw * weight;
+    int found = -1;
+    for (int j = 0; j < cb->top_count; j++) {
+      bool match = true;
+      for (int l = 0; l < cb->ld_size && match; l++) {
+        if (rack_get_letter(&cb->top_leaves[j].leave, l) !=
+            rack_get_letter(leave, l))
+          match = false;
+      }
+      if (match) {
+        found = j;
+        break;
+      }
+    }
+    if (found >= 0) {
+      cb->top_leaves[found].posterior += ps;
+      // Recompute min if we updated it.
+      if (found == cb->top_min_idx) {
+        cb->top_min_idx = 0;
+        for (int j = 1; j < cb->top_count; j++) {
+          if (cb->top_leaves[j].posterior <
+              cb->top_leaves[cb->top_min_idx].posterior)
+            cb->top_min_idx = j;
+        }
+      }
+    } else if (cb->top_count < MAX_SUMMARY_LEAVES) {
+      rack_copy(&cb->top_leaves[cb->top_count].leave, leave);
+      cb->top_leaves[cb->top_count].posterior = ps;
+      cb->top_leaves[cb->top_count].klv = klv_val;
+      if (cb->top_count == 0 || ps < cb->top_leaves[cb->top_min_idx].posterior)
+        cb->top_min_idx = cb->top_count;
+      cb->top_count++;
+    } else if (ps > cb->top_leaves[cb->top_min_idx].posterior) {
+      // Evict the minimum slot.
+      rack_copy(&cb->top_leaves[cb->top_min_idx].leave, leave);
+      cb->top_leaves[cb->top_min_idx].posterior = ps;
+      cb->top_leaves[cb->top_min_idx].klv = klv_val;
+      // Recompute new minimum.
+      cb->top_min_idx = 0;
+      for (int j = 1; j < cb->top_count; j++) {
+        if (cb->top_leaves[j].posterior <
+            cb->top_leaves[cb->top_min_idx].posterior)
+          cb->top_min_idx = j;
+      }
+    }
+  }
+}
+
+// ── Shared summary writer ────────────────────────────────────────────────────
+//
+// Uses top_leaves (top-K unique leaves by accumulated posterior) for the
+// per-leaf table with KLV computed at callback time.
+// Uses running accumulators for the distributional shift.
+static void write_simmedinf_summary(LeafCallbackCtx *cb,
+                                    InferenceResults *results,
+                                    const LetterDistribution *ld, int ld_size) {
+  (void)results; // leave_rack_list no longer needed for KLV
+  // Sort top_leaves descending by accumulated posterior.
+  for (int i = 1; i < cb->top_count; i++) {
+    LeafSummaryEntry key = cb->top_leaves[i];
+    int j = i - 1;
+    while (j >= 0 && cb->top_leaves[j].posterior < key.posterior) {
+      cb->top_leaves[j + 1] = cb->top_leaves[j];
+      j--;
+    }
+    cb->top_leaves[j + 1] = key;
+  }
+
+  FILE *f = cb->f;
+
+  // Report the minimum-gap leave (most plausible rack regardless of rejection).
+  if (cb->total_leaves_seen > 0) {
+    StringBuilder *msb = string_builder_create();
+    string_builder_add_rack(msb, &cb->min_gap_leave, ld,
+                            /*blanks_first=*/false);
+    fprintf(f, "\nMin-gap leave: %-10s  gap=%.2f\n", string_builder_peek(msb),
+            cb->min_gap);
+    string_builder_destroy(msb);
+  }
+
+  fprintf(f,
+          "\n=== SUMMARY (top %d leaves by posterior, %d total / "
+          "%d static-eval / %d simmed) ===\n",
+          cb->top_count, cb->total_leaves_seen, cb->static_eval_count,
+          cb->total_leaves_seen - cb->static_eval_count);
+  fprintf(f, "%-10s  %7s  %6s\n", "Leave", "PostWt%", "KLV");
+  fprintf(f, "%-10s  %7s  %6s\n", "-----", "-------", "---");
+
+  StringBuilder *sb = string_builder_create();
+  const double top_total =
+      cb->total_posterior > 0.0 ? cb->total_posterior : 1.0;
+  for (int i = 0; i < cb->top_count; i++) {
+    const LeafSummaryEntry *e = &cb->top_leaves[i];
+    const double post_pct = 100.0 * e->posterior / top_total;
+    string_builder_clear(sb);
+    string_builder_add_rack(sb, &e->leave, ld, /*blanks_first=*/false);
+    fprintf(f, "%-10s  %6.2f%%  %6.2f\n", string_builder_peek(sb), post_pct,
+            e->klv);
+  }
+  string_builder_destroy(sb);
+
+  // Distributional shift: prior vs posterior from running accumulators.
+  const double tr = cb->total_raw > 0.0 ? cb->total_raw : 1.0;
+  const double tp = cb->total_posterior > 0.0 ? cb->total_posterior : 1.0;
+  fprintf(f,
+          "\n=== DISTRIBUTIONAL SHIFT (posterior − prior, %d leaves) ===\n"
+          "%-12s  %8s  %8s  %8s\n"
+          "%-12s  %8s  %8s  %8s\n"
+          "%-12s  %8.3f  %8.3f  %+8.3f\n"
+          "%-12s  %8.3f  %8.3f  %+8.3f\n"
+          "%-12s  %8.3f  %8.3f  %+8.3f\n"
+          "%-12s  %8.3f  %8.3f  %+8.3f\n"
+          "%-12s  %8.3f  %8.3f  %+8.3f\n",
+          cb->total_leaves_seen, "Attribute", "Prior", "Posterior", "Diff",
+          "---------", "-----", "---------", "----", "LeaveValue",
+          cb->raw_sum_klv / tr, cb->post_sum_klv / tp,
+          cb->post_sum_klv / tp - cb->raw_sum_klv / tr, "TileScore",
+          cb->raw_sum_score / tr, cb->post_sum_score / tp,
+          cb->post_sum_score / tp - cb->raw_sum_score / tr, "Vowels",
+          cb->raw_sum_vow / tr, cb->post_sum_vow / tp,
+          cb->post_sum_vow / tp - cb->raw_sum_vow / tr, "Consonants",
+          cb->raw_sum_con / tr, cb->post_sum_con / tp,
+          cb->post_sum_con / tp - cb->raw_sum_con / tr, "Blanks",
+          cb->raw_sum_bl / tr, cb->post_sum_bl / tp,
+          cb->post_sum_bl / tp - cb->raw_sum_bl / tr);
+
+  // Per-letter expected count: prior vs posterior, sorted by diff descending.
+  // Collect letters with non-negligible prior or posterior.
+  typedef struct {
+    int ml;
+    double prior;
+    double post;
+    double diff;
+  } LetterStat;
+  LetterStat lstats[MAX_ALPHABET_SIZE];
+  int lstat_count = 0;
+  for (int l = 0; l < ld_size; l++) {
+    const double prior = cb->raw_sum_letter[l] / tr;
+    const double post = cb->post_sum_letter[l] / tp;
+    if (prior < 0.001 && post < 0.001)
+      continue;
+    lstats[lstat_count++] = (LetterStat){l, prior, post, post - prior};
+  }
+  // Sort by diff descending (biggest positive shift first).
+  for (int i = 1; i < lstat_count; i++) {
+    LetterStat key = lstats[i];
+    int j = i - 1;
+    while (j >= 0 && lstats[j].diff < key.diff) {
+      lstats[j + 1] = lstats[j];
+      j--;
+    }
+    lstats[j + 1] = key;
+  }
+
+  fprintf(f, "\n=== PER-LETTER EXPECTED COUNT IN LEAVE ===\n");
+  fprintf(f, "%-6s  %7s  %7s  %7s\n", "Letter", "Prior", "Post", "Diff");
+  fprintf(f, "%-6s  %7s  %7s  %7s\n", "------", "-----", "----", "----");
+  StringBuilder *lsb = string_builder_create();
+  Rack letter_rack;
+  rack_set_dist_size_and_reset(&letter_rack, ld_size);
+  for (int i = 0; i < lstat_count; i++) {
+    const LetterStat *s = &lstats[i];
+    rack_reset(&letter_rack);
+    rack_add_letter(&letter_rack, s->ml);
+    string_builder_clear(lsb);
+    string_builder_add_rack(lsb, &letter_rack, ld, /*blanks_first=*/false);
+    fprintf(f, "%-6s  %7.4f  %7.4f  %+7.4f\n", string_builder_peek(lsb),
+            s->prior, s->post, s->diff);
+  }
+  string_builder_destroy(lsb);
+}
+
+// ── On-demand: inspect leave weights after opponent plays 8D QINTAR ──────────
+//
+// Pre-play state: empty board, player 0 on turn.
+// Player 0 (target) rack: QINTARB (QINTAR + one unknown tile we're inferring).
+// Player 1 (nontarget, us) rack: ABCDEFG.
+// Observed move: 8D QINTAR (6-tile play → 1-tile leave, exhaustive inference).
+// Results written to /tmp/qintar_inference.txt.
+void test_qintar_simmedinf(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -wmp true -s1 equity -s2 equity -r1 all -r2 all "
+      "-numplays 1 -threads 10");
+  load_and_exec_config_or_die(
+      config, "cgp 15/15/15/15/15/15/15/15/15/15/15/15/15/15/15 "
+              "QINTARB/ABCDEFG 0/0 0 -lex CSW21");
+
+  ErrorStack *error_stack = error_stack_create();
+  WinPct *win_pcts = win_pct_create(config_get_data_paths(config),
+                                    DEFAULT_WIN_PCT, error_stack);
+  assert(error_stack_is_empty(error_stack));
+
+  const Game *game = config_get_game(config);
+  const LetterDistribution *ld = game_get_ld(game);
+  const int ld_size = ld_get_size(ld);
+
+  // Parse the observed move (player 0 plays QINTAR across from 8D).
+  ValidatedMoves *vms = validated_moves_create(
+      game, /*player_index=*/0, "8D QINTAR",
+      /*allow_phonies=*/true, /*allow_playthrough=*/false, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(validated_moves_get_number_of_moves(vms) == 1);
+  const Move *observed_move = validated_moves_get_move(vms, 0);
+
+  // Extract the tiles played (QINTAR → {Q,I,N,T,A,R}); blanks become
+  // BLANK_MACHINE_LETTER as in the static inference convention.
+  Rack target_played_tiles;
+  rack_set_dist_size_and_reset(&target_played_tiles, ld_size);
+  const int tiles_length = move_get_tiles_length(observed_move);
+  for (int i = 0; i < tiles_length; i++) {
+    MachineLetter ml = move_get_tile(observed_move, i);
+    if (ml != PLAYED_THROUGH_MARKER) {
+      rack_add_letter(&target_played_tiles,
+                      get_is_blanked(ml) ? BLANK_MACHINE_LETTER : ml);
+    }
+  }
+
+  Rack target_known_rack;
+  Rack nontarget_known_rack;
+  rack_set_dist_size_and_reset(&target_known_rack, ld_size);
+  // We (player 1) know our own rack.
+  rack_copy(&nontarget_known_rack, player_get_rack(game_get_player(game, 1)));
+
+  InferenceArgs base_args;
+  infer_args_fill(&base_args, /*num_plays=*/15, int_to_equity(0), NULL, game,
+                  /*num_threads=*/10, /*parent_worker_thread_index=*/0,
+                  /*print_interval=*/0, config_get_thread_control(config),
+                  /*use_game_history=*/false,
+                  /*use_inference_cutoff_optimization=*/true,
+                  /*target_index=*/0,
+                  /*target_score=*/move_get_score(observed_move),
+                  /*target_num_exch=*/0, &target_played_tiles,
+                  &target_known_rack, &nontarget_known_rack);
+
+  InferenceResults *results = inference_results_create(NULL);
+
+  LeafCallbackCtx cb_ctx = {.f = fopen("/tmp/qintar_inference.txt", "w"),
+                            .ld = ld,
+                            .ld_size = ld_size,
+                            .target_index = 0};
+  assert(cb_ctx.f);
+  fprintf(cb_ctx.f,
+          "Simmed inference: opponent played 8D QINTAR (score: %d)\n"
+          "Our rack (nontarget): ABCDEFG\n"
+          "Leave size: 1 tile (exhaustive)\n"
+          "* = observed move (QINTAR)\n",
+          equity_to_int(move_get_score(observed_move)));
+
+  SimmedInferenceArgs si_args = {
+      .base = &base_args,
+      .observed_move = observed_move,
+      .win_pcts = win_pcts,
+      .num_candidate_plays = 5,
+      .num_inner_sim_plies = 2,
+      .probe_iterations = 120,
+      .full_iterations = 600,
+      .time_budget_s = 30.0,
+      .sim_equity_margin = 3.0,
+      .leave_callback = qintar_leave_callback,
+      .leave_callback_data = &cb_ctx,
+  };
+
+  thread_control_set_status(config_get_thread_control(config),
+                            THREAD_CONTROL_STATUS_STARTED);
+  simmed_infer(&si_args, results, error_stack);
+  assert(error_stack_is_empty(error_stack));
+
+  write_simmedinf_summary(&cb_ctx, results, ld, ld_size);
+  fclose(cb_ctx.f);
+
+  printf("Written to /tmp/qintar_inference.txt (%d leaves evaluated)\n",
+         cb_ctx.total_leaves_seen);
+
+  inference_results_destroy(results);
+  validated_moves_destroy(vms);
+  win_pct_destroy(win_pcts);
+  error_stack_destroy(error_stack);
+  config_destroy(config);
+}
+
+// ── On-demand: inspect leave weights after opponent plays 8D DINGS
+// ────────────
+//
+// Pre-play state: empty board, player 0 on turn.
+// Player 0 (target) rack: DINGS + 2 unknown tiles (leave_size = 2, exhaustive).
+// Player 1 (nontarget, us) rack: ABCDEFG.
+// Observed move: 8D DINGS (5-tile play).
+// Results written to /tmp/dings_inference.txt.
+// Per-leave detail is printed only for leaves with weight >= 0.05.
+void test_dings_simmedinf(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -wmp true -s1 equity -s2 equity -r1 all -r2 all "
+      "-numplays 1 -threads 10");
+  // Target rack in CGP: DINGS + arbitrary filler tiles (we override via
+  // InferenceArgs; the exact filler doesn't affect inference).
+  load_and_exec_config_or_die(
+      config, "cgp 15/15/15/15/15/15/15/15/15/15/15/15/15/15/15 "
+              "DINGSAA/ABCDEFG 0/0 0 -lex CSW21");
+
+  ErrorStack *error_stack = error_stack_create();
+  WinPct *win_pcts = win_pct_create(config_get_data_paths(config),
+                                    DEFAULT_WIN_PCT, error_stack);
+  assert(error_stack_is_empty(error_stack));
+
+  const Game *game = config_get_game(config);
+  const LetterDistribution *ld = game_get_ld(game);
+  const int ld_size = ld_get_size(ld);
+
+  // Parse observed move: 8D DINGS.
+  ValidatedMoves *vms = validated_moves_create(
+      game, /*player_index=*/0, "8D DINGS",
+      /*allow_phonies=*/true, /*allow_playthrough=*/false, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(validated_moves_get_number_of_moves(vms) == 1);
+  const Move *observed_move = validated_moves_get_move(vms, 0);
+
+  // Extract tiles played (D, I, N, G, S).
+  Rack target_played_tiles;
+  rack_set_dist_size_and_reset(&target_played_tiles, ld_size);
+  const int tiles_length = move_get_tiles_length(observed_move);
+  for (int i = 0; i < tiles_length; i++) {
+    MachineLetter ml = move_get_tile(observed_move, i);
+    if (ml != PLAYED_THROUGH_MARKER) {
+      rack_add_letter(&target_played_tiles,
+                      get_is_blanked(ml) ? BLANK_MACHINE_LETTER : ml);
+    }
+  }
+
+  Rack target_known_rack;
+  Rack nontarget_known_rack;
+  rack_set_dist_size_and_reset(&target_known_rack, ld_size);
+  rack_copy(&nontarget_known_rack, player_get_rack(game_get_player(game, 1)));
+
+  InferenceArgs base_args;
+  infer_args_fill(&base_args, /*num_plays=*/15, int_to_equity(0), NULL, game,
+                  /*num_threads=*/10, /*parent_worker_thread_index=*/0,
+                  /*print_interval=*/0, config_get_thread_control(config),
+                  /*use_game_history=*/false,
+                  /*use_inference_cutoff_optimization=*/true,
+                  /*target_index=*/0,
+                  /*target_score=*/move_get_score(observed_move),
+                  /*target_num_exch=*/0, &target_played_tiles,
+                  &target_known_rack, &nontarget_known_rack);
+
+  InferenceResults *results = inference_results_create(NULL);
+
+  LeafCallbackCtx cb_ctx = {.f = fopen("/tmp/dings_inference.txt", "w"),
+                            .ld = ld,
+                            .ld_size = ld_size,
+                            .target_index = 0,
+                            .min_weight_to_print = 0.05};
+  assert(cb_ctx.f);
+  fprintf(cb_ctx.f,
+          "Simmed inference: opponent played 8D DINGS (score: %d)\n"
+          "Our rack (nontarget): ABCDEFG\n"
+          "Leave size: 2 tiles (exhaustive)\n"
+          "* = observed move (DINGS)\n"
+          "(Per-leave detail shown only for weight >= 0.05)\n",
+          equity_to_int(move_get_score(observed_move)));
+
+  SimmedInferenceArgs si_args = {
+      .base = &base_args,
+      .observed_move = observed_move,
+      .win_pcts = win_pcts,
+      .num_candidate_plays = 5,
+      .num_inner_sim_plies = 2,
+      .probe_iterations = 120,
+      .full_iterations = 600,
+      .time_budget_s = 60.0,
+      .sim_equity_margin = 3.0,
+      .leave_callback = qintar_leave_callback,
+      .leave_callback_data = &cb_ctx,
+  };
+
+  thread_control_set_status(config_get_thread_control(config),
+                            THREAD_CONTROL_STATUS_STARTED);
+  simmed_infer(&si_args, results, error_stack);
+  assert(error_stack_is_empty(error_stack));
+
+  write_simmedinf_summary(&cb_ctx, results, ld, ld_size);
+  fclose(cb_ctx.f);
+
+  printf("Written to /tmp/dings_inference.txt (%d leaves evaluated, "
+         "%d in summary)\n",
+         cb_ctx.total_leaves_seen,
+         (int)(inference_results_get_leave_rack_list(results)
+                   ? leave_rack_list_get_count(
+                         inference_results_get_leave_rack_list(results))
+                   : 0));
+
+  inference_results_destroy(results);
+  validated_moves_destroy(vms);
+  win_pct_destroy(win_pcts);
+  error_stack_destroy(error_stack);
+  config_destroy(config);
+}
+
+// ── On-demand: inspect leave weights after opponent plays 8G QI ──────────────
+//
+// Pre-play state: empty board, player 0 on turn.
+// Player 0 (target) rack: QI + 5 unknown tiles (leave_size = 5, MC mode).
+// Player 1 (nontarget, us) rack: ABCDEFG.
+// Observed move: 8G QI (2-tile play, score: 22).
+// Results written to /tmp/qi_inference.txt.
+// Per-leave detail is printed only for leaves with weight >= 0.10.
+void test_qi_simmedinf(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -wmp true -s1 equity -s2 equity -r1 all -r2 all "
+      "-numplays 1 -threads 10");
+  load_and_exec_config_or_die(
+      config, "cgp 15/15/15/15/15/15/15/15/15/15/15/15/15/15/15 "
+              "QIAAAAA/ABCDEFG 0/0 0 -lex CSW21");
+
+  ErrorStack *error_stack = error_stack_create();
+  WinPct *win_pcts = win_pct_create(config_get_data_paths(config),
+                                    DEFAULT_WIN_PCT, error_stack);
+  assert(error_stack_is_empty(error_stack));
+
+  const Game *game = config_get_game(config);
+  const LetterDistribution *ld = game_get_ld(game);
+  const int ld_size = ld_get_size(ld);
+
+  // Parse observed move: 8G QI (horizontal).
+  ValidatedMoves *vms = validated_moves_create(
+      game, /*player_index=*/0, "8G QI",
+      /*allow_phonies=*/true, /*allow_playthrough=*/false, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(validated_moves_get_number_of_moves(vms) == 1);
+  const Move *observed_move = validated_moves_get_move(vms, 0);
+
+  // Extract tiles played (Q, I).
+  Rack target_played_tiles;
+  rack_set_dist_size_and_reset(&target_played_tiles, ld_size);
+  const int tiles_length = move_get_tiles_length(observed_move);
+  for (int i = 0; i < tiles_length; i++) {
+    MachineLetter ml = move_get_tile(observed_move, i);
+    if (ml != PLAYED_THROUGH_MARKER) {
+      rack_add_letter(&target_played_tiles,
+                      get_is_blanked(ml) ? BLANK_MACHINE_LETTER : ml);
+    }
+  }
+
+  Rack target_known_rack;
+  Rack nontarget_known_rack;
+  rack_set_dist_size_and_reset(&target_known_rack, ld_size);
+  rack_copy(&nontarget_known_rack, player_get_rack(game_get_player(game, 1)));
+
+  InferenceArgs base_args;
+  infer_args_fill(&base_args, /*num_plays=*/15, int_to_equity(0), NULL, game,
+                  /*num_threads=*/10, /*parent_worker_thread_index=*/0,
+                  /*print_interval=*/0, config_get_thread_control(config),
+                  /*use_game_history=*/false,
+                  /*use_inference_cutoff_optimization=*/true,
+                  /*target_index=*/0,
+                  /*target_score=*/move_get_score(observed_move),
+                  /*target_num_exch=*/0, &target_played_tiles,
+                  &target_known_rack, &nontarget_known_rack);
+
+  InferenceResults *results = inference_results_create(NULL);
+
+  LeafCallbackCtx cb_ctx = {.f = fopen("/tmp/qi_inference.txt", "w"),
+                            .ld = ld,
+                            .ld_size = ld_size,
+                            .target_index = 0,
+                            .min_weight_to_print = 0.1};
+  assert(cb_ctx.f);
+  fprintf(cb_ctx.f,
+          "Simmed inference: opponent played 8G QI (score: %d)\n"
+          "Our rack (nontarget): ABCDEFG\n"
+          "Leave size: 5 tiles (Monte Carlo, time-budgeted)\n"
+          "* = observed move (QI)\n"
+          "(Per-leave detail shown only for weight >= 0.10)\n",
+          equity_to_int(move_get_score(observed_move)));
+
+  SimmedInferenceArgs si_args = {
+      .base = &base_args,
+      .observed_move = observed_move,
+      .win_pcts = win_pcts,
+      .num_candidate_plays = 5,
+      .num_inner_sim_plies = 2,
+      .probe_iterations = 120,
+      .full_iterations = 600,
+      .time_budget_s = 120.0,
+      .sim_equity_margin = 3.0,
+      .leave_callback = qintar_leave_callback,
+      .leave_callback_data = &cb_ctx,
+  };
+
+  thread_control_set_status(config_get_thread_control(config),
+                            THREAD_CONTROL_STATUS_STARTED);
+  simmed_infer(&si_args, results, error_stack);
+  assert(error_stack_is_empty(error_stack));
+
+  write_simmedinf_summary(&cb_ctx, results, ld, ld_size);
+  fclose(cb_ctx.f);
+
+  printf("Written to /tmp/qi_inference.txt (%d leaves sampled, "
+         "%d in summary)\n",
+         cb_ctx.total_leaves_seen,
+         (int)(inference_results_get_leave_rack_list(results)
+                   ? leave_rack_list_get_count(
+                         inference_results_get_leave_rack_list(results))
+                   : 0));
+
+  inference_results_destroy(results);
+  validated_moves_destroy(vms);
+  win_pct_destroy(win_pcts);
+  error_stack_destroy(error_stack);
+  config_destroy(config);
+}
+
+// ── On-demand: inspect leave weights after opponent plays 8H ES ──────────────
+//
+// Pre-play state: empty board, player 0 on turn.
+// Player 0 (target) rack: ES + 5 unknown tiles (leave_size = 5, MC mode).
+// Player 1 (nontarget, us) rack: ABCDEFG.
+// Observed move: 8H ES (2-tile play, center square).
+// Results written to /tmp/es_inference.txt.
+// Per-leave detail is printed only for leaves with weight >= 0.10.
+void test_es_simmedinf(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -wmp true -s1 equity -s2 equity -r1 all -r2 all "
+      "-numplays 1 -threads 10");
+  load_and_exec_config_or_die(
+      config, "cgp 15/15/15/15/15/15/15/15/15/15/15/15/15/15/15 "
+              "ESAAAAA/ABCDEFG 0/0 0 -lex CSW21");
+
+  ErrorStack *error_stack = error_stack_create();
+  WinPct *win_pcts = win_pct_create(config_get_data_paths(config),
+                                    DEFAULT_WIN_PCT, error_stack);
+  assert(error_stack_is_empty(error_stack));
+
+  const Game *game = config_get_game(config);
+  const LetterDistribution *ld = game_get_ld(game);
+  const int ld_size = ld_get_size(ld);
+
+  // Parse observed move: 8H ES (horizontal, center square).
+  ValidatedMoves *vms = validated_moves_create(
+      game, /*player_index=*/0, "8H ES",
+      /*allow_phonies=*/true, /*allow_playthrough=*/false, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(validated_moves_get_number_of_moves(vms) == 1);
+  const Move *observed_move = validated_moves_get_move(vms, 0);
+
+  // Extract tiles played (E, S).
+  Rack target_played_tiles;
+  rack_set_dist_size_and_reset(&target_played_tiles, ld_size);
+  const int tiles_length = move_get_tiles_length(observed_move);
+  for (int i = 0; i < tiles_length; i++) {
+    MachineLetter ml = move_get_tile(observed_move, i);
+    if (ml != PLAYED_THROUGH_MARKER) {
+      rack_add_letter(&target_played_tiles,
+                      get_is_blanked(ml) ? BLANK_MACHINE_LETTER : ml);
+    }
+  }
+
+  Rack target_known_rack;
+  Rack nontarget_known_rack;
+  rack_set_dist_size_and_reset(&target_known_rack, ld_size);
+  rack_copy(&nontarget_known_rack, player_get_rack(game_get_player(game, 1)));
+
+  InferenceArgs base_args;
+  infer_args_fill(&base_args, /*num_plays=*/15, int_to_equity(0), NULL, game,
+                  /*num_threads=*/10, /*parent_worker_thread_index=*/0,
+                  /*print_interval=*/0, config_get_thread_control(config),
+                  /*use_game_history=*/false,
+                  /*use_inference_cutoff_optimization=*/true,
+                  /*target_index=*/0,
+                  /*target_score=*/move_get_score(observed_move),
+                  /*target_num_exch=*/0, &target_played_tiles,
+                  &target_known_rack, &nontarget_known_rack);
+
+  InferenceResults *results = inference_results_create(NULL);
+
+  LeafCallbackCtx cb_ctx = {.f = fopen("/tmp/es_inference.txt", "w"),
+                            .ld = ld,
+                            .ld_size = ld_size,
+                            .target_index = 0,
+                            .min_weight_to_print = 0.1};
+  assert(cb_ctx.f);
+  fprintf(cb_ctx.f,
+          "Simmed inference: opponent played 8H ES (score: %d)\n"
+          "Our rack (nontarget): ABCDEFG\n"
+          "Leave size: 5 tiles (Monte Carlo, time-budgeted)\n"
+          "* = observed move (ES)\n"
+          "(Per-leave detail shown only for weight >= 0.10)\n",
+          equity_to_int(move_get_score(observed_move)));
+
+  SimmedInferenceArgs si_args = {
+      .base = &base_args,
+      .observed_move = observed_move,
+      .win_pcts = win_pcts,
+      .num_candidate_plays = 5,
+      .num_inner_sim_plies = 2,
+      .probe_iterations = 30,
+      .full_iterations = 30,
+      .time_budget_s = 30.0,
+      .sim_equity_margin = 3.0,
+      .leave_callback = qintar_leave_callback,
+      .leave_callback_data = &cb_ctx,
+  };
+
+  thread_control_set_status(config_get_thread_control(config),
+                            THREAD_CONTROL_STATUS_STARTED);
+  simmed_infer(&si_args, results, error_stack);
+  assert(error_stack_is_empty(error_stack));
+
+  write_simmedinf_summary(&cb_ctx, results, ld, ld_size);
+  fclose(cb_ctx.f);
+
+  printf("Written to /tmp/es_inference.txt (%d leaves sampled, "
+         "%d in summary)\n",
+         cb_ctx.total_leaves_seen, cb_ctx.top_count);
+
+  inference_results_destroy(results);
+  validated_moves_destroy(vms);
+  win_pct_destroy(win_pcts);
+  error_stack_destroy(error_stack);
+  config_destroy(config);
+}
+
+// ── On-demand: inspect leave weights after opponent plays 8G EAU ─────────────
+//
+// Pre-play state: empty board, player 0 on turn.
+// Player 0 (target) rack: EAU + 4 unknown tiles (leave_size = 4, MC mode).
+// Player 1 (nontarget, us) rack: ABCDEFG.
+// Observed move: 8G EAU (3-tile play).
+// Results written to /tmp/eau_inference.txt.
+void test_euoi_simmedinf(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -wmp true -s1 equity -s2 equity -r1 all -r2 all "
+      "-numplays 1 -threads 10");
+  load_and_exec_config_or_die(
+      config, "cgp 15/15/15/15/15/15/15/15/15/15/15/15/15/15/15 "
+              "EUOIAAA/ABCDEFG 0/0 0 -lex CSW21");
+
+  ErrorStack *error_stack = error_stack_create();
+  WinPct *win_pcts = win_pct_create(config_get_data_paths(config),
+                                    DEFAULT_WIN_PCT, error_stack);
+  assert(error_stack_is_empty(error_stack));
+
+  const Game *game = config_get_game(config);
+  const LetterDistribution *ld = game_get_ld(game);
+  const int ld_size = ld_get_size(ld);
+
+  ValidatedMoves *vms = validated_moves_create(
+      game, /*player_index=*/0, "8G EUOI",
+      /*allow_phonies=*/true, /*allow_playthrough=*/false, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(validated_moves_get_number_of_moves(vms) == 1);
+  const Move *observed_move = validated_moves_get_move(vms, 0);
+
+  Rack target_played_tiles;
+  rack_set_dist_size_and_reset(&target_played_tiles, ld_size);
+  const int tiles_length = move_get_tiles_length(observed_move);
+  for (int i = 0; i < tiles_length; i++) {
+    MachineLetter ml = move_get_tile(observed_move, i);
+    if (ml != PLAYED_THROUGH_MARKER) {
+      rack_add_letter(&target_played_tiles,
+                      get_is_blanked(ml) ? BLANK_MACHINE_LETTER : ml);
+    }
+  }
+
+  Rack target_known_rack;
+  Rack nontarget_known_rack;
+  rack_set_dist_size_and_reset(&target_known_rack, ld_size);
+  rack_copy(&nontarget_known_rack, player_get_rack(game_get_player(game, 1)));
+
+  InferenceArgs base_args;
+  infer_args_fill(&base_args, /*num_plays=*/15, int_to_equity(0), NULL, game,
+                  /*num_threads=*/10, /*parent_worker_thread_index=*/0,
+                  /*print_interval=*/0, config_get_thread_control(config),
+                  /*use_game_history=*/false,
+                  /*use_inference_cutoff_optimization=*/true,
+                  /*target_index=*/0,
+                  /*target_score=*/move_get_score(observed_move),
+                  /*target_num_exch=*/0, &target_played_tiles,
+                  &target_known_rack, &nontarget_known_rack);
+
+  InferenceResults *results = inference_results_create(NULL);
+
+  LeafCallbackCtx cb_ctx = {.f = fopen("/tmp/euoi_inference.txt", "w"),
+                            .ld = ld,
+                            .ld_size = ld_size,
+                            .target_index = 0,
+                            .min_weight_to_print = 0.1};
+  assert(cb_ctx.f);
+  fprintf(cb_ctx.f,
+          "Simmed inference: opponent played 8G EUOI (score: %d)\n"
+          "Our rack (nontarget): ABCDEFG\n"
+          "Leave size: 3 tiles (Monte Carlo, time-budgeted)\n"
+          "* = observed move (EUOI)\n"
+          "(Per-leave detail shown only for weight >= 0.10)\n",
+          equity_to_int(move_get_score(observed_move)));
+
+  SimmedInferenceArgs si_args = {
+      .base = &base_args,
+      .observed_move = observed_move,
+      .win_pcts = win_pcts,
+      .num_candidate_plays = 5,
+      .num_inner_sim_plies = 2,
+      .probe_iterations = 30,
+      .full_iterations = 30,
+      .time_budget_s = 30.0,
+      .sim_equity_margin = 3.0,
+      .leave_callback = qintar_leave_callback,
+      .leave_callback_data = &cb_ctx,
+  };
+
+  thread_control_set_status(config_get_thread_control(config),
+                            THREAD_CONTROL_STATUS_STARTED);
+  simmed_infer(&si_args, results, error_stack);
+  assert(error_stack_is_empty(error_stack));
+
+  write_simmedinf_summary(&cb_ctx, results, ld, ld_size);
+  fclose(cb_ctx.f);
+
+  printf("Written to /tmp/euoi_inference.txt (%d leaves sampled, "
+         "%d in summary)\n",
+         cb_ctx.total_leaves_seen, cb_ctx.top_count);
+
+  inference_results_destroy(results);
+  validated_moves_destroy(vms);
+  win_pct_destroy(win_pcts);
+  error_stack_destroy(error_stack);
+  config_destroy(config);
+}
+
+void test_eau_simmedinf(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -wmp true -s1 equity -s2 equity -r1 all -r2 all "
+      "-numplays 1 -threads 10");
+  load_and_exec_config_or_die(
+      config, "cgp 15/15/15/15/15/15/15/15/15/15/15/15/15/15/15 "
+              "EAUAAAA/ABCDEFG 0/0 0 -lex CSW21");
+
+  ErrorStack *error_stack = error_stack_create();
+  WinPct *win_pcts = win_pct_create(config_get_data_paths(config),
+                                    DEFAULT_WIN_PCT, error_stack);
+  assert(error_stack_is_empty(error_stack));
+
+  const Game *game = config_get_game(config);
+  const LetterDistribution *ld = game_get_ld(game);
+  const int ld_size = ld_get_size(ld);
+
+  ValidatedMoves *vms = validated_moves_create(
+      game, /*player_index=*/0, "8G EAU",
+      /*allow_phonies=*/true, /*allow_playthrough=*/false, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(validated_moves_get_number_of_moves(vms) == 1);
+  const Move *observed_move = validated_moves_get_move(vms, 0);
+
+  Rack target_played_tiles;
+  rack_set_dist_size_and_reset(&target_played_tiles, ld_size);
+  const int tiles_length = move_get_tiles_length(observed_move);
+  for (int i = 0; i < tiles_length; i++) {
+    MachineLetter ml = move_get_tile(observed_move, i);
+    if (ml != PLAYED_THROUGH_MARKER) {
+      rack_add_letter(&target_played_tiles,
+                      get_is_blanked(ml) ? BLANK_MACHINE_LETTER : ml);
+    }
+  }
+
+  Rack target_known_rack;
+  Rack nontarget_known_rack;
+  rack_set_dist_size_and_reset(&target_known_rack, ld_size);
+  rack_copy(&nontarget_known_rack, player_get_rack(game_get_player(game, 1)));
+
+  InferenceArgs base_args;
+  infer_args_fill(&base_args, /*num_plays=*/15, int_to_equity(0), NULL, game,
+                  /*num_threads=*/10, /*parent_worker_thread_index=*/0,
+                  /*print_interval=*/0, config_get_thread_control(config),
+                  /*use_game_history=*/false,
+                  /*use_inference_cutoff_optimization=*/true,
+                  /*target_index=*/0,
+                  /*target_score=*/move_get_score(observed_move),
+                  /*target_num_exch=*/0, &target_played_tiles,
+                  &target_known_rack, &nontarget_known_rack);
+
+  InferenceResults *results = inference_results_create(NULL);
+
+  LeafCallbackCtx cb_ctx = {.f = fopen("/tmp/eau_inference.txt", "w"),
+                            .ld = ld,
+                            .ld_size = ld_size,
+                            .target_index = 0,
+                            .min_weight_to_print = 0.1};
+  assert(cb_ctx.f);
+  fprintf(cb_ctx.f,
+          "Simmed inference: opponent played 8G EAU (score: %d)\n"
+          "Our rack (nontarget): ABCDEFG\n"
+          "Leave size: 4 tiles (Monte Carlo, time-budgeted)\n"
+          "* = observed move (EAU)\n"
+          "(Per-leave detail shown only for weight >= 0.10)\n",
+          equity_to_int(move_get_score(observed_move)));
+
+  SimmedInferenceArgs si_args = {
+      .base = &base_args,
+      .observed_move = observed_move,
+      .win_pcts = win_pcts,
+      .num_candidate_plays = 5,
+      .num_inner_sim_plies = 2,
+      .probe_iterations = 30,
+      .full_iterations = 30,
+      .time_budget_s = 30.0,
+      .sim_equity_margin = 3.0,
+      .leave_callback = qintar_leave_callback,
+      .leave_callback_data = &cb_ctx,
+  };
+
+  thread_control_set_status(config_get_thread_control(config),
+                            THREAD_CONTROL_STATUS_STARTED);
+  simmed_infer(&si_args, results, error_stack);
+  assert(error_stack_is_empty(error_stack));
+
+  write_simmedinf_summary(&cb_ctx, results, ld, ld_size);
+  fclose(cb_ctx.f);
+
+  printf("Written to /tmp/eau_inference.txt (%d leaves sampled, "
+         "%d in summary)\n",
+         cb_ctx.total_leaves_seen, cb_ctx.top_count);
+
+  inference_results_destroy(results);
+  validated_moves_destroy(vms);
+  win_pct_destroy(win_pcts);
+  error_stack_destroy(error_stack);
+  config_destroy(config);
+}
+
+// Pre-play state: empty board, player 0 on turn.
+// Player 0 (target) rack: GUV + 4 unknown tiles (leave_size = 4, MC mode).
+// Player 1 (nontarget, us) rack: ABCDEFG.
+// Observed move: 8G GUV (3-tile play).
+// Results written to /tmp/guv_inference.txt.
+void test_guvy_simmedinf(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -wmp true -s1 equity -s2 equity -r1 all -r2 all "
+      "-numplays 1 -threads 10");
+  load_and_exec_config_or_die(
+      config, "cgp 15/15/15/15/15/15/15/15/15/15/15/15/15/15/15 "
+              "GUVAAAA/ABCDEFG 0/0 0 -lex CSW21");
+
+  ErrorStack *error_stack = error_stack_create();
+  WinPct *win_pcts = win_pct_create(config_get_data_paths(config),
+                                    DEFAULT_WIN_PCT, error_stack);
+  assert(error_stack_is_empty(error_stack));
+
+  const Game *game = config_get_game(config);
+  const LetterDistribution *ld = game_get_ld(game);
+  const int ld_size = ld_get_size(ld);
+
+  ValidatedMoves *vms = validated_moves_create(
+      game, /*player_index=*/0, "8G GUV",
+      /*allow_phonies=*/true, /*allow_playthrough=*/false, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(validated_moves_get_number_of_moves(vms) == 1);
+  const Move *observed_move = validated_moves_get_move(vms, 0);
+
+  Rack target_played_tiles;
+  rack_set_dist_size_and_reset(&target_played_tiles, ld_size);
+  const int tiles_length = move_get_tiles_length(observed_move);
+  for (int i = 0; i < tiles_length; i++) {
+    MachineLetter ml = move_get_tile(observed_move, i);
+    if (ml != PLAYED_THROUGH_MARKER) {
+      rack_add_letter(&target_played_tiles,
+                      get_is_blanked(ml) ? BLANK_MACHINE_LETTER : ml);
+    }
+  }
+
+  Rack target_known_rack;
+  Rack nontarget_known_rack;
+  rack_set_dist_size_and_reset(&target_known_rack, ld_size);
+  rack_copy(&nontarget_known_rack, player_get_rack(game_get_player(game, 1)));
+
+  InferenceArgs base_args;
+  infer_args_fill(&base_args, /*num_plays=*/15, int_to_equity(0), NULL, game,
+                  /*num_threads=*/10, /*parent_worker_thread_index=*/0,
+                  /*print_interval=*/0, config_get_thread_control(config),
+                  /*use_game_history=*/false,
+                  /*use_inference_cutoff_optimization=*/true,
+                  /*target_index=*/0,
+                  /*target_score=*/move_get_score(observed_move),
+                  /*target_num_exch=*/0, &target_played_tiles,
+                  &target_known_rack, &nontarget_known_rack);
+
+  InferenceResults *results = inference_results_create(NULL);
+
+  LeafCallbackCtx cb_ctx = {.f = fopen("/tmp/guv_inference.txt", "w"),
+                            .ld = ld,
+                            .ld_size = ld_size,
+                            .target_index = 0,
+                            .min_weight_to_print = 0.1};
+  assert(cb_ctx.f);
+  fprintf(cb_ctx.f,
+          "Simmed inference: opponent played 8G GUV (score: %d)\n"
+          "Our rack (nontarget): ABCDEFG\n"
+          "Leave size: 4 tiles (Monte Carlo, time-budgeted)\n"
+          "* = observed move (GUV)\n"
+          "(Per-leave detail shown only for weight >= 0.10)\n",
+          equity_to_int(move_get_score(observed_move)));
+
+  SimmedInferenceArgs si_args = {
+      .base = &base_args,
+      .observed_move = observed_move,
+      .win_pcts = win_pcts,
+      .num_candidate_plays = 5,
+      .num_inner_sim_plies = 2,
+      .probe_iterations = 30,
+      .full_iterations = 30,
+      .time_budget_s = 30.0,
+      .sim_equity_margin = 3.0,
+      .leave_callback = qintar_leave_callback,
+      .leave_callback_data = &cb_ctx,
+  };
+
+  thread_control_set_status(config_get_thread_control(config),
+                            THREAD_CONTROL_STATUS_STARTED);
+  simmed_infer(&si_args, results, error_stack);
+  assert(error_stack_is_empty(error_stack));
+
+  write_simmedinf_summary(&cb_ctx, results, ld, ld_size);
+  fclose(cb_ctx.f);
+
+  printf("Written to /tmp/guv_inference.txt (%d leaves sampled, "
+         "%d in summary)\n",
+         cb_ctx.total_leaves_seen, cb_ctx.top_count);
+
+  inference_results_destroy(results);
+  validated_moves_destroy(vms);
+  win_pct_destroy(win_pcts);
+  error_stack_destroy(error_stack);
+  config_destroy(config);
+}

--- a/test/simmedinf_test.h
+++ b/test/simmedinf_test.h
@@ -1,0 +1,13 @@
+#ifndef SIMMEDINF_TEST_H
+#define SIMMEDINF_TEST_H
+
+void test_simmedinf(void);
+void test_qintar_simmedinf(void);
+void test_dings_simmedinf(void);
+void test_qi_simmedinf(void);
+void test_es_simmedinf(void);
+void test_eau_simmedinf(void);
+void test_euoi_simmedinf(void);
+void test_guvy_simmedinf(void);
+
+#endif

--- a/test/test.c
+++ b/test/test.c
@@ -175,6 +175,7 @@ static TestEntry on_demand_test_table[] = {
     {"peginf", test_peginf},
     {"peginfbench", test_peginf_benchmark},
     {"peginfbenchgen", test_peginf_benchmark_generate},
+    {"peginfbenchgt", test_peginf_benchmark_groundtruth},
     {"peginfendrepro", test_peginf_endgame_repro},
     // Simmed inference (simulation-based opponent-leave inference)
     {"simmedinf_exchange", test_simmedinf},

--- a/test/test.c
+++ b/test/test.c
@@ -174,6 +174,7 @@ static TestEntry on_demand_test_table[] = {
     // Pre-endgame (PEG) inference
     {"peginf", test_peginf},
     {"peginfbench", test_peginf_benchmark},
+    {"peginfbenchgen", test_peginf_benchmark_generate},
     // Simmed inference (simulation-based opponent-leave inference)
     {"simmedinf_exchange", test_simmedinf},
     {"simmedinf", test_simmedinf_benchmark},

--- a/test/test.c
+++ b/test/test.c
@@ -175,6 +175,7 @@ static TestEntry on_demand_test_table[] = {
     {"peginf", test_peginf},
     {"peginfbench", test_peginf_benchmark},
     {"peginfbenchgen", test_peginf_benchmark_generate},
+    {"peginfendrepro", test_peginf_endgame_repro},
     // Simmed inference (simulation-based opponent-leave inference)
     {"simmedinf_exchange", test_simmedinf},
     {"simmedinf", test_simmedinf_benchmark},

--- a/test/test.c
+++ b/test/test.c
@@ -52,6 +52,7 @@
 #include "rack_test.h"
 #include "random_variable_test.h"
 #include "shadow_test.h"
+#include "peginf_benchmark.h"
 #include "peginf_test.h"
 #include "sim_benchmark_test.h"
 #include "sim_test.h"
@@ -172,6 +173,7 @@ static TestEntry on_demand_test_table[] = {
     {"simbench", test_sim_benchmark},
     // Pre-endgame (PEG) inference
     {"peginf", test_peginf},
+    {"peginfbench", test_peginf_benchmark},
     // Simmed inference (simulation-based opponent-leave inference)
     {"simmedinf_exchange", test_simmedinf},
     {"simmedinf", test_simmedinf_benchmark},

--- a/test/test.c
+++ b/test/test.c
@@ -52,6 +52,7 @@
 #include "rack_test.h"
 #include "random_variable_test.h"
 #include "shadow_test.h"
+#include "peginf_test.h"
 #include "sim_benchmark_test.h"
 #include "sim_test.h"
 #include "simmedinf_benchmark.h"
@@ -169,6 +170,8 @@ static TestEntry on_demand_test_table[] = {
     {"kue", test_kue},
     {"monsterq", test_monster_q},
     {"simbench", test_sim_benchmark},
+    // Pre-endgame (PEG) inference
+    {"peginf", test_peginf},
     // Simmed inference (simulation-based opponent-leave inference)
     {"simmedinf_exchange", test_simmedinf},
     {"simmedinf", test_simmedinf_benchmark},

--- a/test/test.c
+++ b/test/test.c
@@ -54,6 +54,8 @@
 #include "shadow_test.h"
 #include "sim_benchmark_test.h"
 #include "sim_test.h"
+#include "simmedinf_benchmark.h"
+#include "simmedinf_test.h"
 #include "stats_test.h"
 #include "string_util_test.h"
 #include "transposition_table_test.h"
@@ -167,6 +169,16 @@ static TestEntry on_demand_test_table[] = {
     {"kue", test_kue},
     {"monsterq", test_monster_q},
     {"simbench", test_sim_benchmark},
+    // Simmed inference (simulation-based opponent-leave inference)
+    {"simmedinf_exchange", test_simmedinf},
+    {"simmedinf", test_simmedinf_benchmark},
+    {"qintar", test_qintar_simmedinf},
+    {"dings", test_dings_simmedinf},
+    {"qi", test_qi_simmedinf},
+    {"es", test_es_simmedinf},
+    {"eau", test_eau_simmedinf},
+    {"euoi", test_euoi_simmedinf},
+    {"guvy", test_guvy_simmedinf},
     {"ap_rit", test_autoplay_rit_correctness},
     // Pre-endgame (PEG) solver
     {"peg1pb", test_peg_1bag_pass_best},


### PR DESCRIPTION
## What this is

An investigation into whether pre-endgame (PEG) opponent-leave inference improves move selection, plus the solver machinery it required. Draft while the final experiment (realistic sim+peg opponent generation, matched to the inference's opponent model) is still running.

## Engine changes (`src/impl/peg.c`, `src/impl/peg.h`, `src/ent/alias_method.h`)

- **Exact evaluation of opponent-leave priors.** A point-mass prior pins the leave into every enumerated split (bounds by `unseen − leave`, weights by the full-`unseen` multinomial — the reduced-pool weights bias win% by a per-outcome 1–6× factor, brute-force verified). Small multi-leaf supports (≤4 distinct leaves) enumerate exactly with per-leaf `w_i/total_i` normalization (unit test: two identical leaves ≡ point-mass to 1e-9).
- **Deep-stage exact/sampled support evaluation** implemented but **gated off by default** (`PEG_DEEP_ENUM`/`PEG_DEEP_SAMPLE`): with current inference accuracy, trusting the prior at depth *underperforms* uniform (see findings).
- **Empty-support priors fall back to uniform** everywhere (previously zeroed every candidate's win%, ranking the field by garbage).
- `PegResult.planned_num_stages` introspection; alias-method support-iteration accessors.

## Benchmark harness (`test/peginf_benchmark.c`, on-demand test `peginfbenchgt`)

Paired ground-truth A/B (uniform vs inference-weighted PEG move, MC playouts against the opponent's *true* leave), inference calibration mode (true-leave found/mass/rank vs the runtime distribution, stratified by leave size), slice gates (leave size × opponent bag, top-N aggregated priors), the peg-inference empty-support repair (0 → ~60-leaf supports), and realistic sim+peg game generation. All env-configurable.

## Findings so far (details in benchmark comments / session log)

- **The solver converts accurate priors**: a psychic (true-leave) prior gains **+0.024 win%** overall, up to **+0.234** on kept-5/one-in-bag positions.
- **No real-inference application has beaten uniform yet** (full trust −0.171, sampled −0.071, every gate/slice ≤0 on fresh seeds). Mechanism: the prior only helps when the true leave carries **dominant mass**; current inference tops out at a few percent (containment without concentration bets on specific wrong racks and loses to uniform's diffuse coverage).
- **Matched-model experiment (completed)**: with `PEGBENCH_REALOPP` the generated opponent plays the sim+peg policy the inference actually models. Result: inference *ranking* improves substantially (sim k=4 top-1 accuracy 7% → 33%), confirming the earlier numbers were suppressed by opponent-model mismatch — but posterior *mass* on the true leave stays at 0.03–0.06, and the gated GT remains negative (−0.087, 0 wins / 3 losses over 9 differing positions, truth in the trusted top-4 only 15% of the time). Conclusion: behavioral-consistency inference at these budgets cannot produce truth-dominant mass even with an exactly-matched opponent model; the +0.024/+0.234 psychic ceiling stands as the bar for any future inference method, and this harness measures a candidate against it in about an hour.

## Testing

`peginf` (schedule/normalization/sampling unit tests) and the PEG regression suite (`peg1pb`, `peg1onyx`, `peg2axe`, `peg3pah`, `peg4pond`, `pegtopkall`, `pegngap`) pass; `peg2acid`/`peg*pess` are pre-existing 120s-budget-edge flakes on this machine (fail identically on baseline, no-prior tests unaffected by these changes). Engine changes were adversarially reviewed (multi-lens) — the review caught and we fixed the multinomial weight bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKQniDvyWewhbMhuCrFKS2
