### PR TITLE
format: rewrap game_string.c line to satisfy clang-format-20

### DIFF
--- a/src/str/game_string.c
+++ b/src/str/game_string.c
@@ -436,7 +436,8 @@ void string_builder_add_game_internal(
     string_builder_add_spaces(game_string, 3);
     if (i == UNSEEN_START_ROW) {
       string_builder_add_formatted_string(game_string, "Unseen: %d (%dv | %dc)",
-                                          num_bag_letters, num_bag_vowels, num_bag_consonants);
+                                          num_bag_letters, num_bag_vowels,
+                                          num_bag_consonants);
     } else if (i > UNSEEN_START_ROW && letter_index < num_bag_letters) {
       for (int j = 0; j < letters_per_row && letter_index < num_bag_letters;
            j++) {


### PR DESCRIPTION
Mechanical clang-format-20 rewrap of one `string_builder_add_formatted_string` call left unformatted by #581 — `lint-fast` currently fails on main itself (and on every branch built from it) because of it. No functional change.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_019SJ8s3CzxxYNbQpQvDAjrX