### PR TITLE
sim: include horizon leftover in the utility blend's spread term

### DIFF
--- a/src/impl/random_variable.c
+++ b/src/impl/random_variable.c
@@ -535,14 +535,23 @@ double rv_sim_sample(RandomVariables *rvs, const uint64_t play_index,
       player_get_score(game_get_player(game, 1 - simmer->initial_player));
   simmed_play_add_equity_stat(simmed_play, simmer->initial_spread, spread,
                               leftover);
+  const game_end_reason_t game_end_reason = game_get_game_end_reason(game);
   const double wpct = simmed_play_add_win_pct_stat(
-      simmer->win_pcts, simmed_play, spread, leftover,
-      game_get_game_end_reason(game),
+      simmer->win_pcts, simmed_play, spread, leftover, game_end_reason,
       // number of tiles unseen to us: bag tiles + tiles on opp rack.
       bag_get_letters(game_get_bag(game)) +
           rack_get_total_letters(player_get_rack(
               game_get_player(game, 1 - simmer->initial_player))),
       plies % 2);
+  // Blend with the same spread the win% lookup used: an unfinished
+  // rollout's spread gets the horizon leftover added (the KLV leave value
+  // the equity stat also credits), so the utility's spread term values
+  // leaves the same way the other two metrics do. A finished rollout's
+  // spread is already exact and gets no leftover, matching
+  // simmed_play_add_win_pct_stat. Captured before game_unplay_last_move
+  // below restores the pre-rollout game state.
+  const Equity blend_spread =
+      game_end_reason == GAME_END_REASON_NONE ? spread + leftover : spread;
   // reset to first state. we only need to restore one backup.
   game_unplay_last_move(game);
   return_rack_to_bag(game, player_off_turn_index);
@@ -555,7 +564,7 @@ double rv_sim_sample(RandomVariables *rvs, const uint64_t play_index,
   }
   sim_results_increment_iteration_count(sim_results);
 
-  return sim_utility_blend(wpct, spread, simmer->utility_w_winpct,
+  return sim_utility_blend(wpct, blend_spread, simmer->utility_w_winpct,
                            simmer->utility_w_spread,
                            simmer->utility_spread_scale);
 }


### PR DESCRIPTION
Confirms the AVA/PSOAI hypothesis from Discord: the blend's spread term was the only one of the three per-rollout metrics that ignored the horizon **leftover** (KLV leave value accumulated on the last two plies):

| Metric | Spread input |
|---|---|
| Equity stat | `spread − initial_spread + leftover` |
| Win% lookup | `spread + leftover` (when game unfinished) |
| **`sim_utility_blend`** | **bare `spread`** ← fixed |

So with `uspread > 0`, BU undervalued plays whose equity lives in their leave and overvalued raw-point plays with weak leaves — exactly the observed case where PSOAI (29 pts, `AV` leave, sim Eq −1.09) ranked above AVA (19 pts, `IOPS` leave, sim Eq +1.57) on BU despite losing on both displayed metrics.

The fix mirrors the win% convention: unfinished rollouts blend on `spread + leftover`; finished rollouts blend on the exact final spread (no leftover), same as `simmed_play_add_win_pct_stat`. The end reason is captured before `game_unplay_last_move` restores the pre-rollout state.

`sim` and `rv` suites pass; `sim_utility_blend` itself is unchanged (pure function — its unit tests are unaffected). Behavior changes only for `uspread > 0`.

**Play-strength A/B (overnight, 10s/turn)**: two binaries differing by exactly this commit, each playing uspread=0.5 vs a uspread=0 control (identical control code in both), paired games on common seeds, 4-ply sims, 10s/turn time budget, alternating chunks — **101 seed-chunks / 1,212 pairs / 2,424 games per arm**:

| Arm | Spread/pair vs control | Win% |
|---|---|---|
| broken blend (main) | +5.40 (p=0.050) | 50.66% |
| fixed blend (this PR) | +5.87 (p=0.001) | 50.68% |
| **paired fixed−broken** | **+0.47, p=0.86** | — |

So this is a **correctness fix, not a strength fix**: whole-game outcomes are statistically identical (the per-turn misvaluations evidently wash out over a game), and both variants keep a similar spread edge over pure win%. The reason to merge is metric coherence — BU orderings now agree with the Eq/Wp columns' leave treatment, which matters for #584's AEqL, where BU defines the "best" reference move and misorderings like AVA/PSOAI directly pollute the mistake metric.

Relevant to #582 (uspread default) and to the AEqL work in #584.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_019SJ8s3CzxxYNbQpQvDAjrX
