### PR TITLE
endgame: fix misleading actual_move matching comment

### DIFF
--- a/src/impl/endgame.h
+++ b/src/impl/endgame.h
@@ -216,8 +216,9 @@ typedef struct EndgameArgs {
   // value for this specific move in the same search that finds the best
   // move, instead of requiring a second endgame_solve call. Must be a legal
   // move for the position (game's player-on-turn rack); matched against
-  // generated root moves by board position + tiles (see
-  // move_get_similarity_key), not by pointer identity. Read only during the
+  // generated root moves by exact board effect -- score, coordinates,
+  // direction, and ordered tiles (see compare_moves_without_equity), not by
+  // pointer identity. Read only during the
   // call; ownership stays with the caller. If the move can't be found among
   // the root moves, ENDGAME_RESULT_ACTUAL is left unset (see
   // endgame_results_get_actual_move_found). Kept at root index 0 through


### PR DESCRIPTION
## Summary

The `EndgameArgs.actual_move` doc comment said the move is "matched against generated root moves by board position + tiles (see `move_get_similarity_key`)". That cross-reference is misleading: `move_get_similarity_key` is **order-insensitive** — it keys on the tile *multiset* plus score, so it collapses anagrams (e.g. `STEARIC`/`RACIEST` at the same anchor).

The actual matching (`augment_single_tile_actual_move`, `force_actual_move_to_front`, `extract_actual_move_pvline`) uses `compare_moves_without_equity`, which is **order-sensitive** — it compares the full ordered tile sequence and so distinguishes anagrams. `move_get_similarity_key` has no functional use anywhere in the endgame (the TT keys on the board zobrist; root dedup uses `compare_moves_without_equity`).

Repointing the comment at `compare_moves_without_equity` keeps a reader from inferring the endgame groups distinct anagrams — or from "fixing" the matching to match the stale comment.

## Change

Comment-only. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)