### PR TITLE
Use const pointers for strstr/strchr results

### DIFF
--- a/src/impl/config.c
+++ b/src/impl/config.c
@@ -6539,7 +6539,7 @@ void config_load_parsed_args(Config *config,
         // Add the rest of the remaining string to the next parg value,
         // which basically treats the rest of the string after the command
         // as a single argument.
-        char *cmd_content = strchr(cmd, ' ');
+        const char *cmd_content = strchr(cmd, ' ');
         if (cmd_content) {
           cmd_content = cmd_content + 1;
         }

--- a/src/impl/get_gcg.c
+++ b/src/impl/get_gcg.c
@@ -39,7 +39,7 @@ static void get_xt_gcg(const char *identifier, GetGCGResult *result,
                        ErrorStack *error_stack) {
   char game_id_str[MAX_GAME_ID_LENGTH + 1] = {0};
   // Check if this is a Cross-tables URL first
-  char *xt_url_start = strstr(identifier, XTABLES_URL);
+  const char *xt_url_start = strstr(identifier, XTABLES_URL);
   if (xt_url_start) {
     size_t game_id_str_len = 0;
     xt_url_start += XTABLES_URL_LENGTH;
@@ -111,7 +111,7 @@ static void get_woogles_gcg(const char *identifier, GetGCGResult *result,
                             ErrorStack *error_stack) {
   char game_id_str[MAX_GAME_ID_LENGTH + 1] = {0};
 
-  char *woogles_url_start = strstr(identifier, WOOGLES_URL);
+  const char *woogles_url_start = strstr(identifier, WOOGLES_URL);
   if (woogles_url_start) {
     size_t game_id_str_len = 0;
     woogles_url_start += WOOGLES_URL_LENGTH;


### PR DESCRIPTION
Small toolchain fix, independent of the cmd_api work stacked on top of it.

Newer glibc makes `strstr`/`strchr` const-correct via generic-selection macros, so assigning their result on a `const char *` input to a plain `char *` fails with `-Werror=discarded-qualifiers` on gcc 15. This makes those three assignments `const char *`.

No behavior change.

This is the base of a 4-PR stack completing the cmd_api embedding API: #599 (correctness) → #600 (libmagpie.so) → #601 (async/FFI) → #602 (examples). Merging this first lets the rest retarget cleanly onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
