### PR TITLE
Add libmagpie shared library build target

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Build release test binary
         run: make magpie_test BUILD=release
 
+      - name: Build shared library
+        run: make libmagpie
+
       - name: Run release tests
         run: ./bin/magpie_test
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,12 @@ venv/
 
 # Compiled libraries
 *.a
+*.so
+*.dylib
+
+# Editor/debugger scratch
+tags
+.gdb_history
 PR_DESCRIPTION.md
 PR_TITLE.txt
 SPEEDUP_NOTES.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ make magpie_test               # build test binary
 make magpie_test BUILD=release # release test binary
 make magpie BUILD=profile      # profiling build
 make magpie BUILD=thread       # thread sanitizer build
+make libmagpie                 # shared library (bin/libmagpie.so); API is src/impl/cmd_api.h
 make clean                     # remove build artifacts
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -58,12 +58,15 @@ cflags.thread := -g -O0 -Wall -Wno-trigraphs -Wextra -Wshadow -Wstrict-prototype
 cflags.vlg := -g -O0 -Wall -Wno-trigraphs -Wextra
 cflags.cov := -g -O0 -Wall -Wno-trigraphs -Wextra --coverage
 cflags.release := -O3 -flto -march=native -DNDEBUG -Wall -Wno-trigraphs
+# Shared library flavor: release optimization plus -fPIC, no sanitizers
+cflags.lib := -O3 -flto -march=native -DNDEBUG -Wall -Wno-trigraphs -fPIC
 # Test-specific flags: like release but without DNDEBUG (asserts always enabled in tests)
 cflags.test_release := -O3 -flto -march=native -Wall -Wno-trigraphs
 cflags.profile := -O3 -g -march=native -DNDEBUG -Wall -Wno-trigraphs -fno-omit-frame-pointer -mllvm -inline-threshold=0
 lflags.cov := --coverage
 
 ldflags.dev := -pthread $(FSAN_ARG)
+ldflags.lib := -pthread
 ldflags.thread := -pthread -fsanitize=thread
 ldflags.vlg := -pthread
 ldflags.release := -pthread
@@ -85,12 +88,37 @@ LFLAGS := ${lflags.${BUILD}}
 LDFLAGS  := ${ldflags.${BUILD}}
 LDLIBS   := -lm
 
-.PHONY: all clean iwyu
+.PHONY: all clean iwyu libmagpie
 
 all: magpie magpie_test
 
 libmagpie_core.a: $(OBJ_SRC)
 	ar rcs $@ $^
+
+# Shared library for embedding magpie; the API surface is src/impl/cmd_api.h
+# and only magpie_* symbols are exported. Re-invokes make with BUILD=lib so
+# objects are always compiled with -fPIC and without sanitizers.
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+SHARED_LIB := $(BIN_DIR)/libmagpie.dylib
+else
+SHARED_LIB := $(BIN_DIR)/libmagpie.so
+endif
+
+libmagpie:
+	@$(MAKE) BUILD=lib $(SHARED_LIB)
+
+$(OBJ_DIR)/libmagpie.map: | $(OBJ_DIR)
+	printf '{ global: magpie_*; local: *; };\n' > $@
+
+$(OBJ_DIR)/libmagpie.exports: | $(OBJ_DIR)
+	printf '_magpie_*\n' > $@
+
+$(BIN_DIR)/libmagpie.so: $(OBJ_SRC) $(OBJ_DIR)/libmagpie.map | $(BIN_DIR)
+	$(CC) -shared $(LDFLAGS) $(LFLAGS) $(OBJ_SRC) $(LDLIBS) -Wl,--version-script=$(OBJ_DIR)/libmagpie.map -o $@
+
+$(BIN_DIR)/libmagpie.dylib: $(OBJ_SRC) $(OBJ_DIR)/libmagpie.exports | $(BIN_DIR)
+	$(CC) -dynamiclib $(LDFLAGS) $(LFLAGS) $(OBJ_SRC) $(LDLIBS) -Wl,-exported_symbols_list,$(OBJ_DIR)/libmagpie.exports -o $@
 
 magpie: $(OBJ_SRC) $(OBJ_CMD) | $(BIN_DIR)
 	$(CC) $(LDFLAGS) $(LFLAGS) $^ $(LDLIBS) -o $(BIN_DIR)/$@

--- a/src/impl/cmd_api.h
+++ b/src/impl/cmd_api.h
@@ -8,6 +8,10 @@
 // struct retains the internal game state between commands, and the caller
 // is responsible for freeing all returned strings with free().
 //
+// Build the embeddable shared library with `make libmagpie`; it produces
+// bin/libmagpie.so (bin/libmagpie.dylib on macOS) exporting only the
+// magpie_* functions declared here.
+//
 // Command output is machine readable by default. Use
 // magpie_run_sync_human_readable to get output formatted for display
 // instead. In either case, an explicit -hr argument in the command string


### PR DESCRIPTION
Second of four stacked PRs for the `cmd_api` embedding API. **Based on #599** — review that one first.

Adds a real shared-library build so magpie can be embedded through `cmd_api.h`.

- `make libmagpie` produces `bin/libmagpie.so` (`bin/libmagpie.dylib` on macOS) under a dedicated `BUILD=lib` flavor: release optimization plus `-fPIC`, no sanitizers.
- A generated linker version script (exported-symbols list on macOS) restricts the exported surface to the `magpie_*` functions declared in `cmd_api.h` — verified with `nm -D` that exactly the 10 API functions are exported and no internal symbols leak.
- The release CI job builds the library so it can't silently rot.
- gitignore shared-library and editor scratch artifacts; document `make libmagpie` in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
