### PR TITLE
cmd_api: add async execution, direct command results, FFI helpers

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -102,7 +102,7 @@ jobs:
           - shard: config
             tests: "config movegen gameplay players string alpha ld l leavemap kwg bag rack bitrack board layout cs move game vm shadow eq eqadj stats infer rv am"
           - shard: rest
-            tests: "hm math bai command gcg words wordprune kwgmaker cgp rl ch cv cd wmp wmpmaker wmg winpct zobrist tt load"
+            tests: "hm math bai command cmdapi gcg words wordprune kwgmaker cgp rl ch cv cd wmp wmpmaker wmg winpct zobrist tt load"
           - shard: ap_rit
             tests: "ap_rit"
     steps:

--- a/src/impl/cmd_api.c
+++ b/src/impl/cmd_api.c
@@ -1,5 +1,7 @@
 #include "cmd_api.h"
 
+#include "../compat/cpthread.h"
+#include "../def/cpthread_defs.h"
 #include "../def/thread_control_defs.h"
 #include "../ent/thread_control.h"
 #include "../util/io_util.h"
@@ -27,21 +29,55 @@ struct Magpie {
   Config *config;
   ErrorStack *error;
   char *output;
+  cpthread_t async_thread;
+  bool async_thread_joinable;
+  cmd_exit_code last_exit_code;
 };
 
-Magpie *magpie_create(const char *data_paths) {
+Magpie *magpie_create_with_options(const char *data_paths,
+                                   const char *settings_filename,
+                                   bool use_wmp) {
   Magpie *mp = malloc_or_die(sizeof(Magpie));
   mp->error = error_stack_create();
-  const ConfigArgs args = {
-      .data_paths = data_paths, .settings_filename = NULL, .use_wmp = false};
+  const ConfigArgs args = {.data_paths = data_paths,
+                           .settings_filename = settings_filename,
+                           .use_wmp = use_wmp};
   mp->config = config_create(&args, mp->error);
   mp->output = empty_string();
+  mp->async_thread_joinable = false;
+  mp->last_exit_code = MAGPIE_SUCCESS;
   return mp;
+}
+
+Magpie *magpie_create(const char *data_paths) {
+  return magpie_create_with_options(data_paths, NULL, false);
+}
+
+// Joins a finished async worker thread if one exists. Returns true if a
+// worker is still running, in which case no other command may start and
+// the caller must not touch the error stack or output.
+static bool async_command_is_active(Magpie *mp) {
+  if (!mp->async_thread_joinable) {
+    return false;
+  }
+  const thread_control_status_t status =
+      thread_control_get_status(config_get_thread_control(mp->config));
+  if (status == THREAD_CONTROL_STATUS_FINISHED) {
+    cpthread_join(mp->async_thread);
+    mp->async_thread_joinable = false;
+    return false;
+  }
+  return true;
 }
 
 void magpie_destroy(Magpie *mp) {
   if (!mp) {
     return;
+  }
+  if (mp->async_thread_joinable) {
+    magpie_stop_current_command(mp);
+    cpthread_join(mp->async_thread);
+    mp->async_thread_joinable = false;
   }
   config_destroy(mp->config);
   error_stack_destroy(mp->error);
@@ -49,24 +85,8 @@ void magpie_destroy(Magpie *mp) {
   free(mp);
 }
 
-static cmd_exit_code run_sync_with_output_format(Magpie *mp,
-                                                 const char *command,
-                                                 bool human_readable) {
-  free(mp->output);
-  mp->output = NULL;
-  if (!mp->config) {
-    mp->output = empty_string();
-    error_stack_push(
-        mp->error, ERROR_STATUS_CMD_API_UNINITIALIZED,
-        string_duplicate("cannot run command: magpie creation failed"));
-    return MAGPIE_DID_NOT_RUN;
-  }
-  config_set_human_readable(mp->config, human_readable);
-  const bool command_ran =
-      run_str_api_command(mp->config, mp->error, command, &mp->output);
-  if (!mp->output) {
-    mp->output = empty_string();
-  }
+static cmd_exit_code exit_code_from_error_stack(const Magpie *mp,
+                                                bool command_ran) {
   if (error_stack_is_empty(mp->error)) {
     return MAGPIE_SUCCESS;
   }
@@ -76,12 +96,96 @@ static cmd_exit_code run_sync_with_output_format(Magpie *mp,
   return MAGPIE_DID_NOT_RUN;
 }
 
+static cmd_exit_code run_sync_with_output_format(Magpie *mp,
+                                                 const char *command,
+                                                 bool human_readable) {
+  if (async_command_is_active(mp)) {
+    return MAGPIE_DID_NOT_RUN;
+  }
+  free(mp->output);
+  mp->output = NULL;
+  if (!mp->config) {
+    mp->output = empty_string();
+    error_stack_push(
+        mp->error, ERROR_STATUS_CMD_API_UNINITIALIZED,
+        string_duplicate("cannot run command: magpie creation failed"));
+    mp->last_exit_code = MAGPIE_DID_NOT_RUN;
+    return mp->last_exit_code;
+  }
+  config_set_human_readable(mp->config, human_readable);
+  const bool command_ran =
+      run_str_api_command(mp->config, mp->error, command, &mp->output);
+  if (!mp->output) {
+    mp->output = empty_string();
+  }
+  mp->last_exit_code = exit_code_from_error_stack(mp, command_ran);
+  return mp->last_exit_code;
+}
+
 cmd_exit_code magpie_run_sync(Magpie *mp, const char *command) {
   return run_sync_with_output_format(mp, command, false);
 }
 
 cmd_exit_code magpie_run_sync_human_readable(Magpie *mp, const char *command) {
   return run_sync_with_output_format(mp, command, true);
+}
+
+static void *async_command_worker(void *arg) {
+  Magpie *mp = arg;
+  const bool command_ran =
+      config_run_str_api_command(mp->config, mp->error, &mp->output);
+  if (!mp->output) {
+    mp->output = empty_string();
+  }
+  mp->last_exit_code = exit_code_from_error_stack(mp, command_ran);
+  return NULL;
+}
+
+static cmd_exit_code run_async_with_output_format(Magpie *mp,
+                                                  const char *command,
+                                                  bool human_readable) {
+  if (async_command_is_active(mp)) {
+    return MAGPIE_DID_NOT_RUN;
+  }
+  free(mp->output);
+  mp->output = NULL;
+  if (!mp->config) {
+    mp->output = empty_string();
+    error_stack_push(
+        mp->error, ERROR_STATUS_CMD_API_UNINITIALIZED,
+        string_duplicate("cannot run command: magpie creation failed"));
+    mp->last_exit_code = MAGPIE_DID_NOT_RUN;
+    return mp->last_exit_code;
+  }
+  config_set_human_readable(mp->config, human_readable);
+  // Load synchronously so parse and data-loading errors are reported to
+  // the caller immediately; only execution happens on the worker thread.
+  // The command string is fully consumed by loading, so the worker does
+  // not need a copy of it.
+  if (!load_command_sync(mp->config, mp->error, command)) {
+    mp->output = empty_string();
+    mp->last_exit_code = MAGPIE_DID_NOT_RUN;
+    return mp->last_exit_code;
+  }
+  cpthread_create(&mp->async_thread, async_command_worker, mp);
+  mp->async_thread_joinable = true;
+  return MAGPIE_SUCCESS;
+}
+
+cmd_exit_code magpie_run_async(Magpie *mp, const char *command) {
+  return run_async_with_output_format(mp, command, false);
+}
+
+cmd_exit_code magpie_run_async_human_readable(Magpie *mp, const char *command) {
+  return run_async_with_output_format(mp, command, true);
+}
+
+cmd_exit_code magpie_await(Magpie *mp) {
+  if (mp->async_thread_joinable) {
+    cpthread_join(mp->async_thread);
+    mp->async_thread_joinable = false;
+  }
+  return mp->last_exit_code;
 }
 
 bool magpie_has_error(const Magpie *mp) {
@@ -129,3 +233,5 @@ magpie_thread_status magpie_get_thread_status(const Magpie *mp) {
   ThreadControl *tc = config_get_thread_control(mp->config);
   return (magpie_thread_status)thread_control_get_status(tc);
 }
+
+void magpie_free_string(char *str) { free(str); }

--- a/src/impl/cmd_api.h
+++ b/src/impl/cmd_api.h
@@ -68,6 +68,12 @@ typedef enum {
 // commands return MAGPIE_DID_NOT_RUN.
 Magpie *magpie_create(const char *data_paths);
 
+// Like magpie_create, with explicit control over the settings filename
+// (NULL for the default) and whether word map (WMP) files are used for
+// move generation.
+Magpie *magpie_create_with_options(const char *data_paths,
+                                   const char *settings_filename, bool use_wmp);
+
 void magpie_destroy(Magpie *mp);
 
 // Runs a command to completion, storing its output in machine-readable
@@ -76,6 +82,22 @@ cmd_exit_code magpie_run_sync(Magpie *mp, const char *command);
 
 // Same as magpie_run_sync, but stores output formatted for human display.
 cmd_exit_code magpie_run_sync_human_readable(Magpie *mp, const char *command);
+
+// Starts a command on a background thread and returns immediately. Returns
+// MAGPIE_SUCCESS if the command started, or MAGPIE_DID_NOT_RUN if it could
+// not (parse and data-loading errors are reported synchronously, and only
+// one command may run at a time). While a command is running, only
+// magpie_get_thread_status, magpie_get_last_command_status_message, and
+// magpie_stop_current_command may be called on this handle; call
+// magpie_await before using any other function.
+cmd_exit_code magpie_run_async(Magpie *mp, const char *command);
+
+// Same as magpie_run_async, but stores output formatted for human display.
+cmd_exit_code magpie_run_async_human_readable(Magpie *mp, const char *command);
+
+// Waits for the running async command (if any) to finish and returns the
+// exit code of the most recently completed command.
+cmd_exit_code magpie_await(Magpie *mp);
 
 // Returns true if an error is pending on the error stack.
 bool magpie_has_error(const Magpie *mp);
@@ -94,6 +116,11 @@ char *magpie_get_last_command_output(const Magpie *mp);
 void magpie_stop_current_command(Magpie *mp);
 
 magpie_thread_status magpie_get_thread_status(const Magpie *mp);
+
+// Frees a string returned by any magpie_* function. Equivalent to free();
+// provided so callers (especially FFI bindings) do not need to share the
+// library's allocator.
+void magpie_free_string(char *str);
 
 #ifdef __cplusplus
 }

--- a/src/impl/config.c
+++ b/src/impl/config.c
@@ -7989,7 +7989,10 @@ void execute_sim(Config *config, ErrorStack *error_stack) {
 
 char *str_api_sim(Config *config, ErrorStack *error_stack) {
   impl_sim(config, ARG_TOKEN_SIM, 0, error_stack);
-  return empty_string();
+  if (!error_stack_is_empty(error_stack)) {
+    return empty_string();
+  }
+  return impl_show_moves_or_sim_results(config, error_stack);
 }
 
 void execute_snoprune(Config *config, ErrorStack *error_stack) {
@@ -8002,7 +8005,10 @@ void execute_snoprune(Config *config, ErrorStack *error_stack) {
 
 char *str_api_snoprune(Config *config, ErrorStack *error_stack) {
   impl_snoprune(config, error_stack);
-  return empty_string();
+  if (!error_stack_is_empty(error_stack)) {
+    return empty_string();
+  }
+  return impl_show_moves_or_sim_results(config, error_stack);
 }
 
 void execute_gen_and_sim(Config *config, ErrorStack *error_stack) {
@@ -8015,7 +8021,10 @@ void execute_gen_and_sim(Config *config, ErrorStack *error_stack) {
 
 char *str_api_gen_and_sim(Config *config, ErrorStack *error_stack) {
   impl_gen_and_sim(config, error_stack);
-  return empty_string();
+  if (!error_stack_is_empty(error_stack)) {
+    return empty_string();
+  }
+  return impl_show_moves_or_sim_results(config, error_stack);
 }
 
 void execute_rack_and_gen(Config *config, ErrorStack *error_stack) {
@@ -8044,7 +8053,10 @@ void execute_rack_and_gen_and_sim(Config *config, ErrorStack *error_stack) {
 
 char *str_api_rack_and_gen_and_sim(Config *config, ErrorStack *error_stack) {
   impl_rack_and_gen_and_sim(config, error_stack);
-  return empty_string();
+  if (!error_stack_is_empty(error_stack)) {
+    return empty_string();
+  }
+  return impl_show_moves_or_sim_results(config, error_stack);
 }
 
 void execute_infer(Config *config, ErrorStack *error_stack) {
@@ -8057,7 +8069,10 @@ void execute_infer(Config *config, ErrorStack *error_stack) {
 
 char *str_api_infer(Config *config, ErrorStack *error_stack) {
   impl_infer(config, error_stack);
-  return empty_string();
+  if (!error_stack_is_empty(error_stack)) {
+    return empty_string();
+  }
+  return impl_show_inference(config, error_stack);
 }
 
 void execute_endgame(Config *config, ErrorStack *error_stack) {
@@ -8070,7 +8085,10 @@ void execute_endgame(Config *config, ErrorStack *error_stack) {
 
 char *str_api_endgame(Config *config, ErrorStack *error_stack) {
   impl_endgame(config, error_stack);
-  return empty_string();
+  if (!error_stack_is_empty(error_stack)) {
+    return empty_string();
+  }
+  return impl_show_endgame(config, error_stack);
 }
 
 void execute_peg(Config *config, ErrorStack *error_stack) {
@@ -8085,7 +8103,10 @@ void execute_peg(Config *config, ErrorStack *error_stack) {
 
 char *str_api_peg(Config *config, ErrorStack *error_stack) {
   impl_peg(config, error_stack);
-  return empty_string();
+  if (!error_stack_is_empty(error_stack)) {
+    return empty_string();
+  }
+  return impl_show_peg(config, error_stack);
 }
 
 void execute_autoplay(Config *config, ErrorStack *error_stack) {
@@ -8630,49 +8651,57 @@ void impl_analyze(Config *config, AnalyzeSummary *summary,
   error_stack_destroy(analyze_error_stack);
 }
 
+// Builds the display string for an analyze summary, consuming the
+// summary's error_details string builder.
+char *analyze_summary_to_string(AnalyzeSummary *summary) {
+  int curr_row = 0;
+  int curr_col = 0;
+  StringGrid *sg = string_grid_create(4, 2, 1);
+  string_grid_set_cell(sg, curr_row, curr_col++, string_duplicate("Success"));
+  string_grid_set_cell(sg, curr_row, curr_col,
+                       get_formatted_string("%d", summary->success_count));
+  curr_row++;
+  curr_col = 0;
+  string_grid_set_cell(sg, curr_row, curr_col++, string_duplicate("Skipped"));
+  string_grid_set_cell(sg, curr_row, curr_col,
+                       get_formatted_string("%d", summary->skipped_count));
+  curr_row++;
+  curr_col = 0;
+  string_grid_set_cell(sg, curr_row, curr_col++, string_duplicate("Error"));
+  string_grid_set_cell(sg, curr_row, curr_col,
+                       get_formatted_string("%d", summary->error_count));
+  curr_row++;
+  curr_col = 0;
+  string_grid_set_cell(sg, curr_row, curr_col++, string_duplicate("Unstarted"));
+  string_grid_set_cell(sg, curr_row, curr_col,
+                       get_formatted_string("%d", summary->not_started_count));
+  StringBuilder *summary_sb = string_builder_create();
+  string_builder_add_string(summary_sb, "\n");
+  string_builder_add_string_grid(summary_sb, sg, false);
+  string_grid_destroy(sg);
+  string_builder_add_string(
+      summary_sb, summary->interrupted ? "\nFinished (user interrupt)\n"
+                                       : "\nFinished (all games analyzed)\n");
+  if (summary->error_details) {
+    string_builder_add_string(summary_sb, "\n=== Errors ===\n");
+    char *error_details_str = string_builder_dump(summary->error_details, NULL);
+    string_builder_add_string(summary_sb, error_details_str);
+    free(error_details_str);
+    string_builder_destroy(summary->error_details);
+    summary->error_details = NULL;
+  }
+  char *summary_str = string_builder_dump(summary_sb, NULL);
+  string_builder_destroy(summary_sb);
+  return summary_str;
+}
+
 void execute_analyze(Config *config, ErrorStack *error_stack) {
   AnalyzeSummary summary = {0};
   impl_analyze(config, &summary, error_stack);
   if (!error_stack_is_empty(error_stack)) {
     return;
   }
-  int curr_row = 0;
-  int curr_col = 0;
-  StringGrid *sg = string_grid_create(4, 2, 1);
-  string_grid_set_cell(sg, curr_row, curr_col++, string_duplicate("Success"));
-  string_grid_set_cell(sg, curr_row, curr_col,
-                       get_formatted_string("%d", summary.success_count));
-  curr_row++;
-  curr_col = 0;
-  string_grid_set_cell(sg, curr_row, curr_col++, string_duplicate("Skipped"));
-  string_grid_set_cell(sg, curr_row, curr_col,
-                       get_formatted_string("%d", summary.skipped_count));
-  curr_row++;
-  curr_col = 0;
-  string_grid_set_cell(sg, curr_row, curr_col++, string_duplicate("Error"));
-  string_grid_set_cell(sg, curr_row, curr_col,
-                       get_formatted_string("%d", summary.error_count));
-  curr_row++;
-  curr_col = 0;
-  string_grid_set_cell(sg, curr_row, curr_col++, string_duplicate("Unstarted"));
-  string_grid_set_cell(sg, curr_row, curr_col,
-                       get_formatted_string("%d", summary.not_started_count));
-  StringBuilder *summary_sb = string_builder_create();
-  string_builder_add_string(summary_sb, "\n");
-  string_builder_add_string_grid(summary_sb, sg, false);
-  string_grid_destroy(sg);
-  string_builder_add_string(
-      summary_sb, summary.interrupted ? "\nFinished (user interrupt)\n"
-                                      : "\nFinished (all games analyzed)\n");
-  if (summary.error_details) {
-    string_builder_add_string(summary_sb, "\n=== Errors ===\n");
-    char *error_details_str = string_builder_dump(summary.error_details, NULL);
-    string_builder_add_string(summary_sb, error_details_str);
-    free(error_details_str);
-    string_builder_destroy(summary.error_details);
-  }
-  char *summary_str = string_builder_dump(summary_sb, NULL);
-  string_builder_destroy(summary_sb);
+  char *summary_str = analyze_summary_to_string(&summary);
   thread_control_print(config->thread_control, summary_str);
   free(summary_str);
 }
@@ -8680,10 +8709,13 @@ void execute_analyze(Config *config, ErrorStack *error_stack) {
 char *str_api_analyze(Config *config, ErrorStack *error_stack) {
   AnalyzeSummary summary = {0};
   impl_analyze(config, &summary, error_stack);
-  if (summary.error_details) {
-    string_builder_destroy(summary.error_details);
+  if (!error_stack_is_empty(error_stack)) {
+    if (summary.error_details) {
+      string_builder_destroy(summary.error_details);
+    }
+    return empty_string();
   }
-  return empty_string();
+  return analyze_summary_to_string(&summary);
 }
 
 Config *config_create(const ConfigArgs *config_args, ErrorStack *error_stack) {

--- a/src/impl/exec.h
+++ b/src/impl/exec.h
@@ -12,6 +12,8 @@ void execute_command_async(Config *config, ErrorStack *error_stack,
                            const char *command);
 bool run_str_api_command(Config *config, ErrorStack *error_stack,
                          const char *command, char **output);
+bool load_command_sync(Config *config, ErrorStack *error_stack,
+                       const char *command);
 char *command_search_status(Config *config, bool should_exit);
 void caches_destroy(void);
 void process_command_default(int argc, char *argv[]);

--- a/test/cmd_api_test.c
+++ b/test/cmd_api_test.c
@@ -125,8 +125,89 @@ void test_cmd_api_errors(void) {
   magpie_destroy(mp);
 }
 
+void test_cmd_api_direct_results(void) {
+  Magpie *mp = magpie_create(DEFAULT_TEST_DATA_PATH);
+  assert(!magpie_has_error(mp));
+  assert_run_sync_success(
+      mp, "set -lex CSW21 -s1 equity -s2 equity -r1 all -r2 all");
+  assert_run_sync_success(mp, TEST_EMPTY_BOARD_CGP);
+  assert_run_sync_success(mp, "generate");
+
+  // Long-running commands return their results directly instead of
+  // requiring a follow-up show command.
+  assert_run_sync_success(mp, "simulate -it 5 -plies 2 -scond none -threads 1");
+  char *sim_output = magpie_get_last_command_output(mp);
+  assert(!strings_equal(sim_output, ""));
+  magpie_free_string(sim_output);
+
+  magpie_destroy(mp);
+}
+
+void test_cmd_api_async(void) {
+  Magpie *mp = magpie_create(DEFAULT_TEST_DATA_PATH);
+  assert(!magpie_has_error(mp));
+  assert_run_sync_success(mp, "set -lex CSW21");
+  assert_run_sync_success(mp, TEST_EMPTY_BOARD_CGP);
+  assert_run_sync_success(mp, "generate");
+
+  // Awaiting with no async command pending returns the last exit code.
+  assert(magpie_await(mp) == MAGPIE_SUCCESS);
+
+  // Start a long-running simulation and stop it from this thread.
+  cmd_exit_code exit_code = magpie_run_async(
+      mp, "simulate -it 100000000 -plies 7 -scond none -threads 1");
+  assert(exit_code == MAGPIE_SUCCESS);
+  assert(magpie_get_thread_status(mp) == MAGPIE_THREAD_STATUS_STARTED);
+
+  // Only one command may run at a time.
+  assert(magpie_run_async(mp, "generate") == MAGPIE_DID_NOT_RUN);
+  assert(magpie_run_sync(mp, "generate") == MAGPIE_DID_NOT_RUN);
+
+  magpie_stop_current_command(mp);
+  exit_code = magpie_await(mp);
+  assert(exit_code == MAGPIE_SUCCESS);
+  assert(magpie_get_thread_status(mp) == MAGPIE_THREAD_STATUS_FINISHED);
+  char *sim_output = magpie_get_last_command_output(mp);
+  assert(!strings_equal(sim_output, ""));
+  magpie_free_string(sim_output);
+
+  // Async parse errors are reported synchronously.
+  exit_code = magpie_run_async(mp, "notacommand");
+  assert(exit_code == MAGPIE_DID_NOT_RUN);
+  assert(magpie_has_error(mp));
+  char *parse_error = magpie_get_and_clear_error(mp);
+  assert(has_substring(parse_error, "notacommand"));
+  magpie_free_string(parse_error);
+
+  // Run a short async command to completion.
+  exit_code = magpie_run_async(mp, "generate");
+  assert(exit_code == MAGPIE_SUCCESS);
+  assert(magpie_await(mp) == MAGPIE_SUCCESS);
+  char *gen_output = magpie_get_last_command_output(mp);
+  assert(has_substring(gen_output, "Showing"));
+  magpie_free_string(gen_output);
+
+  magpie_destroy(mp);
+}
+
+void test_cmd_api_destroy_while_running(void) {
+  Magpie *mp = magpie_create(DEFAULT_TEST_DATA_PATH);
+  assert(!magpie_has_error(mp));
+  assert_run_sync_success(mp, "set -lex CSW21");
+  assert_run_sync_success(mp, TEST_EMPTY_BOARD_CGP);
+  assert_run_sync_success(mp, "generate");
+  assert(magpie_run_async(
+             mp, "simulate -it 100000000 -plies 7 -scond none -threads 1") ==
+         MAGPIE_SUCCESS);
+  // Destroying while a command is running stops and joins the worker.
+  magpie_destroy(mp);
+}
+
 void test_cmd_api(void) {
   test_cmd_api_create_failure();
   test_cmd_api_run_commands();
   test_cmd_api_errors();
+  test_cmd_api_direct_results();
+  test_cmd_api_async();
+  test_cmd_api_destroy_while_running();
 }

--- a/wasmentry/api.c
+++ b/wasmentry/api.c
@@ -1,21 +1,8 @@
-#include "../src/compat/cpthread.h"
 #include "../src/impl/cmd_api.h"
 #include "../src/impl/exec.h"
-#include "../src/util/fileproxy.h"
 #include "../src/util/io_util.h"
-#include <stdlib.h>
-#include <string.h>
 
 static Magpie *wasm_magpie = NULL;
-static pthread_t command_handler_thread;
-static bool command_handler_running = false;
-
-// Thread argument for async command execution
-typedef struct {
-  Magpie *mp;
-  char *command;
-  volatile int *done_flag;
-} AsyncCommandArgs;
 
 int wasm_magpie_init(const char *data_paths) {
   if (wasm_magpie) {
@@ -33,65 +20,30 @@ void wasm_magpie_destroy(void) {
   caches_destroy();
 }
 
-// Worker function that runs on a pthread
-void *wasm_command_thread_worker(void *arg) {
-
-  if (!arg) {
-    return NULL;
-  }
-
-  AsyncCommandArgs *args = (AsyncCommandArgs *)arg;
-
-  if (!args->mp) {
-    free(args->command);
-    free(args);
-    return NULL;
-  }
-
-  if (!args->command) {
-    free(args);
-    return NULL;
-  }
-
-  // Now that we've bypassed mutexes for WASM, this should work
-  int result = magpie_run_sync(args->mp, args->command);
-
-  if (args->done_flag) {
-    *args->done_flag = 1;
-  }
-  free(args->command);
-  free(args);
-  return NULL;
-}
-
-// Synchronous version - now works since we bypass mutexes for WASM
 int wasm_run_command(const char *command) {
   if (!wasm_magpie) {
-    return 2; // MAGPIE_DID_NOT_RUN
+    return MAGPIE_DID_NOT_RUN;
   }
   return magpie_run_sync(wasm_magpie, command);
 }
 
-// Async version - spawns a pthread for better responsiveness
+// Async version - runs the command on a worker thread for responsiveness.
+// Poll wasm_get_thread_status for completion, then read the output.
 void wasm_run_command_async(const char *command) {
   if (!wasm_magpie) {
     return;
   }
-
-  // Allocate args on heap - thread will free them
-  AsyncCommandArgs *args = malloc(sizeof(AsyncCommandArgs));
-  args->mp = wasm_magpie;
-  args->command = strdup(command);
-  args->done_flag = NULL;
-
-  cpthread_t thread;
-  cpthread_create(&thread, wasm_command_thread_worker, args);
-  cpthread_detach(thread); // Don't need to join - let it run independently
+  magpie_run_async(wasm_magpie, command);
 }
 
 char *wasm_get_output(void) {
   if (!wasm_magpie) {
     return NULL;
+  }
+  // Reap the worker thread if the async command has finished; if one is
+  // still running this returns the output of the previous command.
+  if (magpie_get_thread_status(wasm_magpie) != MAGPIE_THREAD_STATUS_STARTED) {
+    magpie_await(wasm_magpie);
   }
   return magpie_get_last_command_output(wasm_magpie);
 }
@@ -114,7 +66,7 @@ char *wasm_get_status(void) {
 // Uses lock-free read to avoid deadlock when called from main thread
 int wasm_get_thread_status(void) {
   if (!wasm_magpie) {
-    return 0;
+    return MAGPIE_THREAD_STATUS_UNINITIALIZED;
   }
   return magpie_get_thread_status(wasm_magpie);
 }


### PR DESCRIPTION
Third of four stacked PRs for the `cmd_api` embedding API. **Based on #600** — review that one first.

Adds async execution, makes long-running commands return results directly, and adds FFI conveniences.

### Async execution
- `magpie_run_async` / `magpie_run_async_human_readable` start a command on a worker thread **after loading it synchronously**, so parse and data-loading errors are still reported immediately. `magpie_await` joins the worker and returns the exit code of the most recent command.
- One command runs at a time (a second `run_*` while active returns `MAGPIE_DID_NOT_RUN`); poll with `magpie_get_thread_status` / `magpie_get_last_command_status_message` and interrupt with `magpie_stop_current_command`. `magpie_destroy` stops and joins a running worker instead of leaking it.
- `wasmentry/api.c` drops its hand-rolled pthread wrapper and uses these functions — one async implementation, two consumers.

### Consistent output contract
`simulate`, `snoprune`, `gsimulate`, `rgsimulate`, `infer`, `endgame`, `peg`, and `analyze` now return their results directly from the str_api path, matching `generate`, instead of returning an empty string that forced a follow-up `sh*` command. The `sh*` commands remain for re-display with filters and mid-run polling.

### FFI hygiene
- `magpie_free_string` frees returned strings without requiring callers to share the library allocator.
- `magpie_create_with_options(data_paths, settings_filename, use_wmp)` exposes the settings filename and WMP toggle.

### Tests
`cmdapi` test extended: direct sim output, async start/poll/stop/await, one-command-at-a-time rejection, destroy-while-running. Runs in the CI dev shard for sanitizer coverage; full release suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
