### PR TITLE
Add embedding examples for the cmd_api shared library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ covhtml
 *.info
 *.out
 magpie*
+!examples/magpie.py
 dev/*.txt
 perf*
 .env

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ LFLAGS := ${lflags.${BUILD}}
 LDFLAGS  := ${ldflags.${BUILD}}
 LDLIBS   := -lm
 
-.PHONY: all clean iwyu libmagpie
+.PHONY: all clean iwyu libmagpie examples
 
 all: magpie magpie_test
 
@@ -119,6 +119,16 @@ $(BIN_DIR)/libmagpie.so: $(OBJ_SRC) $(OBJ_DIR)/libmagpie.map | $(BIN_DIR)
 
 $(BIN_DIR)/libmagpie.dylib: $(OBJ_SRC) $(OBJ_DIR)/libmagpie.exports | $(BIN_DIR)
 	$(CC) -dynamiclib $(LDFLAGS) $(LFLAGS) $(OBJ_SRC) $(LDLIBS) -Wl,-exported_symbols_list,$(OBJ_DIR)/libmagpie.exports -o $@
+
+# Example programs embedding magpie through the shared library
+ifeq ($(UNAME_S),Darwin)
+EXAMPLE_RPATH := -Wl,-rpath,@loader_path
+else
+EXAMPLE_RPATH := -Wl,-rpath,'$$ORIGIN'
+endif
+
+examples: libmagpie
+	$(CC) -O2 -Wall -Werror examples/generate_moves.c -L$(BIN_DIR) -lmagpie $(EXAMPLE_RPATH) -o $(BIN_DIR)/generate_moves
 
 magpie: $(OBJ_SRC) $(OBJ_CMD) | $(BIN_DIR)
 	$(CC) $(LDFLAGS) $(LFLAGS) $^ $(LDLIBS) -o $(BIN_DIR)/$@

--- a/README.md
+++ b/README.md
@@ -192,9 +192,17 @@ For running many commands programatically from another process, it is recommende
 
 ### API Library
 
-For programs embedding magpie as a library, all commands have a corresponding `str_api_*` function. The `str_api_*` functions all have the signature `char* func(Config*, ErrorStack*, char* cmd)` and use the same parser as the `execute` commands, but return the output as a string instead of printing the output to `stdout`.
+Programs can embed MAGPIE through a string -> string C API. Build the shared library with
 
-Currently, the API library has no clients, so if you are interested in this feature, please feel free to reach out to the developers if you run into any issues.
+```
+make libmagpie
+```
+
+which produces `bin/libmagpie.so` (`bin/libmagpie.dylib` on macOS) exporting only the `magpie_*` functions declared in `src/impl/cmd_api.h` — that header plus the shared library is the entire embedding surface.
+
+The API is command-oriented: callers create an opaque `Magpie` handle, pass it the same command strings the console accepts, and read the resulting output back as a string. Output is machine readable by default; the `*_human_readable` function variants format it for display instead. Commands can run synchronously (`magpie_run_sync`) or on a background thread (`magpie_run_async`), with `magpie_get_last_command_status_message` for mid-run progress, `magpie_stop_current_command` to interrupt, and `magpie_await` to collect the result. All returned strings are owned by the caller and freed with `magpie_free_string`.
+
+See `examples/generate_moves.c` for a minimal C client (build it with `make examples`) and `examples/magpie.py` for a Python ctypes wrapper with an interactive REPL.
 
 ## Data
 

--- a/examples/generate_moves.c
+++ b/examples/generate_moves.c
@@ -1,0 +1,49 @@
+// Example of embedding magpie via the cmd_api string API.
+//
+// Build and run:
+//   make examples
+//   ./bin/generate_moves [data-paths]
+//
+// Sets up an empty board with the rack AQRTUYZ and prints the generated
+// move list in machine-readable form.
+#include "../src/impl/cmd_api.h"
+#include <stdio.h>
+
+int main(int argc, char *argv[]) {
+  const char *data_paths = "./data";
+  if (argc > 1) {
+    data_paths = argv[1];
+  }
+
+  Magpie *mp = magpie_create(data_paths);
+  if (magpie_has_error(mp)) {
+    char *error = magpie_get_and_clear_error(mp);
+    (void)fprintf(stderr, "failed to create magpie: %s", error);
+    magpie_free_string(error);
+    magpie_destroy(mp);
+    return 1;
+  }
+
+  const char *commands[] = {
+      "set -lex CSW21",
+      "cgp 15/15/15/15/15/15/15/15/15/15/15/15/15/15/15 AQRTUYZ/ 0/0 0",
+      "generate",
+  };
+  const int num_commands = (int)(sizeof(commands) / sizeof(commands[0]));
+  for (int cmd_idx = 0; cmd_idx < num_commands; cmd_idx++) {
+    if (magpie_run_sync(mp, commands[cmd_idx]) != MAGPIE_SUCCESS) {
+      char *error = magpie_get_and_clear_error(mp);
+      (void)fprintf(stderr, "command '%s' failed: %s", commands[cmd_idx],
+                    error);
+      magpie_free_string(error);
+      magpie_destroy(mp);
+      return 1;
+    }
+  }
+
+  char *moves = magpie_get_last_command_output(mp);
+  printf("%s", moves);
+  magpie_free_string(moves);
+  magpie_destroy(mp);
+  return 0;
+}

--- a/examples/magpie.py
+++ b/examples/magpie.py
@@ -1,0 +1,173 @@
+"""ctypes wrapper and interactive REPL for the magpie shared library.
+
+Build the library first with `make libmagpie`, then run this script from
+the MAGPIE repo root:
+
+    python3 examples/magpie.py
+
+Every returned string is copied to a Python str and the original C string
+is released with magpie_free_string, so no magpie allocations leak into
+the Python side.
+"""
+
+import ctypes
+import os
+import platform
+import sys
+
+MAGPIE_SUCCESS = 0
+MAGPIE_ERROR = 1
+MAGPIE_DID_NOT_RUN = 2
+
+THREAD_STATUS_UNINITIALIZED = 0
+THREAD_STATUS_STARTED = 1
+THREAD_STATUS_USER_INTERRUPT = 2
+THREAD_STATUS_FINISHED = 3
+
+
+class MagpieError(Exception):
+    """Raised when a magpie command fails."""
+
+
+class Magpie:
+    def __init__(self, data_paths="./data", lib_path=None):
+        if lib_path is None:
+            ext = "dylib" if platform.system() == "Darwin" else "so"
+            lib_path = os.path.join("bin", f"libmagpie.{ext}")
+        self._lib = ctypes.CDLL(lib_path)
+        self._declare_functions()
+        self._mp = self._lib.magpie_create(data_paths.encode("utf-8"))
+        if self._lib.magpie_has_error(self._mp):
+            error = self._take_string(self._lib.magpie_get_and_clear_error(self._mp))
+            self.close()
+            raise MagpieError(f"failed to create magpie: {error}")
+
+    def _declare_functions(self):
+        lib = self._lib
+        # Returned strings are declared as c_void_p rather than c_char_p so
+        # the original pointer can be passed back to magpie_free_string.
+        lib.magpie_create.restype = ctypes.c_void_p
+        lib.magpie_create.argtypes = [ctypes.c_char_p]
+        lib.magpie_create_with_options.restype = ctypes.c_void_p
+        lib.magpie_create_with_options.argtypes = [
+            ctypes.c_char_p,
+            ctypes.c_char_p,
+            ctypes.c_bool,
+        ]
+        lib.magpie_destroy.restype = None
+        lib.magpie_destroy.argtypes = [ctypes.c_void_p]
+        for func in (
+            lib.magpie_run_sync,
+            lib.magpie_run_sync_human_readable,
+            lib.magpie_run_async,
+            lib.magpie_run_async_human_readable,
+        ):
+            func.restype = ctypes.c_int
+            func.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+        lib.magpie_await.restype = ctypes.c_int
+        lib.magpie_await.argtypes = [ctypes.c_void_p]
+        lib.magpie_has_error.restype = ctypes.c_bool
+        lib.magpie_has_error.argtypes = [ctypes.c_void_p]
+        for func in (
+            lib.magpie_get_and_clear_error,
+            lib.magpie_get_last_command_status_message,
+            lib.magpie_get_last_command_output,
+        ):
+            func.restype = ctypes.c_void_p
+            func.argtypes = [ctypes.c_void_p]
+        lib.magpie_stop_current_command.restype = None
+        lib.magpie_stop_current_command.argtypes = [ctypes.c_void_p]
+        lib.magpie_get_thread_status.restype = ctypes.c_int
+        lib.magpie_get_thread_status.argtypes = [ctypes.c_void_p]
+        lib.magpie_free_string.restype = None
+        lib.magpie_free_string.argtypes = [ctypes.c_void_p]
+
+    def _take_string(self, ptr):
+        """Copies a C string returned by the library and frees the original."""
+        if not ptr:
+            return ""
+        value = ctypes.string_at(ptr).decode("utf-8")
+        self._lib.magpie_free_string(ptr)
+        return value
+
+    def _check_exit_code(self, command, exit_code):
+        if exit_code == MAGPIE_SUCCESS:
+            return
+        error = self._take_string(self._lib.magpie_get_and_clear_error(self._mp))
+        raise MagpieError(f"command '{command}' failed: {error}")
+
+    def run(self, command, human_readable=False):
+        """Runs a command to completion and returns its output."""
+        if human_readable:
+            run_func = self._lib.magpie_run_sync_human_readable
+        else:
+            run_func = self._lib.magpie_run_sync
+        exit_code = run_func(self._mp, command.encode("utf-8"))
+        self._check_exit_code(command, exit_code)
+        return self.output()
+
+    def run_async(self, command, human_readable=False):
+        """Starts a command on a background thread."""
+        if human_readable:
+            run_func = self._lib.magpie_run_async_human_readable
+        else:
+            run_func = self._lib.magpie_run_async
+        exit_code = run_func(self._mp, command.encode("utf-8"))
+        self._check_exit_code(command, exit_code)
+
+    def wait(self):
+        """Waits for the running async command and returns its output."""
+        exit_code = self._lib.magpie_await(self._mp)
+        self._check_exit_code("<async>", exit_code)
+        return self.output()
+
+    def stop(self):
+        self._lib.magpie_stop_current_command(self._mp)
+
+    def status(self):
+        """Returns the live status message of the running command."""
+        return self._take_string(
+            self._lib.magpie_get_last_command_status_message(self._mp)
+        )
+
+    def thread_status(self):
+        return self._lib.magpie_get_thread_status(self._mp)
+
+    def output(self):
+        return self._take_string(
+            self._lib.magpie_get_last_command_output(self._mp)
+        )
+
+    def close(self):
+        if self._mp:
+            self._lib.magpie_destroy(self._mp)
+            self._mp = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+
+def main():
+    data_paths = sys.argv[1] if len(sys.argv) > 1 else "./data"
+    with Magpie(data_paths) as magpie:
+        print("magpie REPL; type a command, or 'exit' to quit")
+        while True:
+            try:
+                command = input("magpie> ").strip()
+            except EOFError:
+                break
+            if not command:
+                continue
+            if command in ("exit", "quit"):
+                break
+            try:
+                print(magpie.run(command, human_readable=True), end="")
+            except MagpieError as exception:
+                print(exception)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Last of four stacked PRs for the `cmd_api` embedding API. **Based on #601** — review that one first.

Adds worked examples of embedding magpie and documents the API surface.

- `examples/generate_moves.c`: minimal C client, built against `bin/libmagpie.so` by the new `make examples` target (which sets an rpath so the binary finds the library in `bin/`).
- `examples/magpie.py`: Python ctypes wrapper with declared `argtypes`/`restype` for every API function, string ownership handled via `magpie_free_string`, plus an interactive REPL and sync/async helpers.
- README "API Library" section rewritten to document the embedding surface (`make libmagpie`, the command/output model, sync vs async, string ownership) and point at the examples.

Replaces the previous ad-hoc scratch files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
