### PR TITLE
peg: show tie draws in the outcomes column

### DIFF
--- a/src/impl/config.c
+++ b/src/impl/config.c
@@ -1686,10 +1686,15 @@ void add_help_arg_to_string_builder(const Config *config, int token,
       examples[0] = "true";
       text =
           "When true, adds a per-play outcomes column to the graded table: the "
-          "shorter of the winning / losing draws (the other is implied by the "
-          "counts). A draw is a sorted multiset (FGHI) when order is "
-          "irrelevant, or a slash-joined sequence (F/G/H/I) when it matters; "
-          "each carries an xN labeled-ordering weight. Default false.";
+          "largest of the winning / losing / tying draw lists is implied by "
+          "the "
+          "counts and the smaller ones are shown, comma-separated with "
+          "W:/L:/T: "
+          "labels (a tie majority is named as \", otherwise ties\"). A draw is "
+          "a "
+          "sorted multiset (FGHI) when order is irrelevant, or a slash-joined "
+          "sequence (F/G/H/I) when it matters; each carries an xN "
+          "labeled-ordering weight. Default false.";
       break;
     case ARG_TOKEN_PEG_OUT_WIDTH:
       usages[0] = "<columns>";

--- a/src/impl/config.c
+++ b/src/impl/config.c
@@ -1690,11 +1690,13 @@ void add_help_arg_to_string_builder(const Config *config, int token,
           "the "
           "counts and the smaller ones are shown, comma-separated with "
           "W:/L:/T: "
-          "labels (a tie majority is named as \", otherwise ties\"). A draw is "
-          "a "
-          "sorted multiset (FGHI) when order is irrelevant, or a slash-joined "
-          "sequence (F/G/H/I) when it matters; each carries an xN "
-          "labeled-ordering weight. Default false.";
+          "labels. The implied list is named (\", otherwise wins/loses/ties\") "
+          "only when the cell is otherwise ambiguous: ties are the implied "
+          "majority, or the tie list is the only one shown. A draw is a sorted "
+          "multiset (FGHI) when order is irrelevant, or a slash-joined "
+          "sequence "
+          "(F/G/H/I) when it matters; each carries an xN labeled-ordering "
+          "weight. Default false.";
       break;
     case ARG_TOKEN_PEG_OUT_WIDTH:
       usages[0] = "<columns>";

--- a/src/str/peg_string.c
+++ b/src/str/peg_string.c
@@ -25,7 +25,7 @@
 // tagged with its bucket and summed labeled-ordering weight.
 typedef struct {
   char text[64];
-  int bucket; // 0 = win, 1 = loss
+  int bucket; // 0 = win, 1 = loss, 2 = tie
   int64_t weight;
 } PegOutcomeTok;
 
@@ -287,6 +287,24 @@ static void peg_draw_token(char *dst, size_t dst_size, const char *drawn,
   }
 }
 
+// Append every token in `bucket` to `sb`, each preceded by a space and given an
+// "xN" suffix when its labeled-ordering weight exceeds 1.
+static void peg_append_outcome_toks(StringBuilder *sb,
+                                    const PegOutcomeTok *toks, int n_toks,
+                                    int bucket) {
+  for (int tok_idx = 0; tok_idx < n_toks; tok_idx++) {
+    if (toks[tok_idx].bucket != bucket) {
+      continue;
+    }
+    if (toks[tok_idx].weight > 1) {
+      string_builder_add_formatted_string(
+          sb, " %sx%" PRId64, toks[tok_idx].text, toks[tok_idx].weight);
+    } else {
+      string_builder_add_formatted_string(sb, " %s", toks[tok_idx].text);
+    }
+  }
+}
+
 // Condense a candidate's per-ordering rows into one line. Each token is a draw:
 // the mover's drawn tiles (always a sorted multiset, since they are drawn
 // together and order-independent) as a leading segment, followed by the bag
@@ -297,9 +315,12 @@ static void peg_draw_token(char *dst, size_t dst_size, const char *drawn,
 // freely-permutable blocks collapse to a sorted multiset segment and
 // order-significant boundaries stay "/"-separated. Each token carries an "xN"
 // labeled-ordering weight (N=1 omitted), so the win tokens' weights sum to the
-// wins column and the loss tokens' to the loss column. Only the shorter of the
-// win / loss lists is printed (the other is implied by the counts); tie draws
-// are not listed but do count toward the split decision. When every ordering
+// wins column and the loss tokens' to the loss column. The largest of the three
+// lists is left implied (the reader infers it from the count columns); the
+// smaller ones are printed, comma-separated, each with its label ("W:"/"L:"/
+// "T:"). Empty lists are skipped, so a row with no tie draws just shows the
+// shorter of win / loss. A tie majority is rare, so when ties are the implied
+// list it is called out with a trailing ", otherwise ties". When every ordering
 // shares one bucket, says "always wins/loses/ties". Caller frees.
 char *peg_build_outcomes_string_rows(const PegPerScenario *rows, int n_rows) {
   if (n_rows <= 0) {
@@ -361,9 +382,10 @@ char *peg_build_outcomes_string_rows(const PegPerScenario *rows, int n_rows) {
 
   // Pass 2: emit one token per (display form, bucket). When a family's bag
   // orderings all share a bucket, the whole draw is one token (drawn multiset,
-  // then the bag remainder as a multiset). When they span buckets, only the bag
+  // then the bag remainder as a multiset). When they span buckets, the bag
   // remainder is factored per bucket into segmented forms; the drawn multiset
-  // stays a fixed leading segment (no token for a tie-only family).
+  // stays a fixed leading segment. Tie draws get tokens too -- whether they are
+  // finally shown is a display decision made below.
   PegOutcomeTok *toks =
       malloc_or_die((size_t)(n_rows + n_fams) * sizeof(PegOutcomeTok));
   int n_toks = 0;
@@ -378,9 +400,6 @@ char *peg_build_outcomes_string_rows(const PegPerScenario *rows, int n_rows) {
       } else if (fam->seen[1]) {
         bucket = 1;
       }
-      if (bucket == 2) {
-        continue; // tie-only: not listed
-      }
       peg_draw_token(toks[n_toks].text, sizeof(toks[n_toks].text), fam->drawn,
                      fam->rem_ms);
       toks[n_toks].bucket = bucket;
@@ -389,9 +408,9 @@ char *peg_build_outcomes_string_rows(const PegPerScenario *rows, int n_rows) {
       continue;
     }
     // Split: the bag remainder's orderings land in more than one bucket. Factor
-    // them per win/loss bucket, keeping the drawn multiset as a leading
+    // them per win/loss/tie bucket, keeping the drawn multiset as a leading
     // segment.
-    for (int bucket = 0; bucket <= 1; bucket++) {
+    for (int bucket = 0; bucket <= 2; bucket++) {
       PegStrList seqs = {0};
       for (int row_idx = 0; row_idx < n_rows; row_idx++) {
         if (peg_outcome_bucket(rows[row_idx].mover_total) != bucket) {
@@ -425,26 +444,45 @@ char *peg_build_outcomes_string_rows(const PegPerScenario *rows, int n_rows) {
   free(row_rem_ms);
 
   qsort(toks, (size_t)n_toks, sizeof(PegOutcomeTok), peg_outcome_tok_cmp);
-  int n_win_toks = 0;
+  int n_bucket_toks[3] = {0, 0, 0};
   for (int tok_idx = 0; tok_idx < n_toks; tok_idx++) {
-    if (toks[tok_idx].bucket == 0) {
-      n_win_toks++;
+    n_bucket_toks[toks[tok_idx].bucket]++;
+  }
+
+  // Leave the largest list implied -- the reader infers it from the count
+  // columns -- and print the smaller ones, comma-separated, each with its
+  // label. Empty lists are skipped, so a row with no tie draws just shows the
+  // shorter of win / loss, exactly as before ties were tracked. On a size tie,
+  // prefer to imply a loss, then a win, so a tie draw stays visible. A tie
+  // majority is rare and surprising, so when ties are the implied list we call
+  // it out explicitly with a trailing ", otherwise ties".
+  static const int imply_pref[3] = {1, 0, 2}; // loss, then win, then tie
+  int implied = imply_pref[0];
+  for (int pref_idx = 1; pref_idx < 3; pref_idx++) {
+    const int bucket = imply_pref[pref_idx];
+    if (n_bucket_toks[bucket] > n_bucket_toks[implied]) {
+      implied = bucket;
     }
   }
-  const int want = n_win_toks <= n_toks - n_win_toks ? 0 : 1;
 
+  static const char *const labels[3] = {"W:", "L:", "T:"};
+  const int display_order[3] = {0, 2, 1}; // wins, ties, losses
   StringBuilder *sb = string_builder_create();
-  string_builder_add_string(sb, want == 0 ? "W:" : "L:");
-  for (int tok_idx = 0; tok_idx < n_toks; tok_idx++) {
-    if (toks[tok_idx].bucket != want) {
+  bool first = true;
+  for (int order_idx = 0; order_idx < 3; order_idx++) {
+    const int bucket = display_order[order_idx];
+    if (bucket == implied || n_bucket_toks[bucket] == 0) {
       continue;
     }
-    if (toks[tok_idx].weight > 1) {
-      string_builder_add_formatted_string(
-          sb, " %sx%" PRId64, toks[tok_idx].text, toks[tok_idx].weight);
-    } else {
-      string_builder_add_formatted_string(sb, " %s", toks[tok_idx].text);
+    if (!first) {
+      string_builder_add_string(sb, ", ");
     }
+    first = false;
+    string_builder_add_string(sb, labels[bucket]);
+    peg_append_outcome_toks(sb, toks, n_toks, bucket);
+  }
+  if (implied == 2) { // ties implied: rare, so name it explicitly
+    string_builder_add_string(sb, ", otherwise ties");
   }
   free(toks);
   char *out = string_builder_dump(sb, NULL);

--- a/src/str/peg_string.c
+++ b/src/str/peg_string.c
@@ -319,9 +319,12 @@ static void peg_append_outcome_toks(StringBuilder *sb,
 // lists is left implied (the reader infers it from the count columns); the
 // smaller ones are printed, comma-separated, each with its label ("W:"/"L:"/
 // "T:"). Empty lists are skipped, so a row with no tie draws just shows the
-// shorter of win / loss. A tie majority is rare, so when ties are the implied
-// list it is called out with a trailing ", otherwise ties". When every ordering
-// shares one bucket, says "always wins/loses/ties". Caller frees.
+// shorter of win / loss. The implied list is named with a trailing ", otherwise
+// wins/loses/ties" only when the cell would otherwise be ambiguous: ties are
+// the implied majority (rare), or the tie list is the only list shown (its
+// win/loss counterpart was empty, so "T: E" alone cannot say which of win/loss
+// is implied). When every ordering shares one bucket, says "always
+// wins/loses/ties". Caller frees.
 char *peg_build_outcomes_string_rows(const PegPerScenario *rows, int n_rows) {
   if (n_rows <= 0) {
     return string_duplicate("");
@@ -453,9 +456,7 @@ char *peg_build_outcomes_string_rows(const PegPerScenario *rows, int n_rows) {
   // columns -- and print the smaller ones, comma-separated, each with its
   // label. Empty lists are skipped, so a row with no tie draws just shows the
   // shorter of win / loss, exactly as before ties were tracked. On a size tie,
-  // prefer to imply a loss, then a win, so a tie draw stays visible. A tie
-  // majority is rare and surprising, so when ties are the implied list we call
-  // it out explicitly with a trailing ", otherwise ties".
+  // prefer to imply a loss, then a win, so a tie draw stays visible.
   static const int imply_pref[3] = {1, 0, 2}; // loss, then win, then tie
   int implied = imply_pref[0];
   for (int pref_idx = 1; pref_idx < 3; pref_idx++) {
@@ -466,23 +467,33 @@ char *peg_build_outcomes_string_rows(const PegPerScenario *rows, int n_rows) {
   }
 
   static const char *const labels[3] = {"W:", "L:", "T:"};
+  static const char *const otherwise_word[3] = {"wins", "loses", "ties"};
   const int display_order[3] = {0, 2, 1}; // wins, ties, losses
   StringBuilder *sb = string_builder_create();
-  bool first = true;
+  int n_shown = 0;
+  int last_shown = -1;
   for (int order_idx = 0; order_idx < 3; order_idx++) {
     const int bucket = display_order[order_idx];
     if (bucket == implied || n_bucket_toks[bucket] == 0) {
       continue;
     }
-    if (!first) {
+    if (n_shown > 0) {
       string_builder_add_string(sb, ", ");
     }
-    first = false;
     string_builder_add_string(sb, labels[bucket]);
     peg_append_outcome_toks(sb, toks, n_toks, bucket);
+    last_shown = bucket;
+    n_shown++;
   }
-  if (implied == 2) { // ties implied: rare, so name it explicitly
-    string_builder_add_string(sb, ", otherwise ties");
+  // Name the implied list when the cell alone would not pin it down: ties are
+  // the implied majority (rare and surprising), or the only list shown is the
+  // tie list -- its win/loss counterpart was empty, so "T: E" alone cannot say
+  // whether the implied majority is wins or losses. Two labeled lists already
+  // imply the third, and a no-tie row implies its win/loss counterpart, so
+  // those stay label-free.
+  if (implied == 2 || (n_shown == 1 && last_shown == 2)) {
+    string_builder_add_formatted_string(sb, ", otherwise %s",
+                                        otherwise_word[implied]);
   }
   free(toks);
   char *out = string_builder_dump(sb, NULL);

--- a/src/str/peg_string.h
+++ b/src/str/peg_string.h
@@ -28,10 +28,12 @@ char *peg_result_get_string(const PegResult *result, const Game *game,
 // as a sorted multiset prefix, then the bag remainder (a multiset, or
 // "/"-segmented when its orderings split across buckets). The largest of the
 // win/loss/tie lists is left implied (inferred from the count columns) and the
-// smaller ones are printed comma-separated with W:/L:/T: labels; a tie majority
-// is named explicitly as ", otherwise ties". The per-token "xN" weights sum to
-// the count columns. Exposed for unit testing; production reaches it via
-// peg_result_get_string. Caller frees.
+// smaller ones are printed comma-separated with W:/L:/T: labels; the implied
+// list is named as ", otherwise wins/loses/ties" only when the cell is
+// otherwise ambiguous (ties are the implied majority, or the tie list is the
+// only one shown). The per-token "xN" weights sum to the count columns. Exposed
+// for unit testing; production reaches it via peg_result_get_string. Caller
+// frees.
 char *peg_build_outcomes_string_rows(const PegPerScenario *rows, int n_rows);
 
 #endif // PEG_STRING_H

--- a/src/str/peg_string.h
+++ b/src/str/peg_string.h
@@ -6,7 +6,8 @@
 #include <stdbool.h>
 
 // Render a PegResult as a human-readable ranking table. When show_outcomes is
-// true, the graded table gets a per-play outcomes column (W/L draws). When poll
+// true, the graded table gets a per-play outcomes column (W/L/T draws). When
+// poll
 // is non-NULL and the solve is still running, renders a live cross-depth merged
 // view instead of the stored result (pass NULL for final/show callers).
 //
@@ -23,11 +24,14 @@ char *peg_result_get_string(const PegResult *result, const Game *game,
                             bool *out_truncated);
 
 // Render one candidate's per-ordering W/L/T rows as the compact outcomes-cell
-// string (e.g. "W: DH/Ax2 DR/Hx2"): the mover's drawn tiles as a sorted
-// multiset prefix, then the bag remainder (a multiset, or "/"-segmented when
-// its orderings split across buckets). Only the shorter of the win/loss lists
-// is shown; the per-token "xN" weights sum to the win/loss columns. Exposed for
-// unit testing; production reaches it via peg_result_get_string. Caller frees.
+// string (e.g. "W: DH/Ax2 DR/Hx2" or "W: C U Y, T: E"): the mover's drawn tiles
+// as a sorted multiset prefix, then the bag remainder (a multiset, or
+// "/"-segmented when its orderings split across buckets). The largest of the
+// win/loss/tie lists is left implied (inferred from the count columns) and the
+// smaller ones are printed comma-separated with W:/L:/T: labels; a tie majority
+// is named explicitly as ", otherwise ties". The per-token "xN" weights sum to
+// the count columns. Exposed for unit testing; production reaches it via
+// peg_result_get_string. Caller frees.
 char *peg_build_outcomes_string_rows(const PegPerScenario *rows, int n_rows);
 
 #endif // PEG_STRING_H

--- a/test/peg_test.c
+++ b/test/peg_test.c
@@ -1277,22 +1277,24 @@ static void test_peg_outcomes_string(void) {
 
   // A tie draw with no losing draw (the ONYX case from the bug report). The old
   // "shorter list wins" logic picked the empty loss list and rendered a bare
-  // "L:". Now wins (the largest list) is left implied and the tie is shown. The
-  // implied list is a win/loss, so no "otherwise" is needed.
+  // "L:". Now wins (the largest list) is left implied and the tie is shown.
+  // Because the tie list is the only one shown (losses is empty), "T: E" alone
+  // can't say whether the implied majority is wins or losses, so it is named.
   const PegPerScenario tie_no_loss[] = {
       {.drawn = "A", .remaining = "", .weight = 1, .mover_total = 5},
       {.drawn = "B", .remaining = "", .weight = 1, .mover_total = 5},
       {.drawn = "E", .remaining = "", .weight = 1, .mover_total = 0},
   };
-  assert_outcomes_eq(tie_no_loss, 3, "T: E");
+  assert_outcomes_eq(tie_no_loss, 3, "T: E, otherwise wins");
 
-  // A tie draw with no winning draw: losses are the largest list, left implied.
+  // A tie draw with no winning draw: losses are the largest list, left implied,
+  // and the tie is the only list shown, so the implied loss is named.
   const PegPerScenario tie_no_win[] = {
       {.drawn = "P", .remaining = "", .weight = 1, .mover_total = -5},
       {.drawn = "Q", .remaining = "", .weight = 1, .mover_total = -5},
       {.drawn = "X", .remaining = "", .weight = 1, .mover_total = 0},
   };
-  assert_outcomes_eq(tie_no_win, 3, "T: X");
+  assert_outcomes_eq(tie_no_win, 3, "T: X, otherwise loses");
 
   // All three buckets: the largest list (here losses) is implied; the two
   // shorter lists -- wins and the tie -- are printed comma-separated, in

--- a/test/peg_test.c
+++ b/test/peg_test.c
@@ -1274,6 +1274,52 @@ static void test_peg_outcomes_string(void) {
       {.drawn = "X", .remaining = "ZY", .weight = 4, .mover_total = -5},
   };
   assert_outcomes_eq(rem_split, 2, "W: X/Y/Zx4");
+
+  // A tie draw with no losing draw (the ONYX case from the bug report). The old
+  // "shorter list wins" logic picked the empty loss list and rendered a bare
+  // "L:". Now wins (the largest list) is left implied and the tie is shown. The
+  // implied list is a win/loss, so no "otherwise" is needed.
+  const PegPerScenario tie_no_loss[] = {
+      {.drawn = "A", .remaining = "", .weight = 1, .mover_total = 5},
+      {.drawn = "B", .remaining = "", .weight = 1, .mover_total = 5},
+      {.drawn = "E", .remaining = "", .weight = 1, .mover_total = 0},
+  };
+  assert_outcomes_eq(tie_no_loss, 3, "T: E");
+
+  // A tie draw with no winning draw: losses are the largest list, left implied.
+  const PegPerScenario tie_no_win[] = {
+      {.drawn = "P", .remaining = "", .weight = 1, .mover_total = -5},
+      {.drawn = "Q", .remaining = "", .weight = 1, .mover_total = -5},
+      {.drawn = "X", .remaining = "", .weight = 1, .mover_total = 0},
+  };
+  assert_outcomes_eq(tie_no_win, 3, "T: X");
+
+  // All three buckets: the largest list (here losses) is implied; the two
+  // shorter lists -- wins and the tie -- are printed comma-separated, in
+  // wins/ties/loss order.
+  const PegPerScenario win_tie_loss[] = {
+      {.drawn = "C", .remaining = "", .weight = 1, .mover_total = 5},
+      {.drawn = "U", .remaining = "", .weight = 1, .mover_total = 5},
+      {.drawn = "Y", .remaining = "", .weight = 1, .mover_total = 5},
+      {.drawn = "D", .remaining = "", .weight = 1, .mover_total = -5},
+      {.drawn = "F", .remaining = "", .weight = 1, .mover_total = -5},
+      {.drawn = "G", .remaining = "", .weight = 1, .mover_total = -5},
+      {.drawn = "H", .remaining = "", .weight = 1, .mover_total = -5},
+      {.drawn = "E", .remaining = "", .weight = 1, .mover_total = 0},
+  };
+  assert_outcomes_eq(win_tie_loss, 8, "W: C U Y, T: E");
+
+  // Ties are the most common result: the tie list is the largest, so it is the
+  // one left implied. A tie majority is rare, so it is named explicitly with a
+  // trailing ", otherwise ties" after the shorter win / loss lists.
+  const PegPerScenario tie_majority[] = {
+      {.drawn = "A", .remaining = "", .weight = 1, .mover_total = 5},
+      {.drawn = "B", .remaining = "", .weight = 1, .mover_total = -5},
+      {.drawn = "C", .remaining = "", .weight = 1, .mover_total = 0},
+      {.drawn = "D", .remaining = "", .weight = 1, .mover_total = 0},
+      {.drawn = "E", .remaining = "", .weight = 1, .mover_total = 0},
+  };
+  assert_outcomes_eq(tie_majority, 5, "W: A, L: B, otherwise ties");
 }
 
 void test_peg(void) {


### PR DESCRIPTION
## Bug

Reported in #macondo (Discord): the per-play **outcomes** column added in #559 / #561 never shows **tie** draws, and when a play has no losing draw it renders a bare `L:`.

Example from the report — `13L ONYX`, a 1-in-bag position with **7 wins / 1 tie / 0 losses**:

```
depth rank move    wins ties loss win%  spread time outcomes
6-ply  1  13L ONYX   7    1    0  93.8  +8.8  0.4s  L:
```

The renderer prints whichever of the win/loss lists is *shorter* and implies the other from the counts columns. With zero losses the shorter list is the empty loss list, so it emits `L:` with nothing after it — and the tie is dropped on the floor.

## Fix

Generalize the outcomes cell from two lists to three. The **largest** list is left implied (the reader infers it from the wins/ties/loss count columns); the smaller ones are printed, **comma-separated**, each with its label (`W:` / `L:` / `T:`). Empty lists are skipped, so a row with no ties shows just the shorter of win/loss — byte-for-byte as before.

The implied list is **named** with a trailing `, otherwise wins/loses/ties` *only when the cell would otherwise be ambiguous*:
- ties are the implied majority (rare and surprising), or
- the tie list is the only list shown (its win/loss counterpart was empty, so `T: E` alone can't say whether the majority is wins or losses).

Two labeled lists already imply the third, and a no-tie row implies its win/loss counterpart, so those stay label-free.

| Case (W/T/L) | Outcomes cell |
|---|---|
| 7 / 1 / 0 | `T: E, otherwise wins` |
| 0 / 1 / 7 | `T: E, otherwise loses` |
| 3 / 1 / 4 | `W: C U Y, T: E` |
| 3 / 0 / 4 (no ties) | `W: C U Y` (unchanged) |
| 1 / 1 / 3 | `W: A, L: B, otherwise ties` |

The ONYX case now reads:

```
6-ply  1  13L ONYX   7    1    0  93.8  +8.8  0.4s  T: E, otherwise wins
```

## Implementation notes

- Tie-bucket tokens are now emitted in both the single-bucket and split-family paths (`peg_string.c`).
- Per-bucket token formatting is factored into `peg_append_outcome_toks`, shared by every list.
- On a size tie the implied list is a loss, then a win — so tie draws stay visible (a tie is implied only when it is *strictly* the largest).

## Tests

`test_peg_outcomes_string` gains synthetic cases: tie + no loss, tie + no win, all three buckets, and a tie majority (a real tie-dominated PEG position is hard to construct, so it is mocked at the renderer boundary like the existing cases). Existing no-tie cases are untouched and still pass.

- `./bin/magpie_test peg` and `config` — green
- cppcheck 2.17.1 — clean
- clang-format-20 (`format.py --write`) — applied

Docs updated to match: the `-pegoutcomes` help text (`config.c`) and the `peg_string.h` header comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MkWNgErfWHBbSTFxWVnVi