### PR TITLE
Add timed PlayChooser players to autoplay

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,28 @@ magpie> autoplay games 50 -lex CSW21 -threads 4 -hr true
 
 will play 50 games in the CSW21 lexicon with 4 threads and print the results in a human readable format.
 
+Autoplay can use `PlayChooser` for either or both players. `-pc1` and `-pc2`
+set each player's total per-game clock in milliseconds; `-1` disables it (the
+default), and `0` enables it without a clock. For example, this gives both
+players a 30-second clock:
+
+```
+magpie> autoplay games 100 -pc1 30000 -pc2 30000 -hr true
+```
+
+PlayChooser selects its evaluation mode from the position, using simulation,
+pre-endgame, or endgame analysis as appropriate. Timed games deduct 10 points
+per started minute of overtime by default. The penalty and period are
+configurable independently, so blitz runs can deduct one point per started
+second:
+
+```
+magpie> autoplay games 100 -pc1 5000 -pc2 5000 -otpenalty 1 -otperiod 1000 -hr true
+```
+
+When at least one player uses PlayChooser, the final report includes clock
+usage, overtime, and deducted penalty points for each active player.
+
 All commands and settings can be specified by the shortest unambiguous string. For example, the generate command can be specified by any of the following strings:
 
 ```

--- a/README.md
+++ b/README.md
@@ -98,6 +98,21 @@ when combined with a clock. Pairs work by having both games see identical draws
 so that only the players' decisions differ; with timing on, the two games can
 diverge for reasons unrelated to strategy.
 
+How much search a clock buys also depends on the threading mode, so the same
+`-pc1` value is not comparable across `-mtmode` settings:
+
+- Per-game parallelism (`-mtmode pgp`, the default) runs `-threads` games at
+  once and gives each game's PlayChooser a single thread. Raising `-threads`
+  finishes the run sooner but does not give any player more search per second
+  of clock — until the thread count exceeds the machine's available cores, at
+  which point games contend for CPU and the same budget buys measurably less.
+- Intra-game parallelism (`-mtmode igp`) plays one game at a time and gives
+  that game's PlayChooser every thread, so the same clock buys roughly
+  `-threads` times as much search per move.
+
+Compare timed runs only against other runs with the same `-mtmode` and
+`-threads`.
+
 All commands and settings can be specified by the shortest unambiguous string. For example, the generate command can be specified by any of the following strings:
 
 ```

--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ magpie> autoplay games 100 -pc1 5000 -pc2 5000 -otpenalty 1 -otperiod 1000 -hr t
 When at least one player uses PlayChooser, the final report includes clock
 usage, overtime, and deducted penalty points for each active player.
 
+Games with a clocked player are **not reproducible from the seed**. How much
+search fits in the budget varies with machine load, thread count, and build, so
+the same `-seed` will not replay the same moves, and the overtime penalty itself
+varies between runs. This is inherent to timed play rather than a defect, but it
+is worth knowing because the rest of autoplay *is* seed-deterministic. The
+intended output is the aggregate: win percentage, spread, and penalty points
+over enough games. Individual games are not meant to be replayed.
+
+For the same reason, game pairs (`-gp`) lose their variance-reduction property
+when combined with a clock. Pairs work by having both games see identical draws
+so that only the players' decisions differ; with timing on, the two games can
+diverge for reasons unrelated to strategy.
+
 All commands and settings can be specified by the shortest unambiguous string. For example, the generate command can be specified by any of the following strings:
 
 ```

--- a/src/ent/autoplay_results.c
+++ b/src/ent/autoplay_results.c
@@ -39,6 +39,7 @@ typedef struct RecorderArgs {
   uint64_t seed;
   bool divergent;
   bool human_readable;
+  const AutoplayGameTiming *timing;
 } RecorderArgs;
 
 // Read-only data shared across all recorder types
@@ -48,6 +49,10 @@ typedef struct RecorderContext {
   const LetterDistribution *ld;
   KLV *klv;
   const PlayersData *players_data;
+  bool play_chooser_active[2];
+  double time_control_seconds[2];
+  int overtime_penalty_points;
+  double overtime_period_seconds;
 } RecorderContext;
 
 typedef struct Recorder Recorder;
@@ -112,6 +117,10 @@ typedef struct GameData {
   Stat *p0_score;
   Stat *p1_score;
   Stat *turns;
+  double total_seconds_used[2];
+  double total_overtime_seconds[2];
+  uint64_t overtime_games[2];
+  uint64_t penalty_points[2];
   int game_end_reasons[NUMBER_OF_GAME_END_REASONS];
   cpthread_mutex_t mutex;
 } GameData;
@@ -126,6 +135,12 @@ void game_data_reset(GameData *gd) {
   stat_reset(gd->p0_score);
   stat_reset(gd->p1_score);
   stat_reset(gd->turns);
+  for (int i = 0; i < 2; i++) {
+    gd->total_seconds_used[i] = 0.0;
+    gd->total_overtime_seconds[i] = 0.0;
+    gd->overtime_games[i] = 0;
+    gd->penalty_points[i] = 0;
+  }
   for (int i = 0; i < NUMBER_OF_GAME_END_REASONS; i++) {
     gd->game_end_reasons[i] = 0;
   }
@@ -174,6 +189,22 @@ void game_data_add_game(GameData *gd, const RecorderArgs *args) {
   stat_push(gd->p1_score, (double)p1_game_score, 1);
   stat_push(gd->turns, (double)turns, 1);
   gd->total_turns += turns;
+  if (args->timing != NULL) {
+    for (int player_index = 0; player_index < 2; player_index++) {
+      if (!args->timing->active[player_index]) {
+        continue;
+      }
+      gd->total_seconds_used[player_index] +=
+          args->timing->seconds_used[player_index];
+      gd->total_overtime_seconds[player_index] +=
+          args->timing->overtime_seconds[player_index];
+      if (args->timing->overtime_seconds[player_index] > 0.0) {
+        gd->overtime_games[player_index]++;
+      }
+      gd->penalty_points[player_index] +=
+          (uint64_t)args->timing->penalty_points[player_index];
+    }
+  }
   gd->game_end_reasons[game_get_game_end_reason(game)]++;
   cpthread_mutex_unlock(&gd->mutex);
 }
@@ -185,7 +216,14 @@ void string_builder_add_game_end_reasons(StringBuilder *sb,
   }
 }
 
-char *game_data_ucgi_str(const GameData *gd) {
+static bool
+recorder_context_uses_play_chooser(const RecorderContext *recorder_context) {
+  return recorder_context->play_chooser_active[0] ||
+         recorder_context->play_chooser_active[1];
+}
+
+char *game_data_ucgi_str(const GameData *gd,
+                         const RecorderContext *recorder_context) {
   StringBuilder *sb = string_builder_create();
   string_builder_add_formatted_string(
       sb, "autoplay games %lu %lu %lu %lu %lu %f %f %f %f ", gd->total_games,
@@ -193,6 +231,18 @@ char *game_data_ucgi_str(const GameData *gd) {
       stat_get_mean(gd->p0_score), stat_get_stdev(gd->p0_score),
       stat_get_mean(gd->p1_score), stat_get_stdev(gd->p1_score));
   string_builder_add_game_end_reasons(sb, gd);
+  if (recorder_context_uses_play_chooser(recorder_context)) {
+    string_builder_add_formatted_string(
+        sb, "playchooser %d %d %.0f %.0f %.3f %.3f %.3f %.3f %lu %lu ",
+        recorder_context->play_chooser_active[0],
+        recorder_context->play_chooser_active[1],
+        recorder_context->time_control_seconds[0] * 1000.0,
+        recorder_context->time_control_seconds[1] * 1000.0,
+        gd->total_seconds_used[0] * 1000.0, gd->total_seconds_used[1] * 1000.0,
+        gd->total_overtime_seconds[0] * 1000.0,
+        gd->total_overtime_seconds[1] * 1000.0, gd->penalty_points[0],
+        gd->penalty_points[1]);
+  }
   string_builder_add_string(sb, "\n");
   char *res = string_builder_dump(sb, NULL);
   string_builder_destroy(sb);
@@ -243,20 +293,94 @@ void string_builder_add_winning_player_confidence(StringBuilder *sb,
   }
 }
 
-char *game_data_human_readable_str(const GameData *gd, bool divergent) {
-  uint64_t p0_wins = gd->p0_wins;
-  double p0_win_pct = (double)p0_wins / (double)gd->total_games;
-  uint64_t p0_losses = gd->p0_losses;
-  double p0_loss_pct = (double)p0_losses / (double)gd->total_games;
-  uint64_t p0_ties = gd->p0_ties;
-  double p0_tie_pct = (double)p0_ties / (double)gd->total_games;
+static char *get_timing_value_string(bool active, double value) {
+  return active ? get_formatted_string("%.3f", value) : string_duplicate("-");
+}
 
-  double p0_total = (double)gd->p0_wins + (double)gd->p0_ties / (double)2;
-  double p0_total_pct = p0_total / (double)(gd->total_games);
+static char *get_time_control_string(bool active, double seconds) {
+  if (!active) {
+    return string_duplicate("-");
+  }
+  if (seconds <= 0.0) {
+    return string_duplicate("untimed");
+  }
+  return get_formatted_string("%.0f", seconds * 1000.0);
+}
 
-  double p1_total = (double)(gd->total_games) - p0_total;
-  double p1_total_pct = p1_total / (double)(gd->total_games);
+static void
+string_builder_add_play_chooser_timing(StringBuilder *sb, const GameData *gd,
+                                       const RecorderContext *recorder_context,
+                                       int col_width) {
+  if (!recorder_context_uses_play_chooser(recorder_context)) {
+    return;
+  }
 
+  string_builder_add_string(sb, "PlayChooser Timing\n\n");
+  string_builder_add_table_row(sb, col_width, "", "Player 1", "Player 2");
+
+  char *values[2];
+  for (int i = 0; i < 2; i++) {
+    values[i] =
+        get_time_control_string(recorder_context->play_chooser_active[i],
+                                recorder_context->time_control_seconds[i]);
+  }
+  string_builder_add_table_row(sb, col_width, "Time control (ms):", values[0],
+                               values[1]);
+  free(values[0]);
+  free(values[1]);
+
+  for (int i = 0; i < 2; i++) {
+    const double mean_ms =
+        gd->total_games > 0
+            ? gd->total_seconds_used[i] * 1000.0 / (double)gd->total_games
+            : 0.0;
+    values[i] = get_timing_value_string(
+        recorder_context->play_chooser_active[i], mean_ms);
+  }
+  string_builder_add_table_row(sb, col_width, "Mean time used (ms):", values[0],
+                               values[1]);
+  free(values[0]);
+  free(values[1]);
+
+  for (int i = 0; i < 2; i++) {
+    values[i] =
+        get_timing_value_string(recorder_context->play_chooser_active[i],
+                                gd->total_overtime_seconds[i] * 1000.0);
+  }
+  string_builder_add_table_row(sb, col_width, "Total overtime (ms):", values[0],
+                               values[1]);
+  free(values[0]);
+  free(values[1]);
+
+  for (int i = 0; i < 2; i++) {
+    values[i] = recorder_context->play_chooser_active[i]
+                    ? get_formatted_string("%lu", gd->overtime_games[i])
+                    : string_duplicate("-");
+  }
+  string_builder_add_table_row(sb, col_width, "Overtime games:", values[0],
+                               values[1]);
+  free(values[0]);
+  free(values[1]);
+
+  for (int i = 0; i < 2; i++) {
+    values[i] = recorder_context->play_chooser_active[i]
+                    ? get_formatted_string("%lu", gd->penalty_points[i])
+                    : string_duplicate("-");
+  }
+  string_builder_add_table_row(sb, col_width, "Penalty points:", values[0],
+                               values[1]);
+  free(values[0]);
+  free(values[1]);
+
+  string_builder_add_formatted_string(
+      sb, "Rate: %d point%s per started %.0f ms\n\n",
+      recorder_context->overtime_penalty_points,
+      recorder_context->overtime_penalty_points == 1 ? "" : "s",
+      recorder_context->overtime_period_seconds * 1000.0);
+}
+
+char *game_data_human_readable_str(const GameData *gd, bool divergent,
+                                   const RecorderContext *recorder_context) {
   const int col_width = 25;
   StringBuilder *sb = string_builder_create();
   string_builder_add_string(sb, "\n");
@@ -274,10 +398,24 @@ char *game_data_human_readable_str(const GameData *gd, bool divergent) {
 
   if (gd->total_games == 0) {
     string_builder_add_string(sb, "\n");
+    string_builder_add_play_chooser_timing(sb, gd, recorder_context, col_width);
     char *no_games_ret_str = string_builder_dump(sb, NULL);
     string_builder_destroy(sb);
     return no_games_ret_str;
   }
+
+  uint64_t p0_wins = gd->p0_wins;
+  double p0_win_pct = (double)p0_wins / (double)gd->total_games;
+  uint64_t p0_losses = gd->p0_losses;
+  double p0_loss_pct = (double)p0_losses / (double)gd->total_games;
+  uint64_t p0_ties = gd->p0_ties;
+  double p0_tie_pct = (double)p0_ties / (double)gd->total_games;
+
+  double p0_total = (double)gd->p0_wins + (double)gd->p0_ties / (double)2;
+  double p0_total_pct = p0_total / (double)(gd->total_games);
+
+  double p1_total = (double)(gd->total_games) - p0_total;
+  double p1_total_pct = p1_total / (double)(gd->total_games);
 
   string_builder_add_formatted_string(sb, "Turns per Game: %0.2f %0.2f\n\n",
                                       stat_get_mean(gd->turns),
@@ -335,16 +473,19 @@ char *game_data_human_readable_str(const GameData *gd, bool divergent) {
                                                gd->total_games);
   string_builder_add_string(sb, "\n");
 
+  string_builder_add_play_chooser_timing(sb, gd, recorder_context, col_width);
+
   char *ret_str = string_builder_dump(sb, NULL);
   string_builder_destroy(sb);
   return ret_str;
 }
 
-char *game_data_str(const GameData *gd, bool human_readable, bool divergent) {
+char *game_data_str(const GameData *gd, bool human_readable, bool divergent,
+                    const RecorderContext *recorder_context) {
   if (human_readable) {
-    return game_data_human_readable_str(gd, divergent);
+    return game_data_human_readable_str(gd, divergent, recorder_context);
   }
-  return game_data_ucgi_str(gd);
+  return game_data_ucgi_str(gd, recorder_context);
 }
 
 typedef struct GameDataSets {
@@ -413,6 +554,16 @@ void game_data_sets_consolidate_subset(Recorder **recorder_list,
     p1_score_stats[i] = gd_i->p1_score;
     turns_stats[i] = gd_i->turns;
     gd_primary->total_turns += gd_i->total_turns;
+    for (int player_index = 0; player_index < 2; player_index++) {
+      gd_primary->total_seconds_used[player_index] +=
+          gd_i->total_seconds_used[player_index];
+      gd_primary->total_overtime_seconds[player_index] +=
+          gd_i->total_overtime_seconds[player_index];
+      gd_primary->overtime_games[player_index] +=
+          gd_i->overtime_games[player_index];
+      gd_primary->penalty_points[player_index] +=
+          gd_i->penalty_points[player_index];
+    }
     for (int j = 0; j < NUMBER_OF_GAME_END_REASONS; j++) {
       gd_primary->game_end_reasons[j] += gd_i->game_end_reasons[j];
     }
@@ -440,14 +591,15 @@ char *game_data_sets_str(Recorder *recorder, const RecorderArgs *args) {
   const GameDataSets *sets = (GameDataSets *)recorder->data;
   StringBuilder *sb = string_builder_create();
 
-  char *all_game_str =
-      game_data_str(sets->all_games, args->human_readable, false);
+  char *all_game_str = game_data_str(sets->all_games, args->human_readable,
+                                     false, recorder->recorder_context);
   string_builder_add_string(sb, all_game_str);
   free(all_game_str);
 
   if (args->divergent) {
     char *divergent_games_str =
-        game_data_str(sets->divergent_games, args->human_readable, true);
+        game_data_str(sets->divergent_games, args->human_readable, true,
+                      recorder->recorder_context);
     string_builder_add_string(sb, divergent_games_str);
     free(divergent_games_str);
   }
@@ -1097,7 +1249,7 @@ void recorder_consolidate(Recorder **recorder_list, int list_size,
 
 char *recorder_str(Recorder *recorder, bool human_readable,
                    bool show_divergent) {
-  RecorderArgs args;
+  RecorderArgs args = {0};
   args.human_readable = human_readable;
   args.divergent = show_divergent;
   return recorder->str_func(recorder, &args);
@@ -1226,6 +1378,13 @@ RecorderContext *create_recorder_context(void) {
   recorder_context->data_paths = NULL;
   recorder_context->ld = NULL;
   recorder_context->klv = NULL;
+  recorder_context->players_data = NULL;
+  recorder_context->play_chooser_active[0] = false;
+  recorder_context->play_chooser_active[1] = false;
+  recorder_context->time_control_seconds[0] = 0.0;
+  recorder_context->time_control_seconds[1] = 0.0;
+  recorder_context->overtime_penalty_points = 10;
+  recorder_context->overtime_period_seconds = 60.0;
   return recorder_context;
 }
 
@@ -1311,7 +1470,7 @@ void autoplay_results_reset(AutoplayResults *autoplay_results) {
 void autoplay_results_add_move(AutoplayResults *autoplay_results,
                                const Game *game, const Move *move,
                                const Rack *leave) {
-  RecorderArgs args;
+  RecorderArgs args = {0};
   args.game = game;
   args.move = move;
   args.leave = leave;
@@ -1325,11 +1484,20 @@ void autoplay_results_add_move(AutoplayResults *autoplay_results,
 void autoplay_results_add_game(AutoplayResults *autoplay_results,
                                const Game *game, int turns, bool divergent,
                                uint64_t seed) {
-  RecorderArgs args;
+  autoplay_results_add_game_with_timing(autoplay_results, game, turns,
+                                        divergent, seed, NULL);
+}
+
+void autoplay_results_add_game_with_timing(AutoplayResults *autoplay_results,
+                                           const Game *game, int turns,
+                                           bool divergent, uint64_t seed,
+                                           const AutoplayGameTiming *timing) {
+  RecorderArgs args = {0};
   args.game = game;
   args.number_of_turns = turns;
   args.divergent = divergent;
   args.seed = seed;
+  args.timing = timing;
   for (int i = 0; i < NUMBER_OF_AUTOPLAY_RECORDERS; i++) {
     if (autoplay_results->recorders[i]) {
       recorder_add_game(autoplay_results->recorders[i], &args);
@@ -1430,4 +1598,17 @@ void autoplay_results_set_klv(AutoplayResults *autoplay_results, KLV *klv) {
 void autoplay_results_set_players_data(AutoplayResults *autoplay_results,
                                        const PlayersData *players_data) {
   autoplay_results->recorder_context->players_data = players_data;
+}
+
+void autoplay_results_set_play_chooser_config(
+    AutoplayResults *autoplay_results, const bool active[2],
+    const double time_control_seconds[2], int overtime_penalty_points,
+    double overtime_period_seconds) {
+  RecorderContext *context = autoplay_results->recorder_context;
+  for (int i = 0; i < 2; i++) {
+    context->play_chooser_active[i] = active[i];
+    context->time_control_seconds[i] = time_control_seconds[i];
+  }
+  context->overtime_penalty_points = overtime_penalty_points;
+  context->overtime_period_seconds = overtime_period_seconds;
 }

--- a/src/ent/autoplay_results.h
+++ b/src/ent/autoplay_results.h
@@ -18,6 +18,13 @@ typedef enum {
 
 typedef struct AutoplayResults AutoplayResults;
 
+typedef struct AutoplayGameTiming {
+  bool active[2];
+  double seconds_used[2];
+  double overtime_seconds[2];
+  int penalty_points[2];
+} AutoplayGameTiming;
+
 AutoplayResults *autoplay_results_create(void);
 AutoplayResults *
 autoplay_results_create_empty_copy(const AutoplayResults *orig);
@@ -32,6 +39,10 @@ void autoplay_results_add_move(AutoplayResults *autoplay_results,
 void autoplay_results_add_game(AutoplayResults *autoplay_results,
                                const Game *game, int turns, bool divergent,
                                uint64_t seed);
+void autoplay_results_add_game_with_timing(AutoplayResults *autoplay_results,
+                                           const Game *game, int turns,
+                                           bool divergent, uint64_t seed,
+                                           const AutoplayGameTiming *timing);
 void autoplay_results_consolidate(AutoplayResults **autoplay_results_list,
                                   int list_size, AutoplayResults *primary);
 char *autoplay_results_to_string(AutoplayResults *autoplay_results,
@@ -54,6 +65,10 @@ uint64_t autoplay_results_build_option(autoplay_recorder_t recorder_type);
 uint64_t autoplay_results_get_options(const AutoplayResults *autoplay_results);
 void autoplay_results_set_players_data(AutoplayResults *autoplay_results,
                                        const PlayersData *players_data);
+void autoplay_results_set_play_chooser_config(
+    AutoplayResults *autoplay_results, const bool active[2],
+    const double time_control_seconds[2], int overtime_penalty_points,
+    double overtime_period_seconds);
 void autoplay_results_set_status_data(AutoplayResults *autoplay_results,
                                       AutoplayResults **results_list,
                                       int results_list_size, bool finished,

--- a/src/ent/game_timer.h
+++ b/src/ent/game_timer.h
@@ -6,29 +6,43 @@
 #include <stdbool.h>
 
 // Per-side game clock. Each player's clock counts down while it is their
-// turn. A nonpositive time_per_side_seconds means the game is untimed.
+// turn. A player's nonpositive time control means that player is untimed.
 // Engine components (for example the play chooser) can budget per-move
 // thinking time from the remaining clock.
 // Not thread safe.
 typedef struct GameTimer {
-  double time_per_side_seconds;
+  double time_per_player_seconds[2];
   double seconds_used[2];
   // Player whose clock is currently ticking, or -1 when no turn is active.
   int ticking_player_index;
   Timer turn_timer;
 } GameTimer;
 
-static inline void game_timer_reset(GameTimer *game_timer,
-                                    double time_per_side_seconds) {
-  game_timer->time_per_side_seconds = time_per_side_seconds;
+static inline void game_timer_reset_for_players(GameTimer *game_timer,
+                                                double player0_seconds,
+                                                double player1_seconds) {
+  game_timer->time_per_player_seconds[0] = player0_seconds;
+  game_timer->time_per_player_seconds[1] = player1_seconds;
   game_timer->seconds_used[0] = 0.0;
   game_timer->seconds_used[1] = 0.0;
   game_timer->ticking_player_index = -1;
   ctimer_reset(&game_timer->turn_timer);
 }
 
+static inline void game_timer_reset(GameTimer *game_timer,
+                                    double time_per_side_seconds) {
+  game_timer_reset_for_players(game_timer, time_per_side_seconds,
+                               time_per_side_seconds);
+}
+
+static inline bool game_timer_player_is_untimed(const GameTimer *game_timer,
+                                                int player_index) {
+  return game_timer->time_per_player_seconds[player_index] <= 0.0;
+}
+
 static inline bool game_timer_is_untimed(const GameTimer *game_timer) {
-  return game_timer->time_per_side_seconds <= 0.0;
+  return game_timer_player_is_untimed(game_timer, 0) &&
+         game_timer_player_is_untimed(game_timer, 1);
 }
 
 // Stops the currently ticking turn (if any), accumulating the elapsed time
@@ -65,19 +79,30 @@ static inline double game_timer_get_seconds_used(const GameTimer *game_timer,
 static inline double
 game_timer_get_seconds_remaining(const GameTimer *game_timer,
                                  int player_index) {
-  if (game_timer_is_untimed(game_timer)) {
+  if (game_timer_player_is_untimed(game_timer, player_index)) {
     return INFINITY;
   }
   const double seconds_remaining =
-      game_timer->time_per_side_seconds -
+      game_timer->time_per_player_seconds[player_index] -
       game_timer_get_seconds_used(game_timer, player_index);
   return seconds_remaining > 0.0 ? seconds_remaining : 0.0;
 }
 
 static inline bool game_timer_is_expired(const GameTimer *game_timer,
                                          int player_index) {
-  return !game_timer_is_untimed(game_timer) &&
+  return !game_timer_player_is_untimed(game_timer, player_index) &&
          game_timer_get_seconds_remaining(game_timer, player_index) <= 0.0;
+}
+
+static inline double
+game_timer_get_overtime_seconds(const GameTimer *game_timer, int player_index) {
+  if (game_timer_player_is_untimed(game_timer, player_index)) {
+    return 0.0;
+  }
+  const double overtime =
+      game_timer_get_seconds_used(game_timer, player_index) -
+      game_timer->time_per_player_seconds[player_index];
+  return overtime > 0.0 ? overtime : 0.0;
 }
 
 #endif

--- a/src/impl/autoplay.c
+++ b/src/impl/autoplay.c
@@ -5,6 +5,7 @@
 #include "../compat/ctime.h"
 #include "../def/autoplay_defs.h"
 #include "../def/cpthread_defs.h"
+#include "../def/equity_defs.h"
 #include "../def/game_history_defs.h"
 #include "../def/letter_distribution_defs.h"
 #include "../def/players_data_defs.h"

--- a/src/impl/autoplay.c
+++ b/src/impl/autoplay.c
@@ -16,6 +16,7 @@
 #include "../ent/data_filepaths.h"
 #include "../ent/equity.h"
 #include "../ent/game.h"
+#include "../ent/game_timer.h"
 #include "../ent/inference_args.h"
 #include "../ent/inference_results.h"
 #include "../ent/klv.h"
@@ -35,9 +36,10 @@
 #include "../util/io_util.h"
 #include "../util/string_util.h"
 #include "gameplay.h"
+#include "play_chooser.h"
 #include "rack_list.h"
 #include "simmer.h"
-#include <limits.h>
+#include <math.h>
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -64,6 +66,21 @@ void autoplay_reset_total_sim_iterations(void) {
 // the game trajectory independent of sim throughput, so different RIT/BAI
 // variants run through the same sequence of positions.
 static _Atomic bool autoplay_bench_static_move_enabled;
+
+int autoplay_overtime_penalty_points(double overtime_seconds,
+                                     int points_per_period,
+                                     double period_seconds) {
+  if (overtime_seconds <= 0.0 || points_per_period <= 0 ||
+      period_seconds <= 0.0) {
+    return 0;
+  }
+  const double periods = ceil(overtime_seconds / period_seconds);
+  const int max_penalty_points = (int)EQUITY_MAX_DOUBLE;
+  if (periods >= (double)max_penalty_points / (double)points_per_period) {
+    return max_penalty_points;
+  }
+  return (int)periods * points_per_period;
+}
 
 void autoplay_set_bench_static_move(bool enabled) {
   atomic_store_explicit(&autoplay_bench_static_move_enabled, enabled,
@@ -356,12 +373,21 @@ AutoplayWorker *autoplay_worker_create(const AutoplayArgs *args,
   autoplay_worker->inference_results = NULL;
   autoplay_worker->error_stack = NULL;
 
-  // Only allocate sim structs if at least one of the players running a sim.
-  if (ap_args->p1_sim_args.num_plies > 0 ||
-      ap_args->p2_sim_args.num_plies > 0) {
+  const bool any_player_sims =
+      ap_args->p1_sim_args.num_plies > 0 || ap_args->p2_sim_args.num_plies > 0;
+  const bool any_player_uses_play_chooser =
+      ap_args->use_play_chooser[0] || ap_args->use_play_chooser[1];
+  // PlayChooser needs an error stack. The remaining objects are specific to
+  // the legacy autoplay simmer.
+  if (any_player_uses_play_chooser) {
+    autoplay_worker->error_stack = error_stack_create();
+  }
+  if (any_player_sims) {
     autoplay_worker->sim_results = sim_results_create(ap_args->cutoff);
     autoplay_worker->inference_results = inference_results_create(NULL);
-    autoplay_worker->error_stack = error_stack_create();
+    if (autoplay_worker->error_stack == NULL) {
+      autoplay_worker->error_stack = error_stack_create();
+    }
     rack_set_dist_size_and_reset(&autoplay_worker->target_played_tiles,
                                  ld_get_size(ap_args->game_args->ld));
     rack_set_dist_size_and_reset(&autoplay_worker->nontarget_known_rack,
@@ -493,8 +519,19 @@ typedef struct GameRunner {
   // inference
   Game *game_one_move_behind;
   Move previous_move;
+  Move play_chooser_move;
+  PlayChooser *play_choosers[2];
+  GameTimer game_timer;
+  AutoplayGameTiming timing;
   AutoplaySharedData *shared_data;
 } GameRunner;
+
+static void game_runner_destroy_play_choosers(GameRunner *game_runner) {
+  for (int player_index = 0; player_index < 2; player_index++) {
+    play_chooser_destroy(game_runner->play_choosers[player_index]);
+    game_runner->play_choosers[player_index] = NULL;
+  }
+}
 
 GameRunner *game_runner_create(AutoplayWorker *autoplay_worker) {
   const AutoplayArgs *args = &autoplay_worker->args;
@@ -507,6 +544,10 @@ GameRunner *game_runner_create(AutoplayWorker *autoplay_worker) {
   }
   game_runner->pair_game_number =
       0; // Will be set in game_runner_start if using pairs
+  game_runner->play_choosers[0] = NULL;
+  game_runner->play_choosers[1] = NULL;
+  game_timer_reset(&game_runner->game_timer, 0.0);
+  game_runner->timing = (AutoplayGameTiming){0};
   return game_runner;
 }
 
@@ -514,9 +555,26 @@ void game_runner_destroy(GameRunner *game_runner) {
   if (!game_runner) {
     return;
   }
+  game_runner_destroy_play_choosers(game_runner);
   game_destroy(game_runner->game);
   game_destroy(game_runner->game_one_move_behind);
   free(game_runner);
+}
+
+static void game_runner_create_play_choosers(AutoplayWorker *autoplay_worker,
+                                             GameRunner *game_runner,
+                                             uint64_t seed) {
+  game_runner_destroy_play_choosers(game_runner);
+  const AutoplayArgs *args = &autoplay_worker->args;
+  for (int player_index = 0; player_index < 2; player_index++) {
+    if (!args->use_play_chooser[player_index]) {
+      continue;
+    }
+    PlayChooserStrategy strategy = args->play_chooser_strategies[player_index];
+    strategy.game_timer = &game_runner->game_timer;
+    strategy.seed = seed + (uint64_t)player_index;
+    game_runner->play_choosers[player_index] = play_chooser_create(&strategy);
+  }
 }
 
 void game_runner_start(AutoplayWorker *autoplay_worker, GameRunner *game_runner,
@@ -532,6 +590,12 @@ void game_runner_start(AutoplayWorker *autoplay_worker, GameRunner *game_runner,
   autoplay_worker->args.p2_sim_args.seed = iter_output->seed;
   game_set_starting_player_index(game, starting_player_index);
   draw_starting_racks(game);
+  game_timer_reset_for_players(&game_runner->game_timer,
+                               autoplay_worker->args.time_control_seconds[0],
+                               autoplay_worker->args.time_control_seconds[1]);
+  game_runner->timing = (AutoplayGameTiming){0};
+  game_runner_create_play_choosers(autoplay_worker, game_runner,
+                                   iter_output->seed);
   if (game_runner->game_one_move_behind) {
     Game *game_one_move_behind = game_runner->game_one_move_behind;
     game_reset(game_one_move_behind);
@@ -655,6 +719,23 @@ const Move *game_runner_get_best_move(AutoplayWorker *autoplay_worker,
                                       GameRunner *game_runner) {
   const int player_on_turn_index =
       game_get_player_on_turn_index(game_runner->game);
+  PlayChooser *play_chooser = game_runner->play_choosers[player_on_turn_index];
+  if (play_chooser != NULL) {
+    game_timer_start_turn(&game_runner->game_timer, player_on_turn_index);
+    play_chooser_choose_move(play_chooser, game_runner->game,
+                             &game_runner->play_chooser_move,
+                             autoplay_worker->error_stack);
+    game_timer_end_turn(&game_runner->game_timer);
+    if (!error_stack_is_empty(autoplay_worker->error_stack)) {
+      error_stack_print_and_reset(autoplay_worker->error_stack);
+      log_fatal("autoplay PlayChooser failed for player %d on turn %d of "
+                "game number %llu with seed %llu",
+                player_on_turn_index + 1, game_runner->turn_number + 1,
+                (unsigned long long)game_runner->game_number + 1,
+                (unsigned long long)game_runner->seed);
+    }
+    return &game_runner->play_chooser_move;
+  }
   const SimArgs *sim_args = (player_on_turn_index == 0)
                                 ? &autoplay_worker->args.p1_sim_args
                                 : &autoplay_worker->args.p2_sim_args;
@@ -743,7 +824,8 @@ const Move *game_runner_play_move(AutoplayWorker *autoplay_worker,
     const SimArgs *sim_args = (player_on_turn_index == 0)
                                   ? &autoplay_worker->args.p1_sim_args
                                   : &autoplay_worker->args.p2_sim_args;
-    if (sim_args->num_plies > 0) {
+    if (sim_args->num_plies > 0 &&
+        !autoplay_worker->args.use_play_chooser[player_on_turn_index]) {
       char *sim_str = sim_results_get_string(
           game, autoplay_worker->sim_results, sim_args->max_num_display_plays,
           sim_args->max_num_display_plies, -1, -1, NULL, 0, false, false, false,
@@ -770,6 +852,28 @@ const Move *game_runner_play_move(AutoplayWorker *autoplay_worker,
   move_copy(&game_runner->previous_move, move);
   game_runner->turn_number++;
   return move;
+}
+
+static void game_runner_assess_overtime(AutoplayWorker *autoplay_worker,
+                                        GameRunner *game_runner) {
+  const AutoplayArgs *args = &autoplay_worker->args;
+  game_timer_end_turn(&game_runner->game_timer);
+  for (int player_index = 0; player_index < 2; player_index++) {
+    if (!args->use_play_chooser[player_index]) {
+      continue;
+    }
+    game_runner->timing.active[player_index] = true;
+    game_runner->timing.seconds_used[player_index] =
+        game_timer_get_seconds_used(&game_runner->game_timer, player_index);
+    game_runner->timing.overtime_seconds[player_index] =
+        game_timer_get_overtime_seconds(&game_runner->game_timer, player_index);
+    const int penalty_points = autoplay_overtime_penalty_points(
+        game_runner->timing.overtime_seconds[player_index],
+        args->overtime_penalty_points, args->overtime_period_seconds);
+    game_runner->timing.penalty_points[player_index] = penalty_points;
+    player_add_to_score(game_get_player(game_runner->game, player_index),
+                        -int_to_equity(penalty_points));
+  }
 }
 
 void print_current_status(AutoplayWorker *autoplay_worker,
@@ -800,9 +904,10 @@ void print_current_status(AutoplayWorker *autoplay_worker,
 
 void autoplay_add_game(AutoplayWorker *autoplay_worker,
                        const GameRunner *game_runner, bool divergent) {
-  autoplay_results_add_game(autoplay_worker->autoplay_results,
-                            game_runner->game, game_runner->turn_number,
-                            divergent, game_runner->seed);
+  autoplay_results_add_game_with_timing(
+      autoplay_worker->autoplay_results, game_runner->game,
+      game_runner->turn_number, divergent, game_runner->seed,
+      &game_runner->timing);
   AutoplayIterCompletedOutput iter_completed_output;
   autoplay_complete_iter(autoplay_worker->shared_data, &iter_completed_output);
   if (iter_completed_output.print_info) {
@@ -849,6 +954,10 @@ void play_autoplay_game_or_game_pair(AutoplayWorker *autoplay_worker,
          compare_moves_without_equity(move1, move2, true) != -1)) {
       games_are_divergent = true;
     }
+  }
+  game_runner_assess_overtime(autoplay_worker, game_runner1);
+  if (game_runner2) {
+    game_runner_assess_overtime(autoplay_worker, game_runner2);
   }
   if (autoplay_worker->args.print_boards) {
     StringBuilder *output = string_builder_create();
@@ -1018,6 +1127,9 @@ void autoplay(const AutoplayArgs *args, AutoplayResults *autoplay_results,
   }
 
   const bool is_leavegen_mode = args->type == AUTOPLAY_TYPE_LEAVE_GEN;
+  autoplay_results_set_play_chooser_config(
+      autoplay_results, args->use_play_chooser, args->time_control_seconds,
+      args->overtime_penalty_points, args->overtime_period_seconds);
   int num_gens = 1;
   int *min_rack_targets = NULL;
   uint64_t first_gen_num_games;

--- a/src/impl/autoplay.h
+++ b/src/impl/autoplay.h
@@ -7,6 +7,7 @@
 #include "../ent/sim_args.h"
 #include "../ent/thread_control.h"
 #include "../util/io_util.h"
+#include "play_chooser.h"
 #include <stdbool.h>
 
 typedef struct GameStringOptions GameStringOptions;
@@ -40,6 +41,14 @@ typedef struct AutoplayArgs {
   double cutoff;
   SimArgs p1_sim_args;
   SimArgs p2_sim_args;
+  bool use_play_chooser[2];
+  // Total clock for each PlayChooser player. Zero means untimed.
+  double time_control_seconds[2];
+  int overtime_penalty_points;
+  double overtime_period_seconds;
+  // Templates copied into each game runner, which supplies the per-game
+  // timer and seed before constructing its choosers.
+  PlayChooserStrategy play_chooser_strategies[2];
 } AutoplayArgs;
 
 void autoplay(const AutoplayArgs *args, AutoplayResults *autoplay_results,
@@ -56,5 +65,9 @@ void autoplay_reset_total_sim_iterations(void);
 // trajectory so RIT/BAI variants can be compared over identical positions.
 void autoplay_set_bench_static_move(bool enabled);
 bool autoplay_get_bench_static_move(void);
+
+int autoplay_overtime_penalty_points(double overtime_seconds,
+                                     int points_per_period,
+                                     double period_seconds);
 
 #endif

--- a/src/impl/config.c
+++ b/src/impl/config.c
@@ -64,6 +64,7 @@
 #include "inference.h"
 #include "move_gen.h"
 #include "peg.h"
+#include "play_chooser.h"
 #include "simmer.h"
 #include <assert.h>
 #include <ctype.h>

--- a/src/impl/config.c
+++ b/src/impl/config.c
@@ -223,6 +223,10 @@ typedef enum {
   ARG_TOKEN_P2_SIM_WITH_INFERENCE,
   ARG_TOKEN_P1_TIME_LIMIT,
   ARG_TOKEN_P2_TIME_LIMIT,
+  ARG_TOKEN_P1_PLAY_CHOOSER_TIME,
+  ARG_TOKEN_P2_PLAY_CHOOSER_TIME,
+  ARG_TOKEN_OVERTIME_PENALTY_POINTS,
+  ARG_TOKEN_OVERTIME_PERIOD,
   ARG_TOKEN_P1_THRESHOLD,
   ARG_TOKEN_P2_THRESHOLD,
   ARG_TOKEN_P1_SAMPLING_RULE,
@@ -360,6 +364,12 @@ struct Config {
   bool p2_sim_with_inference;
   double p1_time_limit_seconds;
   double p2_time_limit_seconds;
+  // Milliseconds per game. Negative disables PlayChooser; zero enables it
+  // without a clock.
+  double p1_play_chooser_time_ms;
+  double p2_play_chooser_time_ms;
+  int overtime_penalty_points;
+  double overtime_period_ms;
   bai_threshold_t p1_threshold;
   bai_threshold_t p2_threshold;
   bai_sampling_rule_t p1_sampling_rule;
@@ -2090,6 +2100,31 @@ void add_help_arg_to_string_builder(const Config *config, int token,
       text = "Specifies the time limit in seconds for simulation for player "
              "1 or 2 during autoplay. Fractional values supported.";
       break;
+    case ARG_TOKEN_P1_PLAY_CHOOSER_TIME:
+    case ARG_TOKEN_P2_PLAY_CHOOSER_TIME:
+      usages[0] = "<milliseconds>";
+      examples[0] = "30000";
+      examples[1] = "-1";
+      text = "Enables PlayChooser for player 1 or 2 during autoplay and sets "
+             "that player's total per-game clock in milliseconds. -1 "
+             "disables PlayChooser for the player (the default); 0 enables "
+             "it without a clock.";
+      break;
+    case ARG_TOKEN_OVERTIME_PENALTY_POINTS:
+      usages[0] = "<points>";
+      examples[0] = "10";
+      examples[1] = "1";
+      text = "Points deducted for each started overtime period in timed "
+             "PlayChooser autoplay. Defaults to 10.";
+      break;
+    case ARG_TOKEN_OVERTIME_PERIOD:
+      usages[0] = "<milliseconds>";
+      examples[0] = "60000";
+      examples[1] = "1000";
+      text = "Length in milliseconds of each started overtime penalty "
+             "period. Defaults to 60000 (one minute); use 1000 with "
+             "-otpenalty 1 for one point per started second.";
+      break;
     case ARG_TOKEN_P1_THRESHOLD:
     case ARG_TOKEN_P2_THRESHOLD:
       usages[0] = "<threshold>";
@@ -2284,6 +2319,10 @@ char *impl_help(Config *config, ErrorStack *error_stack) {
         ARG_TOKEN_NUMBER_OF_SMALL_PLAYS,   /* numsmallplays */
         ARG_TOKEN_P1_NUM_PLAYS,            /* np1 */
         ARG_TOKEN_P2_NUM_PLAYS,            /* np2 */
+        ARG_TOKEN_OVERTIME_PENALTY_POINTS, /* otpenalty */
+        ARG_TOKEN_OVERTIME_PERIOD,         /* otperiod */
+        ARG_TOKEN_P1_PLAY_CHOOSER_TIME,    /* pc1 */
+        ARG_TOKEN_P2_PLAY_CHOOSER_TIME,    /* pc2 */
         ARG_TOKEN_PEG_NESTED,              /* pegnested */
         ARG_TOKEN_PEG_ONLY,                /* pegonly */
         ARG_TOKEN_PEG_OUTCOMES,            /* pegoutcomes */
@@ -3492,12 +3531,28 @@ void config_fill_autoplay_args(const Config *config,
   config_fill_game_args(config, autoplay_args->game_args);
   autoplay_args->multi_threading_mode = config->multi_threading_mode;
   autoplay_args->cutoff = config->cutoff;
+  const double play_chooser_time_ms[2] = {config->p1_play_chooser_time_ms,
+                                          config->p2_play_chooser_time_ms};
+  for (int player_index = 0; player_index < 2; player_index++) {
+    autoplay_args->use_play_chooser[player_index] =
+        autoplay_type == AUTOPLAY_TYPE_DEFAULT &&
+        play_chooser_time_ms[player_index] >= 0.0;
+    autoplay_args->time_control_seconds[player_index] =
+        autoplay_args->use_play_chooser[player_index]
+            ? play_chooser_time_ms[player_index] / 1000.0
+            : 0.0;
+  }
+  autoplay_args->overtime_penalty_points = config->overtime_penalty_points;
+  autoplay_args->overtime_period_seconds = config->overtime_period_ms / 1000.0;
 
   autoplay_args->num_threads = config->num_threads;
   int num_worker_threads_per_sim = 1;
+  const bool any_player_uses_play_chooser =
+      autoplay_args->use_play_chooser[0] || autoplay_args->use_play_chooser[1];
   if (autoplay_args->multi_threading_mode ==
           MULTI_THREADING_MODE_INTRA_GAME_PARALLELISM &&
-      (config->p1_sim_plies > 0 || config->p2_sim_plies > 0)) {
+      (config->p1_sim_plies > 0 || config->p2_sim_plies > 0 ||
+       any_player_uses_play_chooser)) {
     autoplay_args->num_threads = 1;
     num_worker_threads_per_sim = config->num_threads;
   }
@@ -3568,6 +3623,26 @@ void config_fill_autoplay_args(const Config *config,
       config->p2_utility_w_winpct, config->p2_utility_w_spread,
       config->p2_utility_spread_scale, &p2_inference_args,
       &autoplay_args->p2_sim_args);
+
+  const double utility_win_pct[2] = {config->p1_utility_w_winpct,
+                                     config->p2_utility_w_winpct};
+  const double utility_spread[2] = {config->p1_utility_w_spread,
+                                    config->p2_utility_w_spread};
+  const double utility_spread_scale[2] = {config->p1_utility_spread_scale,
+                                          config->p2_utility_spread_scale};
+  for (int player_index = 0; player_index < 2; player_index++) {
+    autoplay_args->play_chooser_strategies[player_index] =
+        (PlayChooserStrategy){
+            .pre_endgame_eval = PLAY_CHOOSER_EVAL_PEG,
+            .endgame_eval = PLAY_CHOOSER_EVAL_ENDGAME,
+            .win_pcts = config->win_pcts,
+            .num_threads = num_worker_threads_per_sim,
+            .peg_scenario_stride = config->peg_scenario_stride,
+            .utility_w_winpct = utility_win_pct[player_index],
+            .utility_w_spread = utility_spread[player_index],
+            .utility_spread_scale = utility_spread_scale[player_index],
+        };
+  }
 }
 
 void config_autoplay(const Config *config, AutoplayResults *autoplay_results,
@@ -3592,7 +3667,9 @@ void impl_autoplay(Config *config, ErrorStack *error_stack) {
     return;
   }
 
-  if (config->p1_sim_plies > 0 || config->p2_sim_plies > 0) {
+  if (config->p1_sim_plies > 0 || config->p2_sim_plies > 0 ||
+      config->p1_play_chooser_time_ms >= 0.0 ||
+      config->p2_play_chooser_time_ms >= 0.0) {
     config_load_win_pcts(config, error_stack);
     if (!error_stack_is_empty(error_stack)) {
       return;
@@ -7476,6 +7553,27 @@ void config_load_data(Config *config, ErrorStack *error_stack) {
     return;
   }
 
+  config_load_double(config, ARG_TOKEN_P1_PLAY_CHOOSER_TIME, -1, 1e12,
+                     &config->p1_play_chooser_time_ms, error_stack);
+  if (!error_stack_is_empty(error_stack)) {
+    return;
+  }
+  config_load_double(config, ARG_TOKEN_P2_PLAY_CHOOSER_TIME, -1, 1e12,
+                     &config->p2_play_chooser_time_ms, error_stack);
+  if (!error_stack_is_empty(error_stack)) {
+    return;
+  }
+  config_load_int(config, ARG_TOKEN_OVERTIME_PENALTY_POINTS, 0, INT_MAX,
+                  &config->overtime_penalty_points, error_stack);
+  if (!error_stack_is_empty(error_stack)) {
+    return;
+  }
+  config_load_double(config, ARG_TOKEN_OVERTIME_PERIOD, 1, 1e12,
+                     &config->overtime_period_ms, error_stack);
+  if (!error_stack_is_empty(error_stack)) {
+    return;
+  }
+
   if (config_get_parg_value(config, ARG_TOKEN_THRESHOLD, 0) != NULL) {
     config->p1_threshold = config->threshold;
     config->p2_threshold = config->threshold;
@@ -8700,6 +8798,10 @@ Config *config_create(const ConfigArgs *config_args, ErrorStack *error_stack) {
   arg(ARG_TOKEN_P2_SIM_WITH_INFERENCE, "si2", 1, 1);
   arg(ARG_TOKEN_P1_TIME_LIMIT, "tl1", 1, 1);
   arg(ARG_TOKEN_P2_TIME_LIMIT, "tl2", 1, 1);
+  arg(ARG_TOKEN_P1_PLAY_CHOOSER_TIME, "pc1", 1, 1);
+  arg(ARG_TOKEN_P2_PLAY_CHOOSER_TIME, "pc2", 1, 1);
+  arg(ARG_TOKEN_OVERTIME_PENALTY_POINTS, "otpenalty", 1, 1);
+  arg(ARG_TOKEN_OVERTIME_PERIOD, "otperiod", 1, 1);
   arg(ARG_TOKEN_P1_THRESHOLD, "th1", 1, 1);
   arg(ARG_TOKEN_P2_THRESHOLD, "th2", 1, 1);
   arg(ARG_TOKEN_P1_SAMPLING_RULE, "sa1", 1, 1);
@@ -8808,6 +8910,10 @@ Config *config_create(const ConfigArgs *config_args, ErrorStack *error_stack) {
   config->p2_sim_with_inference = config->sim_with_inference;
   config->p1_time_limit_seconds = config->time_limit_seconds;
   config->p2_time_limit_seconds = config->time_limit_seconds;
+  config->p1_play_chooser_time_ms = -1.0;
+  config->p2_play_chooser_time_ms = -1.0;
+  config->overtime_penalty_points = 10;
+  config->overtime_period_ms = 60000.0;
   config->p1_threshold = config->threshold;
   config->p2_threshold = config->threshold;
   config->p1_sampling_rule = config->sampling_rule;
@@ -9337,6 +9443,22 @@ void config_add_settings_to_string_builder(const Config *config,
     case ARG_TOKEN_P2_TIME_LIMIT:
       config_add_double_setting_to_string_builder(
           config, sb, arg_token, config->p2_time_limit_seconds);
+      break;
+    case ARG_TOKEN_P1_PLAY_CHOOSER_TIME:
+      config_add_double_setting_to_string_builder(
+          config, sb, arg_token, config->p1_play_chooser_time_ms);
+      break;
+    case ARG_TOKEN_P2_PLAY_CHOOSER_TIME:
+      config_add_double_setting_to_string_builder(
+          config, sb, arg_token, config->p2_play_chooser_time_ms);
+      break;
+    case ARG_TOKEN_OVERTIME_PENALTY_POINTS:
+      config_add_int_setting_to_string_builder(config, sb, arg_token,
+                                               config->overtime_penalty_points);
+      break;
+    case ARG_TOKEN_OVERTIME_PERIOD:
+      config_add_double_setting_to_string_builder(config, sb, arg_token,
+                                                  config->overtime_period_ms);
       break;
     case ARG_TOKEN_SAMPLING_RULE:
       string_builder_add_formatted_string(sb, " -%s ",

--- a/src/impl/config.c
+++ b/src/impl/config.c
@@ -1791,7 +1791,11 @@ void add_help_arg_to_string_builder(const Config *config, int token,
           "seed, with player one going first in one game and player two going "
           "first in the other game. Since the games are deterministic for a "
           "given starting seed, if both players make the exact same decision "
-          "for each corresponding play, the games will be identical.";
+          "for each corresponding play, the games will be identical. This "
+          "does not hold when a player runs on a PlayChooser clock (-pc1 / "
+          "-pc2): move choice then depends on how much search fits in the "
+          "budget, so the paired games are no longer a controlled comparison "
+          "over identical draws.";
       break;
     case ARG_TOKEN_USE_SMALL_PLAYS:
       usages[0] = "<true_or_false>";
@@ -2109,7 +2113,13 @@ void add_help_arg_to_string_builder(const Config *config, int token,
       text = "Enables PlayChooser for player 1 or 2 during autoplay and sets "
              "that player's total per-game clock in milliseconds. -1 "
              "disables PlayChooser for the player (the default); 0 enables "
-             "it without a clock.";
+             "it without a clock. A clocked player's games are not "
+             "reproducible from the seed: how much search fits in the budget "
+             "varies with machine load, thread count, and build, so move "
+             "choice and the overtime penalty vary between runs of the same "
+             "seed. Read the aggregate results (win%, spread, penalty "
+             "points), which are meaningful across enough games; individual "
+             "games are not intended to replay identically.";
       break;
     case ARG_TOKEN_OVERTIME_PENALTY_POINTS:
       usages[0] = "<points>";

--- a/src/impl/config.c
+++ b/src/impl/config.c
@@ -2119,7 +2119,12 @@ void add_help_arg_to_string_builder(const Config *config, int token,
              "choice and the overtime penalty vary between runs of the same "
              "seed. Read the aggregate results (win%, spread, penalty "
              "points), which are meaningful across enough games; individual "
-             "games are not intended to replay identically.";
+             "games are not intended to replay identically. How much search "
+             "the clock buys also depends on -mtmode: pgp (the default) "
+             "gives each concurrent game's chooser one thread, while igp "
+             "plays one game at a time and gives that chooser every thread. "
+             "Compare timed runs only against runs with the same -mtmode and "
+             "-threads.";
       break;
     case ARG_TOKEN_OVERTIME_PENALTY_POINTS:
       usages[0] = "<points>";

--- a/src/impl/play_chooser.c
+++ b/src/impl/play_chooser.c
@@ -186,10 +186,11 @@ play_chooser_get_seconds_for_move(const PlayChooserStrategy *strategy,
     return strategy->fixed_seconds_per_move;
   }
   const GameTimer *game_timer = strategy->game_timer;
-  if (game_timer == NULL || game_timer_is_untimed(game_timer)) {
+  const int player_on_turn_index = game_get_player_on_turn_index(game);
+  if (game_timer == NULL ||
+      game_timer_player_is_untimed(game_timer, player_on_turn_index)) {
     return PLAY_CHOOSER_DEFAULT_UNTIMED_MOVE_SECONDS;
   }
-  const int player_on_turn_index = game_get_player_on_turn_index(game);
   const int total_unplayed_tiles =
       bag_get_letters(game_get_bag(game)) +
       rack_get_total_letters(player_get_rack(game_get_player(game, 0))) +

--- a/test/autoplay_test.c
+++ b/test/autoplay_test.c
@@ -3,6 +3,7 @@
 #include "../src/ent/equity.h"
 #include "../src/ent/game.h"
 #include "../src/ent/klv.h"
+#include "../src/impl/autoplay.h"
 #include "../src/impl/config.h"
 #include "../src/util/io_util.h"
 #include "../src/util/math_util.h"
@@ -461,6 +462,85 @@ void test_autoplay_sim(void) {
   config_destroy(config);
 }
 
+void test_autoplay_play_chooser(void) {
+  assert(autoplay_overtime_penalty_points(0.0, 10, 60.0) == 0);
+  assert(autoplay_overtime_penalty_points(0.001, 10, 60.0) == 10);
+  assert(autoplay_overtime_penalty_points(60.0, 10, 60.0) == 10);
+  assert(autoplay_overtime_penalty_points(60.001, 10, 60.0) == 20);
+  assert(autoplay_overtime_penalty_points(0.001, 1, 1.0) == 1);
+  assert(autoplay_overtime_penalty_points(1.001, 1, 1.0) == 2);
+  assert(autoplay_overtime_penalty_points(1.0, 0, 1.0) == 0);
+
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -wmp false -s1 equity -s2 equity -r1 best -r2 best "
+      "-numplays 1 -gp false -threads 1 -hr true -pc1 1 -pc2 -1 "
+      "-otpenalty 1 -otperiod 1");
+
+  load_and_exec_config_or_die(config, "autoplay games 1 -seed 123");
+  char *human_output = autoplay_results_to_string(
+      config_get_autoplay_results(config), true, false);
+  assert(has_substring(human_output, "PlayChooser Timing"));
+  assert(has_substring(human_output, "Time control (ms):"));
+  assert(has_substring(human_output, "Penalty points:"));
+  assert(has_substring(human_output, "Rate: 1 point per started 1 ms"));
+  free(human_output);
+
+  char *machine_output = autoplay_results_to_string(
+      config_get_autoplay_results(config), false, false);
+  assert(has_substring(machine_output, "playchooser 1 0 1 0"));
+  const char *play_chooser_output = strstr(machine_output, "playchooser");
+  int active[2];
+  double time_control_ms[2];
+  double seconds_used_ms[2];
+  double overtime_ms[2];
+  unsigned long penalty_points[2];
+  assert(sscanf(play_chooser_output,
+                "playchooser %d %d %lf %lf %lf %lf %lf %lf %lu %lu", &active[0],
+                &active[1], &time_control_ms[0], &time_control_ms[1],
+                &seconds_used_ms[0], &seconds_used_ms[1], &overtime_ms[0],
+                &overtime_ms[1], &penalty_points[0], &penalty_points[1]) == 10);
+  assert(active[0] == 1);
+  assert(active[1] == 0);
+  assert(time_control_ms[0] == 1.0);
+  assert(seconds_used_ms[0] > 1.0);
+  assert(overtime_ms[0] > 0.0);
+  assert(penalty_points[0] > 0);
+  free(machine_output);
+
+  load_and_exec_config_or_die(config,
+                              "autoplay games 1 -pc1 -1 -pc2 -1 -seed 124");
+  human_output = autoplay_results_to_string(config_get_autoplay_results(config),
+                                            true, false);
+  assert(!has_substring(human_output, "PlayChooser Timing"));
+  free(human_output);
+
+  machine_output = autoplay_results_to_string(
+      config_get_autoplay_results(config), false, false);
+  assert(!has_substring(machine_output, "playchooser"));
+  free(machine_output);
+
+  load_and_exec_config_or_die(config,
+                              "autoplay games 0 -hr false -pc1 -1 -pc2 2");
+  machine_output = autoplay_results_to_string(
+      config_get_autoplay_results(config), false, false);
+  assert(has_substring(machine_output, "playchooser 0 1 0 2"));
+  free(machine_output);
+
+  load_and_exec_config_or_die(config,
+                              "autoplay games 1 -pc1 3 -pc2 4 -seed 125");
+  machine_output = autoplay_results_to_string(
+      config_get_autoplay_results(config), false, false);
+  assert(has_substring(machine_output, "playchooser 1 1 3 4"));
+  free(machine_output);
+
+  human_output = autoplay_results_to_string(config_get_autoplay_results(config),
+                                            true, false);
+  assert(has_substring(human_output, "PlayChooser Timing"));
+  free(human_output);
+
+  config_destroy(config);
+}
+
 void test_autoplay_remaining(void) {
   test_odds_that_player_is_better();
   test_autoplay_leavegen();
@@ -469,6 +549,7 @@ void test_autoplay_remaining(void) {
   test_autoplay_leaves_record();
   test_autoplay_leavegen_force_racks();
   test_autoplay_sim();
+  test_autoplay_play_chooser();
 }
 
 void test_autoplay(void) {

--- a/test/autoplay_test.c
+++ b/test/autoplay_test.c
@@ -494,11 +494,15 @@ void test_autoplay_play_chooser(void) {
   double seconds_used_ms[2];
   double overtime_ms[2];
   unsigned long penalty_points[2];
-  assert(sscanf(play_chooser_output,
-                "playchooser %d %d %lf %lf %lf %lf %lf %lf %lu %lu", &active[0],
-                &active[1], &time_control_ms[0], &time_control_ms[1],
-                &seconds_used_ms[0], &seconds_used_ms[1], &overtime_ms[0],
-                &overtime_ms[1], &penalty_points[0], &penalty_points[1]) == 10);
+  // The parsed values are test data, and sscanf's field count is checked
+  // immediately below.
+  // NOLINTNEXTLINE(cert-err34-c)
+  const int parsed_fields = sscanf(
+      play_chooser_output, "playchooser %d %d %lf %lf %lf %lf %lf %lf %lu %lu",
+      &active[0], &active[1], &time_control_ms[0], &time_control_ms[1],
+      &seconds_used_ms[0], &seconds_used_ms[1], &overtime_ms[0],
+      &overtime_ms[1], &penalty_points[0], &penalty_points[1]);
+  assert(parsed_fields == 10);
   assert(active[0] == 1);
   assert(active[1] == 0);
   assert(time_control_ms[0] == 1.0);

--- a/test/autoplay_test.c
+++ b/test/autoplay_test.c
@@ -506,9 +506,20 @@ void test_autoplay_play_chooser(void) {
   assert(active[0] == 1);
   assert(active[1] == 0);
   assert(time_control_ms[0] == 1.0);
-  assert(seconds_used_ms[0] > 1.0);
-  assert(overtime_ms[0] > 0.0);
-  assert(penalty_points[0] > 0);
+  // The player must have used measurable clock, but whether a 1 ms control
+  // is overrun depends on machine speed and build type (a fast release
+  // build can finish every static-fallback move in under 1 ms total), so
+  // assert the overtime accounting is CONSISTENT rather than that overtime
+  // occurred: any overrun must produce overtime and a penalty (1 point per
+  // started 1 ms period), and no overrun must produce neither.
+  assert(seconds_used_ms[0] > 0.0);
+  if (seconds_used_ms[0] > time_control_ms[0]) {
+    assert(overtime_ms[0] > 0.0);
+    assert(penalty_points[0] > 0);
+  } else {
+    assert(overtime_ms[0] == 0.0);
+    assert(penalty_points[0] == 0);
+  }
   free(machine_output);
 
   load_and_exec_config_or_die(config,

--- a/test/config_test.c
+++ b/test/config_test.c
@@ -89,6 +89,18 @@ void test_config_load_error_cases(void) {
   test_config_load_error(config, "set -seed -2",
                          ERROR_STATUS_CONFIG_LOAD_MALFORMED_INT_ARG,
                          error_stack);
+  test_config_load_error(config, "set -pc1 -2",
+                         ERROR_STATUS_CONFIG_LOAD_DOUBLE_ARG_OUT_OF_BOUNDS,
+                         error_stack);
+  test_config_load_error(config, "set -pc2 nope",
+                         ERROR_STATUS_CONFIG_LOAD_MALFORMED_DOUBLE_ARG,
+                         error_stack);
+  test_config_load_error(config, "set -otpenalty -1",
+                         ERROR_STATUS_CONFIG_LOAD_INT_ARG_OUT_OF_BOUNDS,
+                         error_stack);
+  test_config_load_error(config, "set -otperiod 0",
+                         ERROR_STATUS_CONFIG_LOAD_DOUBLE_ARG_OUT_OF_BOUNDS,
+                         error_stack);
   test_config_load_error(config, "sim -lex CSW21 -it 1000 -plies",
                          ERROR_STATUS_CONFIG_LOAD_INSUFFICIENT_NUMBER_OF_VALUES,
                          error_stack);

--- a/test/play_chooser_test.c
+++ b/test/play_chooser_test.c
@@ -62,6 +62,15 @@ static void test_game_timer(void) {
   game_timer_end_turn(&game_timer);
   assert(game_timer_is_expired(&game_timer, 0));
   assert(!game_timer_is_expired(&game_timer, 1));
+  assert(game_timer_get_overtime_seconds(&game_timer, 0) > 0.0);
+  assert(game_timer_get_overtime_seconds(&game_timer, 1) == 0.0);
+
+  game_timer_reset_for_players(&game_timer, 0.01, 0.0);
+  assert(!game_timer_is_untimed(&game_timer));
+  assert(!game_timer_player_is_untimed(&game_timer, 0));
+  assert(game_timer_player_is_untimed(&game_timer, 1));
+  assert(game_timer_get_seconds_remaining(&game_timer, 0) == 0.01);
+  assert(isinf(game_timer_get_seconds_remaining(&game_timer, 1)));
 }
 
 static void drain_bag(const Game *game) {


### PR DESCRIPTION
## Summary

- let either autoplay player use PlayChooser, with an independent total per-game clock specified in milliseconds
- have PlayChooser automatically use sim, pre-endgame, and endgame evaluation based on the position
- assess configurable started-period overtime penalties after each game and include them in final scores
- report PlayChooser clock use, overtime, and penalty points only when at least one player is active

## Interface

- `-pc1 <milliseconds>` / `-pc2 <milliseconds>`: `-1` disables PlayChooser for that player (the default), `0` is untimed, and a positive value sets the total game clock
- `-otpenalty <points>`: points deducted per started overtime period (default `10`)
- `-otperiod <milliseconds>`: overtime period length (default `60000`)

For blitz, `-otpenalty 1 -otperiod 1000` gives one point per started second.

## Autoplay results

Static equity played PlayChooser in paired CSW21 games with seed 606 and 10 workers. The default overtime rule was used.

| Run | Static wins | PlayChooser wins | Static mean score | PlayChooser mean score | Mean PC time/game | Overtime | Wall time |
|---|---:|---:|---:|---:|---:|---:|---:|
| 100 pairs, 1 s clock, concurrent games | 100 (50%) | 100 (50%) | 455.44 | 446.10 | 7.80 s | 188/200 games | 198.5 s |
| 10 pairs, 30 s clock, concurrent games | 7 (35%) | 13 (65%) | 449.00 | 460.45 | 27.29 s | 0/20 games | 56.2 s |
| 10 pairs, 30 s clock, 10 threads/game | 6 (30%) | 14 (70%) | 440.60 | 477.50 | 27.01 s | 1/20 games by 2.13 s | 542.2 s |

The 1-second run incurred 1,960 total penalty points (9.8/game). Before penalties, PlayChooser's estimated mean score was 455.90, essentially even with static's 455.44. This exposes weak deadline enforcement at blitz-scale clocks; follow-up is tracked in #607.

The 30-second samples are too small for a firm strength conclusion, but both favored PlayChooser. Giving all 10 threads to each game increased the observed margin from +11.45 to +36.90 points while making the run roughly 10 times slower wall-clock than concurrent games. All pairs in all three runs diverged.

## Verification

- release build
- strict `-Werror` address/undefined-behavior sanitizer build
- autoplay suite, including real player-1-only and both-player PlayChooser games plus player-2-only and neither-player reporting coverage
- PlayChooser suite
- parser bounds/error coverage for the new settings
