### PR TITLE
peg: discard outcomes from rolled-back stages

### DIFF
--- a/src/impl/peg.c
+++ b/src/impl/peg.c
@@ -2799,6 +2799,14 @@ void peg_solve(const PegArgs *args, PegResult *out, ErrorStack *error_stack) {
       PegRankedCand *restaged =
           malloc_or_die((size_t)eval_count * sizeof(PegRankedCand));
       int done_count = eval_count;
+      // Keep this stage's captures separate until the stage is accepted. A
+      // stage with fewer than two completed candidates is rolled back to the
+      // preceding fidelity, so publishing its captures early would pair deeper
+      // outcomes with the restored shallower ranking.
+      PegCandOutcomes *stage_outcomes =
+          args->include_per_scenario
+              ? malloc_or_die((size_t)eval_count * sizeof(PegCandOutcomes))
+              : NULL;
       if (args->poll != NULL) {
         // Live mode: evaluate one candidate at a time so each completion
         // updates the pollable leaderboard (for `sta`/`shpeg`) and so we can
@@ -2827,13 +2835,12 @@ void peg_solve(const PegArgs *args, PegResult *out, ErrorStack *error_stack) {
           const int64_t cand_start_ns = ctimer_monotonic_ns();
           peg_poll_set_evaluating(args->poll, cand_idx, cand_start_ns);
           ctimer_start(&cand_timer);
-          PegCandOutcomes cand_oc;
           peg_eval_candidates_scenario(
               pool, workers, prepared_base, mover_idx, unseen, ld_size, ld,
               bag_size, &moves[cand_idx], 1, args->opp_model, args->inner_top_k,
               stage_fidelity, scenario_stride, deadline_ns,
               args->thread_control, &inner, /*poll=*/NULL, &restaged[cand_idx],
-              args->include_per_scenario ? &cand_oc : NULL);
+              args->include_per_scenario ? &stage_outcomes[cand_idx] : NULL);
           restaged[cand_idx].eval_seconds = ctimer_elapsed_seconds(&cand_timer);
           peg_poll_set_evaluating(args->poll, -1, 0);
           // If the deadline passed while this candidate was evaluating, some of
@@ -2841,14 +2848,11 @@ void peg_solve(const PegArgs *args, PegResult *out, ErrorStack *error_stack) {
           // rather than show or rank a partial result, and stop the stage.
           if (deadline_ns != 0 && ctimer_monotonic_ns() >= deadline_ns) {
             if (args->include_per_scenario) {
-              free(cand_oc.rows);
+              free(stage_outcomes[cand_idx].rows);
             }
             break;
           }
           done_count = cand_idx + 1;
-          if (args->include_per_scenario) {
-            peg_outcomes_store_upsert(&oc_store, &oc_n, &oc_cap, &cand_oc);
-          }
           // Surface this finished candidate into the leaderboard, then stream
           // the updated ranking to the caller right away — every candidate's
           // result prints as soon as it finishes, so the deep stages fill in
@@ -2869,15 +2873,11 @@ void peg_solve(const PegArgs *args, PegResult *out, ErrorStack *error_stack) {
         // across all candidates at once — a halving stage has few candidates,
         // so pooling their scenarios keeps all cores busy with a single
         // barrier.
-        PegCandOutcomes *stage_oc =
-            args->include_per_scenario
-                ? malloc_or_die((size_t)eval_count * sizeof(PegCandOutcomes))
-                : NULL;
         peg_eval_candidates_scenario(
             pool, workers, prepared_base, mover_idx, unseen, ld_size, ld,
             bag_size, moves, eval_count, args->opp_model, args->inner_top_k,
             stage_fidelity, scenario_stride, deadline_ns, args->thread_control,
-            &progress, args->poll, restaged, stage_oc);
+            &progress, args->poll, restaged, stage_outcomes);
         // A deadline can cut the stage mid-flight: a candidate whose scenario
         // jobs bailed has a short weight_sum, so keep only the fully-scored
         // ones (as the live path does) instead of ranking partial scores.
@@ -2893,7 +2893,7 @@ void peg_solve(const PegArgs *args, PegResult *out, ErrorStack *error_stack) {
         PegRankedCand *part_old =
             malloc_or_die((size_t)eval_count * sizeof(PegRankedCand));
         PegCandOutcomes *part_oc =
-            stage_oc != NULL
+            stage_outcomes != NULL
                 ? malloc_or_die((size_t)eval_count * sizeof(PegCandOutcomes))
                 : NULL;
         int placed = 0;
@@ -2907,7 +2907,7 @@ void peg_solve(const PegArgs *args, PegResult *out, ErrorStack *error_stack) {
             part_new[placed] = restaged[cand_idx];
             part_old[placed] = ranked[cand_idx];
             if (part_oc != NULL) {
-              part_oc[placed] = stage_oc[cand_idx];
+              part_oc[placed] = stage_outcomes[cand_idx];
             }
             placed++;
           }
@@ -2919,20 +2919,15 @@ void peg_solve(const PegArgs *args, PegResult *out, ErrorStack *error_stack) {
         memcpy(ranked, part_old, (size_t)eval_count * sizeof(PegRankedCand));
         free(part_new);
         free(part_old);
-        if (stage_oc != NULL) {
-          memcpy(stage_oc, part_oc,
+        if (stage_outcomes != NULL) {
+          memcpy(stage_outcomes, part_oc,
                  (size_t)eval_count * sizeof(PegCandOutcomes));
           free(part_oc);
-          // Publish only the fully-scored candidates' outcomes; discard the cut
-          // candidates' partial captures.
-          for (int cand_idx = 0; cand_idx < done_count; cand_idx++) {
-            peg_outcomes_store_upsert(&oc_store, &oc_n, &oc_cap,
-                                      &stage_oc[cand_idx]);
-          }
+          // Discard the cut candidates' partial captures. The complete prefix
+          // remains stage-local until the shared acceptance check below.
           for (int cand_idx = done_count; cand_idx < eval_count; cand_idx++) {
-            free(stage_oc[cand_idx].rows);
+            free(stage_outcomes[cand_idx].rows);
           }
-          free(stage_oc);
         }
       }
       // Fewer than 2 finished: nothing to compare at this depth, so discard the
@@ -2941,12 +2936,21 @@ void peg_solve(const PegArgs *args, PegResult *out, ErrorStack *error_stack) {
       if (done_count < 2) {
         n_graded = n_graded_before_stage;
         free(restaged);
+        peg_cand_outcomes_destroy_array(stage_outcomes, done_count);
         // This stage cleared the live poll at its start but contributed
         // nothing, so restore the previous stage's ranking (still in `ranked`)
         // instead of leaving the final snapshot empty.
         peg_poll_replace(args->poll, ranked, live_count, stage_idx - 1,
                          prev_fidelity, live_count);
         break;
+      }
+      if (stage_outcomes != NULL) {
+        for (int cand_idx = 0; cand_idx < done_count; cand_idx++) {
+          peg_outcomes_store_upsert(&oc_store, &oc_n, &oc_cap,
+                                    &stage_outcomes[cand_idx]);
+        }
+        // Ownership of each rows allocation moved into oc_store.
+        free(stage_outcomes);
       }
       qsort(restaged, (size_t)done_count, sizeof(PegRankedCand), peg_rank_cmp);
       // Partial stage: candidates [done_count, eval_count) were selected but

--- a/src/impl/peg.c
+++ b/src/impl/peg.c
@@ -2936,6 +2936,14 @@ void peg_solve(const PegArgs *args, PegResult *out, ErrorStack *error_stack) {
       if (done_count < 2) {
         n_graded = n_graded_before_stage;
         free(restaged);
+        // Frees memory this stage still owns: stage_outcomes[0, done_count)
+        // are completed captures that were never upserted, since the store
+        // only takes them on the accept path below. The cut tail
+        // [done_count, eval_count) was already freed by whichever evaluation
+        // path cut it -- the live path frees the deadline-cut candidate on its
+        // break, the batch path frees the tail after stable-partitioning. With
+        // accept upserting exactly [0, done_count), every rows allocation is
+        // freed exactly once across all three exits.
         peg_cand_outcomes_destroy_array(stage_outcomes, done_count);
         // This stage cleared the live poll at its start but contributed
         // nothing, so restore the previous stage's ranking (still in `ranked`)

--- a/src/str/peg_string.c
+++ b/src/str/peg_string.c
@@ -19,13 +19,24 @@
 #include <stdlib.h>
 #include <string.h>
 
+// Outcome bucket a PEG draw lands in, keyed off the mover's final spread. These
+// values index this file's per-bucket arrays (a family's seen flags, the
+// per-bucket token counts, the display labels), so they must stay a dense
+// 0-based range and NUMBER_OF_PEG_OUTCOME_BUCKETS must stay last.
+enum {
+  PEG_OUTCOME_BUCKET_WIN,
+  PEG_OUTCOME_BUCKET_LOSS,
+  PEG_OUTCOME_BUCKET_TIE,
+  NUMBER_OF_PEG_OUTCOME_BUCKETS,
+};
+
 // One displayable outcome token: a draw rendered as the mover's drawn multiset
 // followed by the bag remainder -- a sorted multiset ("DH/RS") when its
 // orderings share a bucket, or "/"-segmented ("DH/R/S") when they split --
 // tagged with its bucket and summed labeled-ordering weight.
 typedef struct {
   char text[64];
-  int bucket; // 0 = win, 1 = loss, 2 = tie
+  int bucket; // a PEG_OUTCOME_BUCKET_* value
   int64_t weight;
 } PegOutcomeTok;
 
@@ -38,7 +49,7 @@ typedef struct {
 typedef struct {
   char drawn[40];  // sorted mover-draw multiset (leading segment)
   char rem_ms[40]; // sorted bag-remainder multiset (family key tail)
-  bool seen[3];    // [0]=win [1]=loss [2]=tie
+  bool seen[NUMBER_OF_PEG_OUTCOME_BUCKETS];
   int64_t per_ordering;
   int64_t total_weight;
 } PegOutcomeFamily;
@@ -257,15 +268,15 @@ static int peg_outcome_tok_cmp(const void *a, const void *b) {
                 ((const PegOutcomeTok *)b)->text);
 }
 
-// 0 = win, 1 = loss, 2 = tie.
+// Classify a draw by the mover's final spread.
 static int peg_outcome_bucket(int32_t mover_total) {
   if (mover_total > 0) {
-    return 0;
+    return PEG_OUTCOME_BUCKET_WIN;
   }
   if (mover_total < 0) {
-    return 1;
+    return PEG_OUTCOME_BUCKET_LOSS;
   }
-  return 2;
+  return PEG_OUTCOME_BUCKET_TIE;
 }
 
 // Copy a short tile string and sort it into multiset (canonical) order.
@@ -331,15 +342,19 @@ char *peg_build_outcomes_string_rows(const PegPerScenario *rows, int n_rows) {
   }
 
   // "always X" when every ordering shares a single bucket.
-  bool any[3] = {false, false, false};
+  bool any[NUMBER_OF_PEG_OUTCOME_BUCKETS] = {false};
   for (int row_idx = 0; row_idx < n_rows; row_idx++) {
     any[peg_outcome_bucket(rows[row_idx].mover_total)] = true;
   }
-  if ((int)any[0] + (int)any[1] + (int)any[2] == 1) {
+  int n_any_buckets = 0;
+  for (int bucket = 0; bucket < NUMBER_OF_PEG_OUTCOME_BUCKETS; bucket++) {
+    n_any_buckets += (int)any[bucket];
+  }
+  if (n_any_buckets == 1) {
     const char *all_label = "always ties";
-    if (any[0]) {
+    if (any[PEG_OUTCOME_BUCKET_WIN]) {
       all_label = "always wins";
-    } else if (any[1]) {
+    } else if (any[PEG_OUTCOME_BUCKET_LOSS]) {
       all_label = "always loses";
     }
     return string_duplicate(all_label);
@@ -373,9 +388,9 @@ char *peg_build_outcomes_string_rows(const PegPerScenario *rows, int n_rows) {
                      row_drawn[row_idx]);
       (void)snprintf(fams[fam_idx].rem_ms, sizeof(fams[fam_idx].rem_ms), "%s",
                      row_rem_ms[row_idx]);
-      fams[fam_idx].seen[0] = false;
-      fams[fam_idx].seen[1] = false;
-      fams[fam_idx].seen[2] = false;
+      for (int bucket = 0; bucket < NUMBER_OF_PEG_OUTCOME_BUCKETS; bucket++) {
+        fams[fam_idx].seen[bucket] = false;
+      }
       fams[fam_idx].per_ordering = rows[row_idx].weight;
       fams[fam_idx].total_weight = 0;
     }
@@ -394,14 +409,16 @@ char *peg_build_outcomes_string_rows(const PegPerScenario *rows, int n_rows) {
   int n_toks = 0;
   for (int fam_idx = 0; fam_idx < n_fams; fam_idx++) {
     const PegOutcomeFamily *fam = &fams[fam_idx];
-    const int n_buckets =
-        (int)fam->seen[0] + (int)fam->seen[1] + (int)fam->seen[2];
+    int n_buckets = 0;
+    for (int bucket = 0; bucket < NUMBER_OF_PEG_OUTCOME_BUCKETS; bucket++) {
+      n_buckets += (int)fam->seen[bucket];
+    }
     if (n_buckets <= 1) {
-      int bucket = 2;
-      if (fam->seen[0]) {
-        bucket = 0;
-      } else if (fam->seen[1]) {
-        bucket = 1;
+      int bucket = PEG_OUTCOME_BUCKET_TIE;
+      if (fam->seen[PEG_OUTCOME_BUCKET_WIN]) {
+        bucket = PEG_OUTCOME_BUCKET_WIN;
+      } else if (fam->seen[PEG_OUTCOME_BUCKET_LOSS]) {
+        bucket = PEG_OUTCOME_BUCKET_LOSS;
       }
       peg_draw_token(toks[n_toks].text, sizeof(toks[n_toks].text), fam->drawn,
                      fam->rem_ms);
@@ -413,7 +430,7 @@ char *peg_build_outcomes_string_rows(const PegPerScenario *rows, int n_rows) {
     // Split: the bag remainder's orderings land in more than one bucket. Factor
     // them per win/loss/tie bucket, keeping the drawn multiset as a leading
     // segment.
-    for (int bucket = 0; bucket <= 2; bucket++) {
+    for (int bucket = 0; bucket < NUMBER_OF_PEG_OUTCOME_BUCKETS; bucket++) {
       PegStrList seqs = {0};
       for (int row_idx = 0; row_idx < n_rows; row_idx++) {
         if (peg_outcome_bucket(rows[row_idx].mover_total) != bucket) {
@@ -447,7 +464,7 @@ char *peg_build_outcomes_string_rows(const PegPerScenario *rows, int n_rows) {
   free(row_rem_ms);
 
   qsort(toks, (size_t)n_toks, sizeof(PegOutcomeTok), peg_outcome_tok_cmp);
-  int n_bucket_toks[3] = {0, 0, 0};
+  int n_bucket_toks[NUMBER_OF_PEG_OUTCOME_BUCKETS] = {0};
   for (int tok_idx = 0; tok_idx < n_toks; tok_idx++) {
     n_bucket_toks[toks[tok_idx].bucket]++;
   }
@@ -457,22 +474,39 @@ char *peg_build_outcomes_string_rows(const PegPerScenario *rows, int n_rows) {
   // label. Empty lists are skipped, so a row with no tie draws just shows the
   // shorter of win / loss, exactly as before ties were tracked. On a size tie,
   // prefer to imply a loss, then a win, so a tie draw stays visible.
-  static const int imply_pref[3] = {1, 0, 2}; // loss, then win, then tie
+  static const int imply_pref[NUMBER_OF_PEG_OUTCOME_BUCKETS] = {
+      PEG_OUTCOME_BUCKET_LOSS,
+      PEG_OUTCOME_BUCKET_WIN,
+      PEG_OUTCOME_BUCKET_TIE,
+  };
   int implied = imply_pref[0];
-  for (int pref_idx = 1; pref_idx < 3; pref_idx++) {
+  for (int pref_idx = 1; pref_idx < NUMBER_OF_PEG_OUTCOME_BUCKETS; pref_idx++) {
     const int bucket = imply_pref[pref_idx];
     if (n_bucket_toks[bucket] > n_bucket_toks[implied]) {
       implied = bucket;
     }
   }
 
-  static const char *const labels[3] = {"W:", "L:", "T:"};
-  static const char *const otherwise_word[3] = {"wins", "loses", "ties"};
-  const int display_order[3] = {0, 2, 1}; // wins, ties, losses
+  static const char *const labels[NUMBER_OF_PEG_OUTCOME_BUCKETS] = {
+      [PEG_OUTCOME_BUCKET_WIN] = "W:",
+      [PEG_OUTCOME_BUCKET_LOSS] = "L:",
+      [PEG_OUTCOME_BUCKET_TIE] = "T:",
+  };
+  static const char *const otherwise_word[NUMBER_OF_PEG_OUTCOME_BUCKETS] = {
+      [PEG_OUTCOME_BUCKET_WIN] = "wins",
+      [PEG_OUTCOME_BUCKET_LOSS] = "loses",
+      [PEG_OUTCOME_BUCKET_TIE] = "ties",
+  };
+  const int display_order[NUMBER_OF_PEG_OUTCOME_BUCKETS] = {
+      PEG_OUTCOME_BUCKET_WIN,
+      PEG_OUTCOME_BUCKET_TIE,
+      PEG_OUTCOME_BUCKET_LOSS,
+  };
   StringBuilder *sb = string_builder_create();
   int n_shown = 0;
   int last_shown = -1;
-  for (int order_idx = 0; order_idx < 3; order_idx++) {
+  for (int order_idx = 0; order_idx < NUMBER_OF_PEG_OUTCOME_BUCKETS;
+       order_idx++) {
     const int bucket = display_order[order_idx];
     if (bucket == implied || n_bucket_toks[bucket] == 0) {
       continue;
@@ -491,7 +525,8 @@ char *peg_build_outcomes_string_rows(const PegPerScenario *rows, int n_rows) {
   // whether the implied majority is wins or losses. Two labeled lists already
   // imply the third, and a no-tie row implies its win/loss counterpart, so
   // those stay label-free.
-  if (implied == 2 || (n_shown == 1 && last_shown == 2)) {
+  if (implied == PEG_OUTCOME_BUCKET_TIE ||
+      (n_shown == 1 && last_shown == PEG_OUTCOME_BUCKET_TIE)) {
     string_builder_add_formatted_string(sb, ", otherwise %s",
                                         otherwise_word[implied]);
   }

--- a/test/peg_test.c
+++ b/test/peg_test.c
@@ -773,8 +773,8 @@ static void peg_test_interrupt_discarded_stage(int stage_idx, int cand_rank,
   (void)mean_spread;
   (void)scen_done;
   (void)reordered;
-  PegDiscardStageContext *context = user_data;
   if (stage_idx == 2 && cand_rank == 0) {
+    PegDiscardStageContext *context = user_data;
     context->interrupted_stage = stage_idx;
     thread_control_set_status(context->thread_control,
                               THREAD_CONTROL_STATUS_USER_INTERRUPT);

--- a/test/peg_test.c
+++ b/test/peg_test.c
@@ -4,6 +4,7 @@
 #include "../src/def/equity_defs.h"
 #include "../src/def/letter_distribution_defs.h"
 #include "../src/def/move_defs.h"
+#include "../src/def/thread_control_defs.h"
 #include "../src/ent/bag.h"
 #include "../src/ent/board.h"
 #include "../src/ent/game.h"
@@ -11,6 +12,7 @@
 #include "../src/ent/move.h"
 #include "../src/ent/player.h"
 #include "../src/ent/rack.h"
+#include "../src/ent/thread_control.h"
 #include "../src/ent/validated_move.h"
 #include "../src/impl/config.h"
 #include "../src/impl/move_gen.h"
@@ -753,6 +755,92 @@ static void test_peg_main_progress_detail(void) {
   config_destroy(config);
 }
 
+typedef struct PegDiscardStageContext {
+  ThreadControl *thread_control;
+  int interrupted_stage;
+} PegDiscardStageContext;
+
+// Interrupt the second halving stage after its first candidate finishes. The
+// solver must discard that one-candidate stage and keep every published result,
+// including its captured outcomes, at the preceding fidelity.
+static void peg_test_interrupt_discarded_stage(int stage_idx, int cand_rank,
+                                               const Move *cand, double win_pct,
+                                               double mean_spread,
+                                               int scen_done, bool reordered,
+                                               void *user_data) {
+  (void)cand;
+  (void)win_pct;
+  (void)mean_spread;
+  (void)scen_done;
+  (void)reordered;
+  PegDiscardStageContext *context = user_data;
+  if (stage_idx == 2 && cand_rank == 0) {
+    context->interrupted_stage = stage_idx;
+    thread_control_set_status(context->thread_control,
+                              THREAD_CONTROL_STATUS_USER_INTERRUPT);
+  }
+}
+
+static void test_peg_discarded_stage_outcomes(void) {
+  const char *cgp =
+      "cgp 15/3Q7U3/3U2TAURINE2/1CHANSONS2W3/2AI6JO3/DIRL1PO3IN3/E1D2EF3V4/"
+      "F1I2p1TRAIK3/O1L2T4E4/ABy1PIT2BRIG2/ME1MOZELLE5/1GRADE1O1NOH3/"
+      "WE3R1V7/AT5E7/G6D7 ENOSTXY/ACEISUY 356/378 0 -lex NWL20";
+  Config *config = config_create_or_die("set -threads 4 -s1 score -s2 score");
+  load_and_exec_config_or_die(config, cgp);
+  Game *game = config_get_game(config);
+  ThreadControl *thread_control = config_get_thread_control(config);
+  ErrorStack *error_stack = error_stack_create();
+
+  ValidatedMoves *moves = validated_moves_create(
+      game, game_get_player_on_turn_index(game), "13L ONYX,13L OXY",
+      /*allow_phonies=*/false, /*allow_playthrough=*/true, error_stack);
+  assert(error_stack_is_empty(error_stack));
+  assert(validated_moves_get_number_of_moves(moves) == 2);
+  const Move *only_moves[2] = {validated_moves_get_move(moves, 0),
+                               validated_moves_get_move(moves, 1)};
+
+  PegPoll *poll = peg_poll_create();
+  PegDiscardStageContext context = {
+      .thread_control = thread_control,
+      .interrupted_stage = -1,
+  };
+  static const int stage_top_k[] = {2, 2};
+  PegArgs args;
+  memset(&args, 0, sizeof(args));
+  args.game = game;
+  args.thread_control = thread_control;
+  args.num_threads = 4;
+  args.time_budget_seconds = 10.0;
+  args.stage_top_k = stage_top_k;
+  args.num_stages = 2;
+  args.only_moves = only_moves;
+  args.n_only_moves = 2;
+  args.include_per_scenario = true;
+  args.poll = poll;
+  args.on_cand_done = peg_test_interrupt_discarded_stage;
+  args.user_data = &context;
+
+  PegResult result;
+  memset(&result, 0, sizeof(result));
+  peg_solve(&args, &result, error_stack);
+  assert(error_stack_is_empty(error_stack));
+
+  assert(context.interrupted_stage == 2);
+  assert(result.last_completed_stage == 1);
+  assert(result.n_cand_outcomes == 2);
+  for (int outcome_idx = 0; outcome_idx < result.n_cand_outcomes;
+       outcome_idx++) {
+    assert(result.cand_outcomes[outcome_idx].fidelity == 2);
+  }
+
+  peg_result_destroy(&result);
+  peg_poll_destroy(poll);
+  validated_moves_destroy(moves);
+  error_stack_destroy(error_stack);
+  config_destroy(config);
+}
+
 // Exercises PegArgs.inner_top_k. On a 2-in-bag board (so non-emptying cands
 // leave the opponent tiles to draw, where the model and its cap actually bite),
 // solve one candidate pessimistically with the cap off (k=0, the unbounded
@@ -1286,6 +1374,7 @@ void test_peg(void) {
   test_peg_main_opp_models();
   test_peg_main_pnoprune();
   test_peg_main_progress_detail();
+  test_peg_discarded_stage_outcomes();
   test_peg_main_inner_top_k();
   // Cases drawn from the macondo codebase + pre-endgame manual.
   test_peg_macondo_only_onyx();


### PR DESCRIPTION
## Bug

When a time limit or interrupt lets fewer than two candidates finish a deeper PEG halving stage, the solver discards that stage and restores the preceding fidelity's ranking. The per-candidate outcome captures were published before that acceptance check, however, so a completed candidate could retain deeper outcomes beside shallower win/tie/loss counts.

This produces the contradiction from the report: the stage table shows `1/16` candidates completed at 3-ply, the graded row correctly falls back to 2-ply with `8/0/0`, but its outcomes cell comes from the discarded 3-ply evaluation and says `L: R T`.

## Fix

- Keep each halving stage's outcome captures in a stage-local array.
- Merge completed captures into the persistent outcome store only after at least two candidates finish and the stage is accepted.
- Free the stage-local captures when the stage is rolled back.
- Apply the same ownership flow to live sequential evaluation and non-live pooled evaluation.

## Regression test

The new test uses a callback to interrupt the second halving stage immediately after its first candidate finishes. This reproduces the failure deterministically without relying on a wall-clock race. It verifies that the accepted result and both candidates' outcome captures remain at 2-ply.

Before the fix, the first capture incorrectly reports fidelity 3. After the fix, both report fidelity 2.

## Exact report reproduction

Replayed the supplied `r2.gcg` at event 23 (`goto 23`) and ran:

```
peg -pegoutcomes true -tlim 15
```

Both revisions reached the same interrupted state: 302 greedy candidates, all 32 candidates complete at 2-ply, and 1/16 complete at the discarded 3-ply stage.

- Parent commit: `14B M(OS)` showed `8 wins, 0 ties, 0 losses, 100.0%` but `L: R T`.
- This PR: the same row shows `8 wins, 0 ties, 0 losses, 100.0%` and `always wins`.

The remaining accepted 2-ply rows retained their expected outcomes.

## Ownership invariant, documented

Review noted that the rollback's `peg_cand_outcomes_destroy_array` is the subtle safety hinge here, and that seeing why it is not a double free requires tracing all three stage exits — no single hunk shows it. That whole-picture invariant is now recorded at the call site:

- the completed prefix `[0, done_count)` reaching the rollback was never upserted, since accept is the only publisher;
- the cut tail was already freed by whichever evaluation path cut it (live frees the deadline-cut candidate on its `break`; batch frees `[done_count, eval_count)` after stable-partitioning);
- accept upserts exactly `[0, done_count)` and then frees only the array.

So every `rows` allocation is freed exactly once regardless of which exit runs.

## Also: name the outcome buckets

Folded in a small readability cleanup to the outcomes renderer, since it is the same subsystem and the same reviewer context.

`peg_string.c` classified every draw into win/loss/tie as a bare `int`, with the meaning carried only by comments — and one had already gone stale: `PegOutcomeTok.bucket` still read `0 = win, 1 = loss` after the tie bucket was added in #603. The unrolled cardinality sums (`any[0] + any[1] + any[2]`, and the matching `fam->seen` sum) would also silently undercount if a fourth bucket ever appeared.

`PEG_OUTCOME_BUCKET_{WIN,LOSS,TIE}` plus a trailing `NUMBER_OF_PEG_OUTCOME_BUCKETS` now live in a top-of-file anonymous enum, matching how `sim_string.c` and `bag_string.c` hold their file-private constants. They replace the literals in array extents, loop bounds, the classifier's returns, and the implied-bucket comparisons; the unrolled sums and the triple `seen[]` assignment become loops over the bucket range. The `labels` / `otherwise_word` lookup tables get designated initializers so the value-to-index binding is explicit — `imply_pref` and `display_order` stay positional, since they map preference and display rank to bucket rather than being bucket-indexed.

Pure refactor with no behavior change; the renderer tests assert exact output strings, so they pin that.

## Verification

- `python3 format.py --write`
- `make magpie_test BUILD=release`
- `./bin/magpie_test peg`, `./bin/magpie_test config`
- `make magpie_test` (dev/ASAN/UBSAN build with `-Werror`)
- `./cppcheck.sh` (2.17.1) clean, `python3 find_circ_deps.py` no cycles
- Exact `r2.gcg` parent-vs-fix reproduction above
- Complete `r2.gcg` 3-ply run: all 32/32 displayed candidates completed, with tie draws rendered
- All 17 CI checks green

## Note on the diff

#603 has since merged to `main`, and this branch is merged up to it, so its commits no longer appear in this diff. What remains is `peg.c` (the fix), `peg_test.c` (the regression test), and `peg_string.c` (the bucket enum).
