### PR TITLE
Avoid materializing losing WMP moves

### DIFF
--- a/src/ent/static_eval.h
+++ b/src/ent/static_eval.h
@@ -80,6 +80,27 @@ shadow_endgame_adjustment(const LetterDistribution *ld, const Rack *opp_rack,
   return endgame_outplay_adjustment(rack_get_score(ld, opp_rack));
 }
 
+// Computes the parts of a move's static equity that do not depend on its
+// placement. Callers may use this before materializing a Move when the board
+// is nonempty; opening-move placement_adjustment still requires the Move.
+static inline Equity static_eval_get_nonopening_move_equity(
+    const LetterDistribution *ld, const Rack *player_leave,
+    const Rack *opp_rack, int tiles_played, int number_of_tiles_in_bag,
+    Equity score, Equity leave_value) {
+  Equity equity = score;
+  if (number_of_tiles_in_bag > 0) {
+    equity += leave_value;
+    const int bag_plus_rack_size =
+        number_of_tiles_in_bag - tiles_played + RACK_SIZE;
+    if (bag_plus_rack_size < PEG_ADJUST_VALUES_LENGTH) {
+      equity += peg_adjust_values[bag_plus_rack_size];
+    }
+  } else {
+    equity += standard_endgame_adjustment(ld, player_leave, opp_rack);
+  }
+  return equity;
+}
+
 static inline Equity
 static_eval_get_shadow_equity(const LetterDistribution *ld,
                               const Rack *opp_rack, const Equity *best_leaves,
@@ -116,7 +137,6 @@ static inline Equity static_eval_get_move_equity_with_leave_value(
     const Rack *opp_rack, const Equity *opening_move_penalties,
     int board_number_of_tiles_played, int number_of_tiles_in_bag,
     Equity leave_value) {
-  Equity leave_adjustment = 0;
   Equity other_adjustments = 0;
 
   if (board_number_of_tiles_played == 0 &&
@@ -124,18 +144,10 @@ static inline Equity static_eval_get_move_equity_with_leave_value(
     other_adjustments = placement_adjustment(ld, move, opening_move_penalties);
   }
 
-  if (number_of_tiles_in_bag > 0) {
-    leave_adjustment = leave_value;
-    int bag_plus_rack_size =
-        number_of_tiles_in_bag - move_get_tiles_played(move) + RACK_SIZE;
-    if (bag_plus_rack_size < PEG_ADJUST_VALUES_LENGTH) {
-      other_adjustments += peg_adjust_values[bag_plus_rack_size];
-    }
-  } else {
-    other_adjustments +=
-        standard_endgame_adjustment(ld, player_leave, opp_rack);
-  }
-  return move_get_score(move) + leave_adjustment + other_adjustments;
+  return static_eval_get_nonopening_move_equity(
+             ld, player_leave, opp_rack, move_get_tiles_played(move),
+             number_of_tiles_in_bag, move_get_score(move), leave_value) +
+         other_adjustments;
 }
 
 // Assumes all fields of the move are set except the equity.

--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -669,6 +669,36 @@ static inline Equity get_move_equity_for_sort_type_wmp(MoveGen *gen,
 #endif
 }
 
+// On a nonempty board, static equity depends only on the score, leave, racks,
+// and number of tiles played. Compute it before writing a full Move so bounded
+// record modes can discard a losing candidate without copying its strip.
+// Opening placement penalties inspect the Move and use the regular path
+// instead.
+static inline bool get_wmp_equity_without_move(const MoveGen *gen, Equity score,
+                                               Equity leave_value,
+                                               Equity *equity) {
+  switch (gen->move_sort_type) {
+  case MOVE_SORT_SCORE:
+    *equity = score;
+    return true;
+  case MOVE_SORT_EQUITY:
+    if (gen->board_number_of_tiles_played == 0) {
+      return false;
+    }
+    *equity = static_eval_get_nonopening_move_equity(
+        &gen->ld, &gen->leave, &gen->opponent_rack, gen->max_tiles_to_play,
+        gen->number_of_tiles_in_bag, score, leave_value);
+    return true;
+  default:
+    log_fatal("unhandled move sort type: %d", gen->move_sort_type);
+  }
+#if defined(__has_builtin) && __has_builtin(__builtin_unreachable)
+  __builtin_unreachable();
+#else
+  return false;
+#endif
+}
+
 static inline void
 update_best_move_or_insert_into_movelist_wmp(MoveGen *gen, int start_col,
                                              Equity score, Equity leave_value) {
@@ -677,10 +707,28 @@ update_best_move_or_insert_into_movelist_wmp(MoveGen *gen, int start_col,
   switch (gen->move_record_type) {
   case MOVE_RECORD_ALL:
   case MOVE_RECORD_WITHIN_X_EQUITY_OF_BEST: {
+    Equity precomputed_equity = 0;
+    const bool has_precomputed_equity = get_wmp_equity_without_move(
+        gen, score, leave_value, &precomputed_equity);
+    if (has_precomputed_equity && !gen->stop_on_threshold) {
+      if (gen->move_record_type == MOVE_RECORD_ALL &&
+          move_list_get_count(gen->move_list) ==
+              move_list_get_capacity(gen->move_list) &&
+          precomputed_equity < move_list_peek_equity(gen->move_list)) {
+        return;
+      }
+      if (gen->move_record_type == MOVE_RECORD_WITHIN_X_EQUITY_OF_BEST &&
+          gen->best_move_equity_or_score != EQUITY_INITIAL_VALUE &&
+          precomputed_equity < gen_get_cutoff_equity_or_score(gen)) {
+        return;
+      }
+    }
     Move *move = move_list_get_spare_move(gen->move_list);
     set_play_for_record_wmp(gen, move, start_col, score);
     move_equity_or_score =
-        get_move_equity_for_sort_type_wmp(gen, move, leave_value);
+        has_precomputed_equity
+            ? precomputed_equity
+            : get_move_equity_for_sort_type_wmp(gen, move, leave_value);
     if (gen->move_record_type == MOVE_RECORD_WITHIN_X_EQUITY_OF_BEST) {
       // This updates the cutoff move internally so no update will be pending
       // afterward.
@@ -691,10 +739,19 @@ update_best_move_or_insert_into_movelist_wmp(MoveGen *gen, int start_col,
     break;
   }
   case MOVE_RECORD_BEST: {
+    Equity precomputed_equity = 0;
+    const bool has_precomputed_equity = get_wmp_equity_without_move(
+        gen, score, leave_value, &precomputed_equity);
+    if (has_precomputed_equity &&
+        precomputed_equity < move_get_equity(gen_get_readonly_best_move(gen))) {
+      return;
+    }
     Move *current_move = gen_get_current_move(gen);
     set_play_for_record_wmp(gen, current_move, start_col, score);
     move_equity_or_score =
-        get_move_equity_for_sort_type_wmp(gen, current_move, leave_value);
+        has_precomputed_equity
+            ? precomputed_equity
+            : get_move_equity_for_sort_type_wmp(gen, current_move, leave_value);
     move_set_equity(current_move, move_equity_or_score);
     if (compare_moves(current_move, gen_get_readonly_best_move(gen), false)) {
       need_to_update_best_move_equity_or_score = true;

--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -672,6 +672,36 @@ static inline Equity get_move_equity_for_sort_type_wmp(MoveGen *gen,
 #endif
 }
 
+// On a nonempty board, static equity depends only on the score, leave, racks,
+// and number of tiles played. Compute it before writing a full Move so bounded
+// record modes can discard a losing candidate without copying its strip.
+// Opening placement penalties inspect the Move and use the regular path
+// instead.
+static inline bool get_wmp_equity_without_move(const MoveGen *gen, Equity score,
+                                               Equity leave_value,
+                                               Equity *equity) {
+  switch (gen->move_sort_type) {
+  case MOVE_SORT_SCORE:
+    *equity = score;
+    return true;
+  case MOVE_SORT_EQUITY:
+    if (gen->board_number_of_tiles_played == 0) {
+      return false;
+    }
+    *equity = static_eval_get_nonopening_move_equity(
+        &gen->ld, &gen->leave, &gen->opponent_rack, gen->max_tiles_to_play,
+        gen->number_of_tiles_in_bag, score, leave_value);
+    return true;
+  default:
+    log_fatal("unhandled move sort type: %d", gen->move_sort_type);
+  }
+#if defined(__has_builtin) && __has_builtin(__builtin_unreachable)
+  __builtin_unreachable();
+#else
+  return false;
+#endif
+}
+
 static inline void
 update_best_move_or_insert_into_movelist_wmp(MoveGen *gen, int start_col,
                                              Equity score, Equity leave_value) {
@@ -680,10 +710,28 @@ update_best_move_or_insert_into_movelist_wmp(MoveGen *gen, int start_col,
   switch (gen->move_record_type) {
   case MOVE_RECORD_ALL:
   case MOVE_RECORD_WITHIN_X_EQUITY_OF_BEST: {
+    Equity precomputed_equity = 0;
+    const bool has_precomputed_equity = get_wmp_equity_without_move(
+        gen, score, leave_value, &precomputed_equity);
+    if (has_precomputed_equity && !gen->stop_on_threshold) {
+      if (gen->move_record_type == MOVE_RECORD_ALL &&
+          move_list_get_count(gen->move_list) ==
+              move_list_get_capacity(gen->move_list) &&
+          precomputed_equity < move_list_peek_equity(gen->move_list)) {
+        return;
+      }
+      if (gen->move_record_type == MOVE_RECORD_WITHIN_X_EQUITY_OF_BEST &&
+          gen->best_move_equity_or_score != EQUITY_INITIAL_VALUE &&
+          precomputed_equity < gen_get_cutoff_equity_or_score(gen)) {
+        return;
+      }
+    }
     Move *move = move_list_get_spare_move(gen->move_list);
     set_play_for_record_wmp(gen, move, start_col, score);
     move_equity_or_score =
-        get_move_equity_for_sort_type_wmp(gen, move, leave_value);
+        has_precomputed_equity
+            ? precomputed_equity
+            : get_move_equity_for_sort_type_wmp(gen, move, leave_value);
     if (gen->move_record_type == MOVE_RECORD_WITHIN_X_EQUITY_OF_BEST) {
       // This updates the cutoff move internally so no update will be pending
       // afterward.
@@ -694,10 +742,19 @@ update_best_move_or_insert_into_movelist_wmp(MoveGen *gen, int start_col,
     break;
   }
   case MOVE_RECORD_BEST: {
+    Equity precomputed_equity = 0;
+    const bool has_precomputed_equity = get_wmp_equity_without_move(
+        gen, score, leave_value, &precomputed_equity);
+    if (has_precomputed_equity &&
+        precomputed_equity < move_get_equity(gen_get_readonly_best_move(gen))) {
+      return;
+    }
     Move *current_move = gen_get_current_move(gen);
     set_play_for_record_wmp(gen, current_move, start_col, score);
     move_equity_or_score =
-        get_move_equity_for_sort_type_wmp(gen, current_move, leave_value);
+        has_precomputed_equity
+            ? precomputed_equity
+            : get_move_equity_for_sort_type_wmp(gen, current_move, leave_value);
     move_set_equity(current_move, move_equity_or_score);
     if (compare_moves(current_move, gen_get_readonly_best_move(gen), false)) {
       need_to_update_best_move_equity_or_score = true;

--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -677,6 +677,13 @@ static inline Equity get_move_equity_for_sort_type_wmp(MoveGen *gen,
 // record modes can discard a losing candidate without copying its strip.
 // Opening placement penalties inspect the Move and use the regular path
 // instead.
+//
+// The tile count is gen->max_tiles_to_play, which wordmap_gen sets to the
+// anchor's tiles_to_play: every word for a size-k subrack plays exactly k
+// tiles, so it is what set_play_for_record_wmp writes into the Move. If a WMP
+// anchor ever emitted plays of varying length, the pre-endgame adjustment
+// (bag_plus_rack_size < PEG_ADJUST_VALUES_LENGTH) would be the only place
+// this went wrong, and it would do so silently.
 static inline bool get_wmp_equity_without_move(const MoveGen *gen, Equity score,
                                                Equity leave_value,
                                                Equity *equity) {
@@ -1039,6 +1046,9 @@ static inline __attribute__((always_inline)) void
 wordmap_gen(MoveGen *gen, const Anchor *anchor, bool lazy) {
   assert(gen != NULL);
   assert(anchor != NULL);
+  // Every play recorded for this anchor uses exactly this many rack tiles;
+  // get_wmp_equity_without_move relies on that to price a candidate before
+  // its Move exists.
   gen->max_tiles_to_play = anchor->tiles_to_play;
   assert(anchor->tiles_to_play <= rack_get_total_letters(&gen->player_rack));
   WMPMoveGen *wgen = &gen->wmp_move_gen;

--- a/test/wmp_move_gen_test.c
+++ b/test/wmp_move_gen_test.c
@@ -21,8 +21,10 @@
 #include "../src/impl/gameplay.h"
 #include "../src/impl/move_gen.h"
 #include "../src/impl/wmp_move_gen.h"
+#include "test_constants.h"
 #include "test_util.h"
 #include <assert.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -374,12 +376,217 @@ void test_playthrough_bingo_existence(void) {
   config_destroy(config);
 }
 
+// A WMP candidate's equity on a nonempty board depends only on its score,
+// leave, the racks, and the number of tiles played, so the bounded record modes
+// compute it before writing a Move and discard candidates that could not enter
+// the list. Whatever they discard must be exactly what the unbounded list would
+// have ranked out: the best move has the equity of the head of the full sorted
+// list, a list of capacity k has the equities of its first k entries, and a
+// within-x list holds every entry strictly inside the margin. Equal-equity
+// moves are compared by membership rather than by position, because the
+// bounded modes also let shadow skip anchors that cannot beat the running
+// cutoff, and that already decides ties by anchor order.
+enum { RECORD_MODES_FULL_CAPACITY = 100000 };
+
+// A SortedMoveList borrows its Move objects from the MoveList it was built
+// from, so the two live and die together.
+typedef struct SortedGeneration {
+  MoveList *move_list;
+  SortedMoveList *sorted;
+} SortedGeneration;
+
+static SortedGeneration
+generate_sorted_with_record_type(Game *game, move_record_t record_type,
+                                 move_sort_t sort_type, Equity eq_margin,
+                                 int capacity) {
+  SortedGeneration generation;
+  generation.move_list = move_list_create(capacity);
+  const MoveGenArgs args = {
+      .game = game,
+      .move_list = generation.move_list,
+      .move_record_type = record_type,
+      .move_sort_type = sort_type,
+      .eq_margin_movegen = eq_margin,
+      .target_equity = EQUITY_MAX_VALUE,
+      .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+  };
+  // Not generate_moves_for_game(): that replaces the record type with the
+  // on-turn player's configured one.
+  generate_moves(&args);
+  generation.sorted = sorted_move_list_create(generation.move_list);
+  return generation;
+}
+
+static void sorted_generation_destroy(SortedGeneration *generation) {
+  sorted_move_list_destroy(generation->sorted);
+  move_list_destroy(generation->move_list);
+}
+
+static bool moves_match(const Move *move_1, const Move *move_2) {
+  if (move_get_type(move_1) != move_get_type(move_2) ||
+      move_get_row_start(move_1) != move_get_row_start(move_2) ||
+      move_get_col_start(move_1) != move_get_col_start(move_2) ||
+      move_get_dir(move_1) != move_get_dir(move_2) ||
+      move_get_tiles_played(move_1) != move_get_tiles_played(move_2) ||
+      move_get_tiles_length(move_1) != move_get_tiles_length(move_2) ||
+      move_get_score(move_1) != move_get_score(move_2) ||
+      move_get_equity(move_1) != move_get_equity(move_2)) {
+    return false;
+  }
+  for (int tile_idx = 0; tile_idx < move_get_tiles_length(move_1); tile_idx++) {
+    if (move_get_tile(move_1, tile_idx) != move_get_tile(move_2, tile_idx)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// The bounded move must be a move the full list also holds, at the same
+// equity: a shortcut that let through something the regular path would have
+// computed differently shows up here.
+static void assert_move_in_full_list(const SortedMoveList *full,
+                                     const Move *move) {
+  for (int move_idx = 0; move_idx < full->count; move_idx++) {
+    if (moves_match(full->moves[move_idx], move)) {
+      return;
+    }
+  }
+  assert(false);
+}
+
+static int count_moves_above(const SortedMoveList *sorted, Equity cutoff) {
+  int count = 0;
+  while (count < sorted->count &&
+         move_get_equity(sorted->moves[count]) > cutoff) {
+    count++;
+  }
+  return count;
+}
+
+static void assert_bounded_record_modes_match_full_list(Game *game,
+                                                        Game *plain_game,
+                                                        move_sort_t sort_type) {
+  SortedGeneration full_generation = generate_sorted_with_record_type(
+      game, MOVE_RECORD_ALL, sort_type, 0, RECORD_MODES_FULL_CAPACITY);
+  const SortedMoveList *full = full_generation.sorted;
+  assert(full->count > 10);
+
+  // The full WMP list's own equities come from the precomputed value too, so
+  // pin them to the generator without a WMP, whose equities come from the
+  // materialized Move.
+  SortedGeneration plain_generation = generate_sorted_with_record_type(
+      plain_game, MOVE_RECORD_ALL, sort_type, 0, RECORD_MODES_FULL_CAPACITY);
+  const SortedMoveList *plain_full = plain_generation.sorted;
+  assert(plain_full->count == full->count);
+  for (int move_idx = 0; move_idx < full->count; move_idx++) {
+    assert(move_get_equity(full->moves[move_idx]) ==
+           move_get_equity(plain_full->moves[move_idx]));
+    assert_move_in_full_list(plain_full, full->moves[move_idx]);
+  }
+  sorted_generation_destroy(&plain_generation);
+
+  SortedGeneration best_generation =
+      generate_sorted_with_record_type(game, MOVE_RECORD_BEST, sort_type, 0, 1);
+  const SortedMoveList *best = best_generation.sorted;
+  assert(best->count == 1);
+  assert(move_get_equity(best->moves[0]) == move_get_equity(full->moves[0]));
+  assert_move_in_full_list(full, best->moves[0]);
+  sorted_generation_destroy(&best_generation);
+
+  const int capacities[] = {1, 3, 10};
+  for (size_t cap_idx = 0; cap_idx < sizeof(capacities) / sizeof(capacities[0]);
+       cap_idx++) {
+    const int capacity = capacities[cap_idx];
+    SortedGeneration bounded_generation = generate_sorted_with_record_type(
+        game, MOVE_RECORD_ALL, sort_type, 0, capacity);
+    const SortedMoveList *bounded = bounded_generation.sorted;
+    assert(bounded->count == capacity);
+    for (int move_idx = 0; move_idx < capacity; move_idx++) {
+      assert(move_get_equity(bounded->moves[move_idx]) ==
+             move_get_equity(full->moves[move_idx]));
+      assert_move_in_full_list(full, bounded->moves[move_idx]);
+    }
+    sorted_generation_destroy(&bounded_generation);
+  }
+
+  // With the WMP, a score-sorted within-x list currently drops some vertical
+  // plays, including ties for the best -- a pre-existing gap in that mode,
+  // independent of the shortcut under test -- so the within-x check runs for
+  // equity sort only.
+  if (sort_type != MOVE_SORT_EQUITY) {
+    sorted_generation_destroy(&full_generation);
+    return;
+  }
+  const int margins[] = {0, 5, 20, 40};
+  for (size_t margin_idx = 0; margin_idx < sizeof(margins) / sizeof(margins[0]);
+       margin_idx++) {
+    const Equity margin = int_to_equity(margins[margin_idx]);
+    SortedGeneration within_generation = generate_sorted_with_record_type(
+        game, MOVE_RECORD_WITHIN_X_EQUITY_OF_BEST, sort_type, margin,
+        RECORD_MODES_FULL_CAPACITY);
+    const SortedMoveList *within = within_generation.sorted;
+    const Equity cutoff = move_get_equity(full->moves[0]) - margin;
+    assert(within->count > 0);
+    assert(move_get_equity(within->moves[0]) ==
+           move_get_equity(full->moves[0]));
+    assert(count_moves_above(within, cutoff) ==
+           count_moves_above(full, cutoff));
+    for (int move_idx = 0; move_idx < within->count; move_idx++) {
+      assert(move_get_equity(within->moves[move_idx]) >= cutoff);
+      assert_move_in_full_list(full, within->moves[move_idx]);
+    }
+    sorted_generation_destroy(&within_generation);
+  }
+  sorted_generation_destroy(&full_generation);
+}
+
+void test_wmp_bounded_record_modes(void) {
+  const char *settings = "-s1 equity -s2 equity -r1 all -r2 all -numplays 1 "
+                         "-threads 1";
+  char cmd[256];
+  (void)snprintf(cmd, sizeof(cmd), "set -lex CSW21 -wmp true %s", settings);
+  Config *config = config_create_or_die(cmd);
+  (void)snprintf(cmd, sizeof(cmd), "set -lex CSW21 -wmp false %s", settings);
+  Config *plain_config = config_create_or_die(cmd);
+  const char *cgps[] = {
+      "cgp " DOUG_V_EMELY_CGP,
+      "cgp " GUY_VS_BOT_CGP,
+      "cgp " NOAH_VS_MISHU_CGP,
+      "cgp " JOSH2_CGP,
+      "cgp " SOME_ISC_GAME_CGP,
+      "cgp " UTF8_DOS_CGP,
+      "cgp " VS_FRENTZ_CGP,
+      "cgp " NOAH_VS_PETER_CGP,
+      "cgp " DOUG_V_EMELY_DOUBLE_CHALLENGE_CGP,
+      "cgp 5U4OHMIC/5N3WREATH/5T4FAX2/5i3B1VIA1/5N3L1E3/5G2VELDT2/5E3S5/"
+      "5DREKS1F3/8YELL3/4ABASER1U3/4GYM3ZO3/WAITE5OR2J/10OI2A/3QUOIT1PINNER/"
+      "4RENEGADE2P CDIOST?/AIINOOU 450/392 0 -lex CSW21;",
+      "cgp 5U4OHMIC/5N3WREATH/5T4FAX2/5i3B1VIA1/5N3L1E3/5G2VELDT2/5E3S5/"
+      "5DREKS1F3/8YELL3/4ABASER1U3/4GYM3ZO3/WAITE5OR2J/10OI2A/3QUOIT1PINNER/"
+      "4RENEGADE2P AIINOOU/CDIOS 392/450 0 -lex CSW21;",
+  };
+  for (size_t cgp_idx = 0; cgp_idx < sizeof(cgps) / sizeof(cgps[0]);
+       cgp_idx++) {
+    load_and_exec_config_or_die(config, cgps[cgp_idx]);
+    load_and_exec_config_or_die(plain_config, cgps[cgp_idx]);
+    Game *game = config_get_game(config);
+    Game *plain_game = config_get_game(plain_config);
+    assert_bounded_record_modes_match_full_list(game, plain_game,
+                                                MOVE_SORT_EQUITY);
+    assert_bounded_record_modes_match_full_list(game, plain_game,
+                                                MOVE_SORT_SCORE);
+  }
+  config_destroy(plain_config);
+  config_destroy(config);
+}
+
 void test_wmp_move_gen(void) {
   test_wmp_move_gen_inactive();
   test_nonplaythrough_subrack_enumeration();
   test_wit_prune_skips_block_longer_than_anchor_word();
   test_nonplaythrough_existence();
   test_playthrough_bingo_existence();
+  test_wmp_bounded_record_modes();
 }
 
 // The RIT-backed path resolves nonplaythrough WMP entries lazily at record


### PR DESCRIPTION
## What this does

In the WMP record path, every candidate word was written out as a full `Move` — strip, position, tiles — before its equity was computed and compared against the cutoff, even when it was about to be discarded. On a nonempty board the parts of static equity that matter for that comparison do not depend on placement: score, leave value, the number of tiles played, the bag, and the racks. (The opening move's placement penalty does, so an empty board keeps the old path.)

This PR computes that equity first, from values the generator already has, and only materializes the `Move` when it can still matter:

- `MOVE_RECORD_BEST`: skip a candidate whose equity is below the best so far.
- `MOVE_RECORD_ALL` with a full list: skip a candidate below the list's minimum.
- `MOVE_RECORD_WITHIN_X_EQUITY_OF_BEST`: skip a candidate below the cutoff.

Every skip is on a strict `<`, so ties still go through the full comparison and tie-breaking is unchanged. The shared arithmetic moves into `static_eval_get_nonopening_move_equity`, which the existing `Move`-based path now calls too, so the two cannot drift. The tile count it uses is `gen->max_tiles_to_play`, which is also what `set_play_for_record_wmp` writes into the `Move`; the leave and opponent rack are the same objects the `Move` path reads. In `MOVE_RECORD_BEST` the inference threshold is only checked when the best move is replaced, which a skipped candidate never does; the other two modes leave inference (`stop_on_threshold`) on the original path.

Based on `main`, which now includes #614 (merged as `fb0fc7f7`), so the pre-check sits inside the record loop #614 specializes per generation.

## Performance

Against `main` with #614 merged (measured at `6847ade5`, #614's final commit, which is what `main` merged), WIT on: M4 Mac mini, 8 workers, `no_pgo_release`, `simbench` 0.5 s/turn, seeds 42/24301/1552 × 6 interleaved rounds, paired within-round geometric means, stratified-bootstrap 95% CIs, 18 pairs per row. All three seeds are positive in both rows.

| configuration | this PR vs `main` | 95% CI |
|---|---:|---:|
| **RIT on** (the production configuration) | **+0.80%** | [+0.68%, +0.91%] |
| RIT off | +0.63% | [+0.51%, +0.74%] |

**Why it pays.** Counting in the same workload (one 20 s `simbench` run, 8 threads): in the playouts (`MOVE_RECORD_BEST`) the shortcut discards **90.8%** of WMP candidate words before a `Move` is written — 25.1M of 27.6M with the RIT on, 90.7% with it off — and 95.5% at the top level (capacity-bounded `MOVE_RECORD_ALL`). In a `BUILD=profile` sample (inlining suppressed, RIT on) the record-path leaves — `record_wmp_play`, `record_wmp_plays_for_word`, `static_eval_get_move_equity_with_leave_value` — go from 0.59% of samples to 0.39%, and `get_wmp_equity_without_move` costs 0.05%; the shortcut removes roughly a third of what the record path spent, and nothing else in the profile moves.

## Correctness

- **New test** `test_wmp_bounded_record_modes` (`wmg` suite, runs in CI): on 11 CSW21 positions — midgame boards, racks with blanks and fewer than seven tiles, a short bag, an empty bag, and an empty board where the shortcut declines — in both sort types. It first pins the WMP generator's full list to the generator without a WMP, whose equities come from the materialized `Move`, so the precomputed value is checked against the real one and not only against itself. It then checks that `MOVE_RECORD_BEST` returns the equity of the head of the full list, that capacity-1/3/10 lists carry the equities of its first *k* entries, and (equity sort) that within-0/5/20/40 lists hold every entry strictly inside the margin, every bounded move being one the full list holds at that equity. It passes on `main` without this PR too. Mutation check: an equity one point low, a tile count one low, and each skip made one point too eager (`BEST`, full `ALL`, within-x) are all caught; relaxing a skip's strict `<` to `<=` is not, because that only changes tie-breaking, which the test tolerates on purpose and the differential below covers.
- **Score sort + within-x + WMP**: while writing the test I found that a score-sorted `MOVE_RECORD_WITHIN_X_EQUITY_OF_BEST` list from the WMP generator drops some vertical plays, including ties for the best (e.g. WINDY board, rack ADEEGIL, margin 20: E7 LID for 4 is missing; margin 5 on another position loses a 24-point tie for the top). The generator without a WMP is complete, and it happens identically on `main`, so it predates this PR; the test limits the within-x check to equity sort. Tracked in #673 and fixed in #674; once that merges, the guard can go.
- **Autoplay differential** against `main`: the same seeded 200 game pairs (400 games) played by `main`'s `no_pgo_release` binary (with #614 merged) and this one, CSW24 with WMP and WIT, in four record/sort configurations (`best`/equity, `all -numplays 15`/equity, `best`/score, `all -numplays 5`/score), each with the RIT on and off: all eight aggregate reports (turns, scores, bingos, end reasons) are identical.
- Earlier, before #614 landed, a move-for-move differential against the `main` of that time (32 seeded CSW24 games, 712 positions, 967,104 moves per export, RIT on and off) and a Wordsmog differential (20,027,705 moves) were identical.
- Release suites `wmg movegen shadow rit witsweep` and the WIT copy differential on this tree; ASan `wmg movegen`; cppcheck, circular-dependency check and `format.py` clean.

## What can build on this

- **Fold the switches to constants.** `get_wmp_equity_without_move` switches on `move_sort_type` per candidate, and the record path on `move_record_type`. Both are fixed for a generation. #614's conditional-inlining pattern — an `always_inline` body with a `bool`/enum every caller passes as a constant, instantiated once per mode by a per-generation dispatch — would make both branches vanish from the hot path. Untested; the pattern's cost model is only known for the RIT switch.
- **#614** (merged into `main`): lazy resolution of RIT-backed WMP entries — the other half of the record path. The number above is this PR's increment on top of it.
- **#618–#623** (pending drafts): WMP shadow-side work stacked on the merged `wit-subrack-pruning`, each needing a `rebase --onto main`; #618 measured at the noise floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEZJov4z3ZkZpTsTrLQMd1

