### PR TITLE
Snapshot the rack once per shadow pass instead of per anchor

### DIFF
--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -2824,7 +2824,6 @@ static inline void shadow_start(MoveGen *gen) {
   }
 
   const uint64_t original_rack_cross_set = gen->rack_cross_set;
-  rack_copy(&gen->full_player_rack, &gen->player_rack);
   if (gen->is_wordsmog) {
     rack_copy(&gen->bingo_alpha_rack, &gen->player_rack);
   }
@@ -2838,7 +2837,14 @@ static inline void shadow_start(MoveGen *gen) {
   }
 
   gen->rack_cross_set = original_rack_cross_set;
-  rack_copy(&gen->player_rack, &gen->full_player_rack);
+  // Rightward restrictions restore their own rack snapshot. A lower total
+  // here therefore means the leftward shadow consumed at least one uniquely
+  // forced tile. Restore only in that case; most anchors never mutate the
+  // rack at all.
+  if (rack_get_total_letters(&gen->player_rack) !=
+      gen->number_of_letters_on_rack) {
+    rack_copy(&gen->player_rack, &gen->full_player_rack);
+  }
 }
 
 // Simplified shadow_start for small move types.
@@ -2851,7 +2857,6 @@ static inline void shadow_start_small(MoveGen *gen) {
   }
 
   const uint64_t original_rack_cross_set = gen->rack_cross_set;
-  rack_copy(&gen->full_player_rack, &gen->player_rack);
 
   const MachineLetter current_letter =
       gen_cache_get_letter(gen, gen->current_left_col);
@@ -2862,7 +2867,10 @@ static inline void shadow_start_small(MoveGen *gen) {
   }
 
   gen->rack_cross_set = original_rack_cross_set;
-  rack_copy(&gen->player_rack, &gen->full_player_rack);
+  if (rack_get_total_letters(&gen->player_rack) !=
+      gen->number_of_letters_on_rack) {
+    rack_copy(&gen->player_rack, &gen->full_player_rack);
+  }
 }
 
 // The algorithm used in this file for
@@ -3368,6 +3376,12 @@ void gen_shadow(MoveGen *gen) {
   leave_map_set_current_index(
       &gen->leave_map, (1 << rack_get_total_letters(&gen->player_rack)) - 1);
   anchor_heap_reset(&gen->anchor_heap);
+  // Keep one immutable rack snapshot for all anchors. shadow_start restores
+  // from it only when a leftward unique-hook restriction changed player_rack.
+  // ALL_SMALL bypasses shadow_start entirely and needs no snapshot.
+  if (gen->move_record_type != MOVE_RECORD_ALL_SMALL) {
+    rack_copy(&gen->full_player_rack, &gen->player_rack);
+  }
 
   for (int dir = 0; dir < 2; dir++) {
     gen->dir = dir;
@@ -3385,6 +3399,7 @@ void gen_shadow(MoveGen *gen) {
 // Skips leave_map setup and uses small shadow functions.
 void gen_shadow_small(MoveGen *gen) {
   anchor_heap_reset(&gen->anchor_heap);
+  rack_copy(&gen->full_player_rack, &gen->player_rack);
 
   for (int dir = 0; dir < 2; dir++) {
     gen->dir = dir;

--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -2515,7 +2515,6 @@ static inline void shadow_start(MoveGen *gen) {
   }
 
   const uint64_t original_rack_cross_set = gen->rack_cross_set;
-  rack_copy(&gen->full_player_rack, &gen->player_rack);
   if (gen->is_wordsmog) {
     rack_copy(&gen->bingo_alpha_rack, &gen->player_rack);
   }
@@ -2529,7 +2528,14 @@ static inline void shadow_start(MoveGen *gen) {
   }
 
   gen->rack_cross_set = original_rack_cross_set;
-  rack_copy(&gen->player_rack, &gen->full_player_rack);
+  // Rightward restrictions restore their own rack snapshot. A lower total
+  // here therefore means the leftward shadow consumed at least one uniquely
+  // forced tile. Restore only in that case; most anchors never mutate the
+  // rack at all.
+  if (rack_get_total_letters(&gen->player_rack) !=
+      gen->number_of_letters_on_rack) {
+    rack_copy(&gen->player_rack, &gen->full_player_rack);
+  }
 }
 
 // Simplified shadow_start for small move types.
@@ -2542,7 +2548,6 @@ static inline void shadow_start_small(MoveGen *gen) {
   }
 
   const uint64_t original_rack_cross_set = gen->rack_cross_set;
-  rack_copy(&gen->full_player_rack, &gen->player_rack);
 
   const MachineLetter current_letter =
       gen_cache_get_letter(gen, gen->current_left_col);
@@ -2553,7 +2558,10 @@ static inline void shadow_start_small(MoveGen *gen) {
   }
 
   gen->rack_cross_set = original_rack_cross_set;
-  rack_copy(&gen->player_rack, &gen->full_player_rack);
+  if (rack_get_total_letters(&gen->player_rack) !=
+      gen->number_of_letters_on_rack) {
+    rack_copy(&gen->player_rack, &gen->full_player_rack);
+  }
 }
 
 // The algorithm used in this file for
@@ -3050,6 +3058,12 @@ void gen_shadow(MoveGen *gen) {
   leave_map_set_current_index(
       &gen->leave_map, (1 << rack_get_total_letters(&gen->player_rack)) - 1);
   anchor_heap_reset(&gen->anchor_heap);
+  // Keep one immutable rack snapshot for all anchors. shadow_start restores
+  // from it only when a leftward unique-hook restriction changed player_rack.
+  // ALL_SMALL bypasses shadow_start entirely and needs no snapshot.
+  if (gen->move_record_type != MOVE_RECORD_ALL_SMALL) {
+    rack_copy(&gen->full_player_rack, &gen->player_rack);
+  }
 
   for (int dir = 0; dir < 2; dir++) {
     gen->dir = dir;
@@ -3067,6 +3081,7 @@ void gen_shadow(MoveGen *gen) {
 // Skips leave_map setup and uses small shadow functions.
 void gen_shadow_small(MoveGen *gen) {
   anchor_heap_reset(&gen->anchor_heap);
+  rack_copy(&gen->full_player_rack, &gen->player_rack);
 
   for (int dir = 0; dir < 2; dir++) {
     gen->dir = dir;


### PR DESCRIPTION
## What this changes

`shadow_start` and `shadow_start_small` copied the player rack into `full_player_rack` on entry and back on exit — two 104-byte `rack_copy`s — for **every anchor**. Rightward restrictions already restore their own snapshot, so the rack can only differ on exit when the leftward shadow consumed a uniquely forced tile, and most anchors never mutate it at all.

Take the snapshot once in `gen_shadow` / `gen_shadow_small`, and restore only when the tile count shows the leftward shadow changed the rack. `ALL_SMALL` bypasses `shadow_start` and needs no snapshot.

This is #613 ported onto `main` on its own; the port carries exactly the original's 23 changed lines.

## Correctness

- The condition is exact: during shadow the only mutation of `player_rack` is the `rack_take_letter` in `restrict_tile_and_accumulate_score` (take only, never a swap), so an unchanged total means unchanged contents.
- `full_player_rack` is also used by the wordsmog record path, but record runs strictly after shadow and `gen_record_scoring_plays` resets it first, so it never reads the snapshot.
- Move-for-move differential against `main`, RIT off and on: 32 seeded CSW24 games, 712 positions, 967,104 moves per export; all sorted exports identical to `main`'s (SHA-256 `f1c017b0a2eaff34…`).
- Wordsmog differential (`-lex CSW21_alpha -var wordsmog -r all`): 32 games, 20,027,705 moves, identical to `main`'s.
- Dev/ASan suites `wmg`, `movegen`, `shadow`, `sim`, `eq`, `gameplay` pass; cppcheck 2.17.1, circular-dependency check and `format.py` clean.

## Performance

Instrumented builds confirm the mechanism: per position, rack copies drop from 300.3 to 21.9 (−93 %) and restores from 150.2 to 19.9, with identical shadow work (155.9 `shadow_start` calls).

Isolated `generate_moves` timing (release, MOVE_RECORD_ALL, 712 positions × 50 reps per run, base/candidate order alternated every round, quiet host):

| Configuration | Rounds | Candidate / base | 95 % interval | Candidate faster |
|---|---|---|---|---|
| RIT enabled | 30 | 1.0015 | 0.9984 .. 1.0047 | 12/30 |
| RIT disabled | 12 | 1.0006 | 0.9993 .. 1.0019 | 4/12 |

No measurable effect: any gain larger than 0.16 % is excluded. The removed copies are L1-resident (`MoveGen` fields) and overlap with surrounding work. A simbench campaign (M4 Mac mini, 24 matched pairs, 8 workers) had shown +0.17 % pooled, 21/24 pairs faster; given the isolated result that should be read as noise. Profiles agree: the shadow functions move by less than one sample pair can resolve.

**Assessment:** correct and harmless, but not a measurable speedup, so it does not qualify as a standalone performance PR. Full evidence, harness and raw results are archived outside the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DTuR9ECFRsXumHLu9Jfu4
