### PR TITLE
Defer RIT-backed WMP lookups until record time

### DIFF
--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -3649,12 +3649,8 @@ void generate_moves(const MoveGenArgs *args) {
           leaves_are_populated && subrack_entry->valid &&
           bit_rack_equals(&subrack_entry->key, &wgen->player_bit_rack);
       if (subrack_cache_hit) {
-        // Restore enumerate_nonplaythrough_subracks output AND the
-        // per-subrack wmp_entry pointers from cache. Both pieces are
-        // rack-determined (subracks via combinatoric walk, wmp_entries
-        // via WMP hash), so on hit we skip both the enumeration and the
-        // per-subrack wmp_get_word_entry calls that the size walk would
-        // otherwise run.
+        // Restore the enumeration output and whichever per-subrack WMP
+        // entries prior occurrences of this rack actually needed.
         memcpy(wgen->count_by_size, subrack_entry->count_by_size,
                sizeof(wgen->count_by_size));
         for (int i = 0; i < MOVEGEN_SUBRACK_CACHE_ENTRIES; i++) {
@@ -3663,18 +3659,22 @@ void generate_moves(const MoveGenArgs *args) {
               subrack_entry->leave_values[i];
           wgen->nonplaythrough_infos[i].wmp_entry =
               subrack_entry->wmp_entries[i];
+          wgen->nonplaythrough_infos[i].wmp_entry_is_set =
+              subrack_entry->wmp_entries_are_set[i];
         }
       }
+      if (leaves_are_populated) {
+        wgen->nonplaythrough_wmp_entry_cache = subrack_entry->wmp_entries;
+        wgen->nonplaythrough_wmp_entry_cache_set =
+            subrack_entry->wmp_entries_are_set;
+      }
       if (gen->rit_entry != NULL) {
-        // RIT-backed fast path: skip the per-size wmp_get_word_entry loop
-        // for any played size where the RIT entry says no canonical
-        // k-subrack of this rack forms a k-letter word on its own. Seeds
-        // nonplaythrough_best_leave_values directly from the cached max
-        // the RIT already computed at build time.
+        // The RIT supplies existence and best-leave bounds. Defer each
+        // per-subrack WMP lookup until wordmap generation survives those
+        // bounds and actually needs that subrack's words.
         wmp_move_gen_check_nonplaythrough_existence_with_rit(
             wgen, check_leaves, &gen->leave_map, gen->rit_entry,
-            /*subracks_precomputed=*/subrack_cache_hit,
-            /*wmp_entries_precomputed=*/subrack_cache_hit);
+            /*subracks_precomputed=*/subrack_cache_hit);
       } else {
         wmp_move_gen_check_nonplaythrough_existence(
             wgen, check_leaves, &gen->leave_map,
@@ -3682,8 +3682,8 @@ void generate_moves(const MoveGenArgs *args) {
             /*wmp_entries_precomputed=*/subrack_cache_hit);
       }
       if (!subrack_cache_hit && leaves_are_populated) {
-        // Store the newly-computed enumeration and wmp_entry pointers
-        // into the cache. Only cache when leaves_are_populated so we
+        // Store the newly computed enumeration and any WMP entries that have
+        // already been resolved. Only cache when leaves_are_populated so we
         // don't stash garbage leave_values from an uninitialized leave_map.
         subrack_entry->key = wgen->player_bit_rack;
         subrack_entry->valid = true;
@@ -3695,6 +3695,8 @@ void generate_moves(const MoveGenArgs *args) {
               wgen->nonplaythrough_infos[i].leave_value;
           subrack_entry->wmp_entries[i] =
               wgen->nonplaythrough_infos[i].wmp_entry;
+          subrack_entry->wmp_entries_are_set[i] =
+              wgen->nonplaythrough_infos[i].wmp_entry_is_set;
         }
       }
     }

--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -41,6 +41,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+// See WMP_ENTRY_UNRESOLVED in wmp_move_gen.h. Only its address is used.
+const WMPEntry wmp_entry_unresolved_sentinel = {0};
+
 #define INITIAL_LAST_ANCHOR_COL (BOARD_DIM)
 
 // Cache move generators since destroying
@@ -3480,14 +3483,10 @@ void generate_moves(const MoveGenArgs *args) {
               subrack_entry->leave_values[i];
           wgen->nonplaythrough_infos[i].wmp_entry =
               subrack_entry->wmp_entries[i];
-          wgen->nonplaythrough_infos[i].wmp_entry_is_set =
-              subrack_entry->wmp_entries_are_set[i];
         }
       }
       if (leaves_are_populated) {
         wgen->nonplaythrough_wmp_entry_cache = subrack_entry->wmp_entries;
-        wgen->nonplaythrough_wmp_entry_cache_set =
-            subrack_entry->wmp_entries_are_set;
       }
       if (gen->rit_entry != NULL) {
         // The RIT supplies existence and best-leave bounds. Defer each
@@ -3516,8 +3515,6 @@ void generate_moves(const MoveGenArgs *args) {
               wgen->nonplaythrough_infos[i].leave_value;
           subrack_entry->wmp_entries[i] =
               wgen->nonplaythrough_infos[i].wmp_entry;
-          subrack_entry->wmp_entries_are_set[i] =
-              wgen->nonplaythrough_infos[i].wmp_entry_is_set;
         }
       }
     }

--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -888,8 +888,8 @@ bool wordmap_gen_check_playthrough_and_crosses(MoveGen *gen, int word_idx,
 // fuses exactly as it did before the prune; the second copy lands in the
 // out-of-line masked scan below, away from generate_moves.
 static inline __attribute__((always_inline)) bool
-wordmap_gen_record_subrack(MoveGen *gen, const Anchor *anchor,
-                           int subrack_idx) {
+wordmap_gen_record_subrack(MoveGen *gen, const Anchor *anchor, int subrack_idx,
+                           bool lazy) {
   WMPMoveGen *wgen = &gen->wmp_move_gen;
   if (gen->number_of_tiles_in_bag > 0) {
     const Equity leave_value = wmp_move_gen_get_leave_value(wgen, subrack_idx);
@@ -898,7 +898,7 @@ wordmap_gen_record_subrack(MoveGen *gen, const Anchor *anchor,
       return false;
     }
   }
-  if (!wmp_move_gen_get_subrack_words(wgen, subrack_idx)) {
+  if (!wmp_move_gen_get_subrack_words(wgen, subrack_idx, lazy)) {
     return false;
   }
   if (gen->number_of_tiles_in_bag == 0) {
@@ -949,7 +949,7 @@ wordmap_gen_forbidden_subracks(MoveGen *gen, const Anchor *anchor,
                                  forbidden_subrack_high)) {
       continue;
     }
-    if (wordmap_gen_record_subrack(gen, anchor, subrack_idx)) {
+    if (wordmap_gen_record_subrack(gen, anchor, subrack_idx, true)) {
       return;
     }
   }
@@ -978,7 +978,8 @@ static inline uint32_t clear_lowest_set_bit(uint32_t bitset) {
   return bitset & (bitset - 1U);
 }
 
-void wordmap_gen(MoveGen *gen, const Anchor *anchor) {
+static inline __attribute__((always_inline)) void
+wordmap_gen(MoveGen *gen, const Anchor *anchor, bool lazy) {
   assert(gen != NULL);
   assert(anchor != NULL);
   gen->max_tiles_to_play = anchor->tiles_to_play;
@@ -1080,7 +1081,7 @@ void wordmap_gen(MoveGen *gen, const Anchor *anchor) {
   }
   for (int subrack_idx = 0; subrack_idx < num_subrack_combinations;
        subrack_idx++) {
-    if (wordmap_gen_record_subrack(gen, anchor, subrack_idx)) {
+    if (wordmap_gen_record_subrack(gen, anchor, subrack_idx, lazy)) {
       return;
     }
   }
@@ -3306,7 +3307,8 @@ void gen_record_scoring_plays_small(MoveGen *gen) {
   }
 }
 
-void gen_record_scoring_plays(MoveGen *gen) {
+static inline __attribute__((always_inline)) void
+gen_record_scoring_plays_impl(MoveGen *gen, bool lazy) {
   if (gen->threshold_exceeded) {
     return;
   }
@@ -3357,7 +3359,7 @@ void gen_record_scoring_plays(MoveGen *gen) {
       recursive_gen_alpha(gen, anchor.col, anchor.col, anchor.col,
                           gen->dir == BOARD_HORIZONTAL_DIRECTION, 0, 1, 0);
     } else if (wmp_move_gen_is_active(&gen->wmp_move_gen)) {
-      wordmap_gen(gen, &anchor);
+      wordmap_gen(gen, &anchor, lazy);
     } else {
       recursive_gen(gen, anchor.col, kwg_root_node_index, anchor.col,
                     anchor.col, gen->dir == BOARD_HORIZONTAL_DIRECTION, 0, 1,
@@ -3367,6 +3369,20 @@ void gen_record_scoring_plays(MoveGen *gen) {
     // If a better play has been found than should have been possible for
     // this anchor, highest_possible_equity was invalid.
     assert(!better_play_has_been_found(gen, anchor.highest_possible_equity));
+  }
+}
+
+static __attribute__((noinline)) void
+gen_record_scoring_plays_eager(MoveGen *gen) {
+  gen_record_scoring_plays_impl(gen, false);
+}
+
+static inline __attribute__((always_inline)) void
+gen_record_scoring_plays(MoveGen *gen) {
+  if (gen->rit_entry == NULL) {
+    gen_record_scoring_plays_eager(gen);
+  } else {
+    gen_record_scoring_plays_impl(gen, true);
   }
 }
 

--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -3470,12 +3470,8 @@ void generate_moves(const MoveGenArgs *args) {
           leaves_are_populated && subrack_entry->valid &&
           bit_rack_equals(&subrack_entry->key, &wgen->player_bit_rack);
       if (subrack_cache_hit) {
-        // Restore enumerate_nonplaythrough_subracks output AND the
-        // per-subrack wmp_entry pointers from cache. Both pieces are
-        // rack-determined (subracks via combinatoric walk, wmp_entries
-        // via WMP hash), so on hit we skip both the enumeration and the
-        // per-subrack wmp_get_word_entry calls that the size walk would
-        // otherwise run.
+        // Restore the enumeration output and whichever per-subrack WMP
+        // entries prior occurrences of this rack actually needed.
         memcpy(wgen->count_by_size, subrack_entry->count_by_size,
                sizeof(wgen->count_by_size));
         for (int i = 0; i < MOVEGEN_SUBRACK_CACHE_ENTRIES; i++) {
@@ -3484,18 +3480,22 @@ void generate_moves(const MoveGenArgs *args) {
               subrack_entry->leave_values[i];
           wgen->nonplaythrough_infos[i].wmp_entry =
               subrack_entry->wmp_entries[i];
+          wgen->nonplaythrough_infos[i].wmp_entry_is_set =
+              subrack_entry->wmp_entries_are_set[i];
         }
       }
+      if (leaves_are_populated) {
+        wgen->nonplaythrough_wmp_entry_cache = subrack_entry->wmp_entries;
+        wgen->nonplaythrough_wmp_entry_cache_set =
+            subrack_entry->wmp_entries_are_set;
+      }
       if (gen->rit_entry != NULL) {
-        // RIT-backed fast path: skip the per-size wmp_get_word_entry loop
-        // for any played size where the RIT entry says no canonical
-        // k-subrack of this rack forms a k-letter word on its own. Seeds
-        // nonplaythrough_best_leave_values directly from the cached max
-        // the RIT already computed at build time.
+        // The RIT supplies existence and best-leave bounds. Defer each
+        // per-subrack WMP lookup until wordmap generation survives those
+        // bounds and actually needs that subrack's words.
         wmp_move_gen_check_nonplaythrough_existence_with_rit(
             wgen, check_leaves, &gen->leave_map, gen->rit_entry,
-            /*subracks_precomputed=*/subrack_cache_hit,
-            /*wmp_entries_precomputed=*/subrack_cache_hit);
+            /*subracks_precomputed=*/subrack_cache_hit);
       } else {
         wmp_move_gen_check_nonplaythrough_existence(
             wgen, check_leaves, &gen->leave_map,
@@ -3503,8 +3503,8 @@ void generate_moves(const MoveGenArgs *args) {
             /*wmp_entries_precomputed=*/subrack_cache_hit);
       }
       if (!subrack_cache_hit && leaves_are_populated) {
-        // Store the newly-computed enumeration and wmp_entry pointers
-        // into the cache. Only cache when leaves_are_populated so we
+        // Store the newly computed enumeration and any WMP entries that have
+        // already been resolved. Only cache when leaves_are_populated so we
         // don't stash garbage leave_values from an uninitialized leave_map.
         subrack_entry->key = wgen->player_bit_rack;
         subrack_entry->valid = true;
@@ -3516,6 +3516,8 @@ void generate_moves(const MoveGenArgs *args) {
               wgen->nonplaythrough_infos[i].leave_value;
           subrack_entry->wmp_entries[i] =
               wgen->nonplaythrough_infos[i].wmp_entry;
+          subrack_entry->wmp_entries_are_set[i] =
+              wgen->nonplaythrough_infos[i].wmp_entry_is_set;
         }
       }
     }

--- a/src/impl/move_gen.h
+++ b/src/impl/move_gen.h
@@ -62,10 +62,11 @@ typedef struct SubrackEnumCacheEntry {
   // Flat array indexed by subracks_get_combination_offset(size) + idx_for_size.
   BitRack subracks[MOVEGEN_SUBRACK_CACHE_ENTRIES];
   Equity leave_values[MOVEGEN_SUBRACK_CACHE_ENTRIES];
-  // wmp_entry pointers per subrack, also rack-determined. Storing them
-  // lets us skip the per-subrack wmp_get_word_entry hash lookups on
-  // cache hit. Invalidated when the WMP pointer changes.
+  // Lazily populated wmp_entry pointers per subrack, also rack-determined.
+  // The parallel flags distinguish an unresolved entry from a resolved miss
+  // (NULL). Invalidated when the WMP pointer changes.
   const WMPEntry *wmp_entries[MOVEGEN_SUBRACK_CACHE_ENTRIES];
+  bool wmp_entries_are_set[MOVEGEN_SUBRACK_CACHE_ENTRIES];
   uint8_t count_by_size[RACK_SIZE + 1];
 } SubrackEnumCacheEntry;
 

--- a/src/impl/move_gen.h
+++ b/src/impl/move_gen.h
@@ -62,11 +62,10 @@ typedef struct SubrackEnumCacheEntry {
   // Flat array indexed by subracks_get_combination_offset(size) + idx_for_size.
   BitRack subracks[MOVEGEN_SUBRACK_CACHE_ENTRIES];
   Equity leave_values[MOVEGEN_SUBRACK_CACHE_ENTRIES];
-  // Lazily populated wmp_entry pointers per subrack, also rack-determined.
-  // The parallel flags distinguish an unresolved entry from a resolved miss
-  // (NULL). Invalidated when the WMP pointer changes.
+  // Lazily populated wmp_entry pointers per subrack, also rack-determined:
+  // WMP_ENTRY_UNRESOLVED, a resolved miss (NULL), or a resolved entry.
+  // Invalidated when the WMP pointer changes.
   const WMPEntry *wmp_entries[MOVEGEN_SUBRACK_CACHE_ENTRIES];
-  bool wmp_entries_are_set[MOVEGEN_SUBRACK_CACHE_ENTRIES];
   uint8_t count_by_size[RACK_SIZE + 1];
 } SubrackEnumCacheEntry;
 

--- a/src/impl/wmp_move_gen.h
+++ b/src/impl/wmp_move_gen.h
@@ -27,6 +27,7 @@ typedef struct SubrackInfo {
   BitRack subrack;
   const WMPEntry *wmp_entry;
   Equity leave_value;
+  bool wmp_entry_is_set;
 } SubrackInfo;
 
 // NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
@@ -70,6 +71,11 @@ typedef struct WMPMoveGen {
   int word_length;
   int num_words;
   Equity leave_value;
+  // When the caller has an active per-rack cache, lazily resolved
+  // nonplaythrough WMP entries are written through to it for the next
+  // occurrence of the rack.
+  const WMPEntry **nonplaythrough_wmp_entry_cache;
+  bool *nonplaythrough_wmp_entry_cache_set;
   // AND, over this anchor's playthrough blocks, of each block's word info table
   // letter set at this anchor's word length (bit ml set iff some word of that
   // length containing the block uses ml). Accumulated for free while scanning
@@ -95,6 +101,8 @@ static inline void wmp_move_gen_init(WMPMoveGen *wmp_move_gen,
                                      const LetterDistribution *ld,
                                      const Rack *player_rack, const WMP *wmp) {
   wmp_move_gen->wmp = wmp;
+  wmp_move_gen->nonplaythrough_wmp_entry_cache = NULL;
+  wmp_move_gen->nonplaythrough_wmp_entry_cache_set = NULL;
   if (wmp == NULL || player_rack == NULL || ld == NULL) {
     return;
   }
@@ -148,6 +156,7 @@ wmp_move_gen_enumerate_nonplaythrough_subracks(WMPMoveGen *wmp_move_gen,
         wmp_move_gen->nonplaythrough_infos + insert_index;
     subrack_info->subrack = *current;
     subrack_info->leave_value = leave_map_get_current_value(leave_map);
+    subrack_info->wmp_entry_is_set = false;
     wmp_move_gen->count_by_size[count]++;
     return;
   }
@@ -324,6 +333,9 @@ wmp_move_gen_check_nonplaythroughs_of_size(WMPMoveGen *wmp_move_gen, int size,
     if (!wmp_entries_precomputed) {
       subrack_info->wmp_entry =
           wmp_get_word_entry(wmp_move_gen->wmp, &subrack_info->subrack, size);
+      subrack_info->wmp_entry_is_set = true;
+    } else {
+      assert(subrack_info->wmp_entry_is_set);
     }
     if (subrack_info->wmp_entry == NULL) {
       continue;
@@ -364,14 +376,10 @@ static inline void wmp_move_gen_check_nonplaythrough_existence(
   }
 }
 
-// RIT-backed variant of wmp_move_gen_check_nonplaythrough_existence. Skips
-// the per-size wmp_get_word_entry loop for any size where the RIT entry
-// says there is no canonical size-k subrack that forms a valid k-letter
-// word. For sizes that do have words, still runs the existing walk to
-// populate subrack_info->wmp_entry pointers needed at record time. Also
-// seeds nonplaythrough_best_leave_values from the RIT entry directly so
-// that even for the walked sizes we avoid the running-max update inside
-// the inner loop.
+// RIT-backed variant of wmp_move_gen_check_nonplaythrough_existence. The RIT
+// supplies both the per-size existence result and best leave, so no WMP hash
+// walk is needed here. Nonplaythrough WMP entries are resolved lazily if
+// record-time generation actually reaches their subrack.
 //
 // Precondition: rit_entry is non-NULL and corresponds to this move_gen's
 // full player_rack.
@@ -380,8 +388,7 @@ static inline void wmp_move_gen_check_nonplaythrough_existence(
 // cache), so we skip the enumerate_nonplaythrough_subracks step.
 static inline void wmp_move_gen_check_nonplaythrough_existence_with_rit(
     WMPMoveGen *wmp_move_gen, bool check_leaves, LeaveMap *leave_map,
-    const RackInfoTableEntry *rit_entry, bool subracks_precomputed,
-    bool wmp_entries_precomputed) {
+    const RackInfoTableEntry *rit_entry, bool subracks_precomputed) {
   leave_map_set_current_index(leave_map,
                               (1 << wmp_move_gen->full_rack_size) - 1);
   if (!subracks_precomputed) {
@@ -414,36 +421,6 @@ static inline void wmp_move_gen_check_nonplaythrough_existence_with_rit(
     } else {
       wmp_move_gen->nonplaythrough_best_leave_values[leave_size] = rit_best;
     }
-  }
-
-  // For sizes that have at least one valid nonplaythrough word we still
-  // need to populate subrack_info->wmp_entry pointers for the eventual
-  // record-time wmp_entry_write_words_to_buffer call. But we can skip the
-  // walk entirely for sizes where no canonical subrack makes a word -- the
-  // wmp_entry cache for those sizes is never read because shadow_record
-  // early-returns on wmp_move_gen_nonplaythrough_word_of_length_exists
-  // before getting to the record stage.
-  for (int size = MINIMUM_WORD_LENGTH; size <= wmp_move_gen->full_rack_size;
-       size++) {
-    if (!wmp_move_gen->nonplaythrough_has_word_of_length[size]) {
-      continue;
-    }
-    const int leave_size = wmp_move_gen->full_rack_size - size;
-    // The existing wmp_move_gen_check_nonplaythroughs_of_size writes to
-    // nonplaythrough_best_leave_values[leave_size] and runs a max update
-    // across subracks. We already seeded the final value from the RIT, so
-    // stash it and restore after the walk (the walk only keeps a running
-    // max vs EQUITY_MIN_VALUE, which matches the RIT-seeded max).
-    const Equity seeded_best =
-        wmp_move_gen->nonplaythrough_best_leave_values[leave_size];
-    wmp_move_gen_check_nonplaythroughs_of_size(wmp_move_gen, size, check_leaves,
-                                               wmp_entries_precomputed);
-    // Assert the walk's max matches what RIT already stored. Cheap sanity
-    // check that catches maker/consumer drift.
-    assert(!check_leaves ||
-           wmp_move_gen->nonplaythrough_best_leave_values[leave_size] ==
-               seeded_best);
-    (void)seeded_best;
   }
 }
 
@@ -641,11 +618,18 @@ static inline bool wmp_move_gen_get_subrack_words(WMPMoveGen *wmp_move_gen,
   SubrackInfo *subrack_info =
       is_playthrough ? &wmp_move_gen->playthrough_infos[subrack_idx]
                      : &wmp_move_gen->nonplaythrough_infos[subrack_idx];
-  // Nonplaythrough subracks' wmp entries were already looked up during
-  // shadow.
   if (is_playthrough) {
     subrack_info->wmp_entry = wmp_get_word_entry(
         wmp_move_gen->wmp, &subrack_info->subrack, wmp_move_gen->word_length);
+  } else if (!subrack_info->wmp_entry_is_set) {
+    subrack_info->wmp_entry = wmp_get_word_entry(
+        wmp_move_gen->wmp, &subrack_info->subrack, wmp_move_gen->word_length);
+    subrack_info->wmp_entry_is_set = true;
+    if (wmp_move_gen->nonplaythrough_wmp_entry_cache != NULL) {
+      wmp_move_gen->nonplaythrough_wmp_entry_cache[subrack_idx] =
+          subrack_info->wmp_entry;
+      wmp_move_gen->nonplaythrough_wmp_entry_cache_set[subrack_idx] = true;
+    }
   }
 
   if (subrack_info->wmp_entry == NULL) {

--- a/src/impl/wmp_move_gen.h
+++ b/src/impl/wmp_move_gen.h
@@ -27,8 +27,14 @@ typedef struct SubrackInfo {
   BitRack subrack;
   const WMPEntry *wmp_entry;
   Equity leave_value;
-  bool wmp_entry_is_set;
 } SubrackInfo;
+
+// A nonplaythrough subrack's wmp_entry has three states: unresolved (this
+// sentinel), a resolved miss (NULL), or a resolved entry. Only the RIT-backed
+// path ever writes the sentinel, so the non-RIT path is unchanged by lazy
+// resolution. The object lives in move_gen.c; only its address matters.
+extern const WMPEntry wmp_entry_unresolved_sentinel;
+#define WMP_ENTRY_UNRESOLVED (&wmp_entry_unresolved_sentinel)
 
 // NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
 typedef struct WMPMoveGen {
@@ -80,9 +86,8 @@ typedef struct WMPMoveGen {
   uint32_t playthrough_addable;
   // When the caller has an active per-rack cache, lazily resolved
   // nonplaythrough WMP entries are written through to it for the next
-  // occurrence of the rack.
+  // occurrence of the rack. The cache stores the same three-state pointers.
   const WMPEntry **nonplaythrough_wmp_entry_cache;
-  bool *nonplaythrough_wmp_entry_cache_set;
 } WMPMoveGen;
 
 static inline void wmp_move_gen_reset_anchors(WMPMoveGen *wmp_move_gen) {
@@ -102,7 +107,6 @@ static inline void wmp_move_gen_init(WMPMoveGen *wmp_move_gen,
                                      const Rack *player_rack, const WMP *wmp) {
   wmp_move_gen->wmp = wmp;
   wmp_move_gen->nonplaythrough_wmp_entry_cache = NULL;
-  wmp_move_gen->nonplaythrough_wmp_entry_cache_set = NULL;
   if (wmp == NULL || player_rack == NULL || ld == NULL) {
     return;
   }
@@ -159,7 +163,6 @@ static inline void wmp_move_gen_enumerate_compact_nonplaythrough_subracks(
         wmp_move_gen->nonplaythrough_infos + insert_index;
     subrack_info->subrack = *current;
     subrack_info->leave_value = leave_map_get_current_value(leave_map);
-    subrack_info->wmp_entry_is_set = false;
     wmp_move_gen->count_by_size[count]++;
     return;
   }
@@ -362,9 +365,11 @@ wmp_move_gen_check_nonplaythroughs_of_size(WMPMoveGen *wmp_move_gen, int size,
     if (!wmp_entries_precomputed) {
       subrack_info->wmp_entry =
           wmp_get_word_entry(wmp_move_gen->wmp, &subrack_info->subrack, size);
-      subrack_info->wmp_entry_is_set = true;
     } else {
-      assert(subrack_info->wmp_entry_is_set);
+      // Only the RIT-backed path leaves entries unresolved, and a rack's path
+      // is fixed by whether it has a RIT entry, so a precomputed entry
+      // reaching the eager walk must already be resolved.
+      assert(subrack_info->wmp_entry != WMP_ENTRY_UNRESOLVED);
     }
     if (subrack_info->wmp_entry == NULL) {
       continue;
@@ -445,6 +450,26 @@ static inline void wmp_move_gen_check_nonplaythrough_existence_with_rit(
           check_leaves ? EQUITY_MIN_VALUE : 0;
     } else {
       wmp_move_gen->nonplaythrough_best_leave_values[leave_size] = rit_best;
+    }
+  }
+
+  // Freshly enumerated subracks carry stale wmp_entry pointers from whatever
+  // rack was generated before. Mark the ones record time can reach as
+  // unresolved; wmp_move_gen_get_subrack_words resolves them on demand. Sizes
+  // with no word are never read, so their pointers are left alone. On a cache
+  // hit the restored pointers already carry each slot's state.
+  if (!subracks_precomputed) {
+    for (int size = MINIMUM_WORD_LENGTH; size <= wmp_move_gen->full_rack_size;
+         size++) {
+      if (!wmp_move_gen->nonplaythrough_has_word_of_length[size]) {
+        continue;
+      }
+      const int offset = subracks_get_combination_offset(size);
+      const int count = wmp_move_gen->count_by_size[size];
+      for (int idx = 0; idx < count; idx++) {
+        wmp_move_gen->nonplaythrough_infos[offset + idx].wmp_entry =
+            WMP_ENTRY_UNRESOLVED;
+      }
     }
   }
 }
@@ -658,14 +683,12 @@ wmp_move_gen_get_subrack_words(WMPMoveGen *wmp_move_gen, int idx_for_size) {
   if (is_playthrough) {
     subrack_info->wmp_entry = wmp_get_word_entry(
         wmp_move_gen->wmp, &subrack_info->subrack, wmp_move_gen->word_length);
-  } else if (!subrack_info->wmp_entry_is_set) {
+  } else if (subrack_info->wmp_entry == WMP_ENTRY_UNRESOLVED) {
     subrack_info->wmp_entry = wmp_get_word_entry(
         wmp_move_gen->wmp, &subrack_info->subrack, wmp_move_gen->word_length);
-    subrack_info->wmp_entry_is_set = true;
     if (wmp_move_gen->nonplaythrough_wmp_entry_cache != NULL) {
       wmp_move_gen->nonplaythrough_wmp_entry_cache[subrack_idx] =
           subrack_info->wmp_entry;
-      wmp_move_gen->nonplaythrough_wmp_entry_cache_set[subrack_idx] = true;
     }
   }
 

--- a/src/impl/wmp_move_gen.h
+++ b/src/impl/wmp_move_gen.h
@@ -27,6 +27,7 @@ typedef struct SubrackInfo {
   BitRack subrack;
   const WMPEntry *wmp_entry;
   Equity leave_value;
+  bool wmp_entry_is_set;
 } SubrackInfo;
 
 // NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
@@ -77,6 +78,11 @@ typedef struct WMPMoveGen {
   // be one of these letters, so move generation can skip the whole anchor when
   // the rack cannot supply enough of them. All-ones when no table is loaded.
   uint32_t playthrough_addable;
+  // When the caller has an active per-rack cache, lazily resolved
+  // nonplaythrough WMP entries are written through to it for the next
+  // occurrence of the rack.
+  const WMPEntry **nonplaythrough_wmp_entry_cache;
+  bool *nonplaythrough_wmp_entry_cache_set;
 } WMPMoveGen;
 
 static inline void wmp_move_gen_reset_anchors(WMPMoveGen *wmp_move_gen) {
@@ -95,6 +101,8 @@ static inline void wmp_move_gen_init(WMPMoveGen *wmp_move_gen,
                                      const LetterDistribution *ld,
                                      const Rack *player_rack, const WMP *wmp) {
   wmp_move_gen->wmp = wmp;
+  wmp_move_gen->nonplaythrough_wmp_entry_cache = NULL;
+  wmp_move_gen->nonplaythrough_wmp_entry_cache_set = NULL;
   if (wmp == NULL || player_rack == NULL || ld == NULL) {
     return;
   }
@@ -151,6 +159,7 @@ static inline void wmp_move_gen_enumerate_compact_nonplaythrough_subracks(
         wmp_move_gen->nonplaythrough_infos + insert_index;
     subrack_info->subrack = *current;
     subrack_info->leave_value = leave_map_get_current_value(leave_map);
+    subrack_info->wmp_entry_is_set = false;
     wmp_move_gen->count_by_size[count]++;
     return;
   }
@@ -353,6 +362,9 @@ wmp_move_gen_check_nonplaythroughs_of_size(WMPMoveGen *wmp_move_gen, int size,
     if (!wmp_entries_precomputed) {
       subrack_info->wmp_entry =
           wmp_get_word_entry(wmp_move_gen->wmp, &subrack_info->subrack, size);
+      subrack_info->wmp_entry_is_set = true;
+    } else {
+      assert(subrack_info->wmp_entry_is_set);
     }
     if (subrack_info->wmp_entry == NULL) {
       continue;
@@ -391,14 +403,10 @@ static inline void wmp_move_gen_check_nonplaythrough_existence(
   }
 }
 
-// RIT-backed variant of wmp_move_gen_check_nonplaythrough_existence. Skips
-// the per-size wmp_get_word_entry loop for any size where the RIT entry
-// says there is no canonical size-k subrack that forms a valid k-letter
-// word. For sizes that do have words, still runs the existing walk to
-// populate subrack_info->wmp_entry pointers needed at record time. Also
-// seeds nonplaythrough_best_leave_values from the RIT entry directly so
-// that even for the walked sizes we avoid the running-max update inside
-// the inner loop.
+// RIT-backed variant of wmp_move_gen_check_nonplaythrough_existence. The RIT
+// supplies both the per-size existence result and best leave, so no WMP hash
+// walk is needed here. Nonplaythrough WMP entries are resolved lazily if
+// record-time generation actually reaches their subrack.
 //
 // Precondition: rit_entry is non-NULL and corresponds to this move_gen's
 // full player_rack.
@@ -407,8 +415,7 @@ static inline void wmp_move_gen_check_nonplaythrough_existence(
 // cache), so we skip the enumerate_nonplaythrough_subracks step.
 static inline void wmp_move_gen_check_nonplaythrough_existence_with_rit(
     WMPMoveGen *wmp_move_gen, bool check_leaves, LeaveMap *leave_map,
-    const RackInfoTableEntry *rit_entry, bool subracks_precomputed,
-    bool wmp_entries_precomputed) {
+    const RackInfoTableEntry *rit_entry, bool subracks_precomputed) {
   leave_map_set_current_index(leave_map,
                               (1 << wmp_move_gen->full_rack_size) - 1);
   if (!subracks_precomputed) {
@@ -439,36 +446,6 @@ static inline void wmp_move_gen_check_nonplaythrough_existence_with_rit(
     } else {
       wmp_move_gen->nonplaythrough_best_leave_values[leave_size] = rit_best;
     }
-  }
-
-  // For sizes that have at least one valid nonplaythrough word we still
-  // need to populate subrack_info->wmp_entry pointers for the eventual
-  // record-time wmp_entry_write_words_to_buffer call. But we can skip the
-  // walk entirely for sizes where no canonical subrack makes a word -- the
-  // wmp_entry cache for those sizes is never read because shadow_record
-  // early-returns on wmp_move_gen_nonplaythrough_word_of_length_exists
-  // before getting to the record stage.
-  for (int size = MINIMUM_WORD_LENGTH; size <= wmp_move_gen->full_rack_size;
-       size++) {
-    if (!wmp_move_gen->nonplaythrough_has_word_of_length[size]) {
-      continue;
-    }
-    const int leave_size = wmp_move_gen->full_rack_size - size;
-    // The existing wmp_move_gen_check_nonplaythroughs_of_size writes to
-    // nonplaythrough_best_leave_values[leave_size] and runs a max update
-    // across subracks. We already seeded the final value from the RIT, so
-    // stash it and restore after the walk (the walk only keeps a running
-    // max vs EQUITY_MIN_VALUE, which matches the RIT-seeded max).
-    const Equity seeded_best =
-        wmp_move_gen->nonplaythrough_best_leave_values[leave_size];
-    wmp_move_gen_check_nonplaythroughs_of_size(wmp_move_gen, size, check_leaves,
-                                               wmp_entries_precomputed);
-    // Assert the walk's max matches what RIT already stored. Cheap sanity
-    // check that catches maker/consumer drift.
-    assert(!check_leaves ||
-           wmp_move_gen->nonplaythrough_best_leave_values[leave_size] ==
-               seeded_best);
-    (void)seeded_best;
   }
 }
 
@@ -678,11 +655,18 @@ wmp_move_gen_get_subrack_words(WMPMoveGen *wmp_move_gen, int idx_for_size) {
   SubrackInfo *subrack_info =
       is_playthrough ? &wmp_move_gen->playthrough_infos[subrack_idx]
                      : &wmp_move_gen->nonplaythrough_infos[subrack_idx];
-  // Nonplaythrough subracks' wmp entries were already looked up during
-  // shadow.
   if (is_playthrough) {
     subrack_info->wmp_entry = wmp_get_word_entry(
         wmp_move_gen->wmp, &subrack_info->subrack, wmp_move_gen->word_length);
+  } else if (!subrack_info->wmp_entry_is_set) {
+    subrack_info->wmp_entry = wmp_get_word_entry(
+        wmp_move_gen->wmp, &subrack_info->subrack, wmp_move_gen->word_length);
+    subrack_info->wmp_entry_is_set = true;
+    if (wmp_move_gen->nonplaythrough_wmp_entry_cache != NULL) {
+      wmp_move_gen->nonplaythrough_wmp_entry_cache[subrack_idx] =
+          subrack_info->wmp_entry;
+      wmp_move_gen->nonplaythrough_wmp_entry_cache_set[subrack_idx] = true;
+    }
   }
 
   if (subrack_info->wmp_entry == NULL) {

--- a/src/impl/wmp_move_gen.h
+++ b/src/impl/wmp_move_gen.h
@@ -671,7 +671,8 @@ wmp_move_gen_get_nonplaythrough_subrack(const WMPMoveGen *wmp_move_gen,
 // anywhere in that translation unit flips the cost model and turns the loop
 // into a call per subrack (measured: about -5% sim throughput). Pin it.
 static inline __attribute__((always_inline)) bool
-wmp_move_gen_get_subrack_words(WMPMoveGen *wmp_move_gen, int idx_for_size) {
+wmp_move_gen_get_subrack_words(WMPMoveGen *wmp_move_gen, int idx_for_size,
+                               bool lazy) {
   const int offset =
       subracks_get_combination_offset(wmp_move_gen->tiles_to_play);
   const int subrack_idx = offset + idx_for_size;
@@ -683,7 +684,7 @@ wmp_move_gen_get_subrack_words(WMPMoveGen *wmp_move_gen, int idx_for_size) {
   if (is_playthrough) {
     subrack_info->wmp_entry = wmp_get_word_entry(
         wmp_move_gen->wmp, &subrack_info->subrack, wmp_move_gen->word_length);
-  } else if (subrack_info->wmp_entry == WMP_ENTRY_UNRESOLVED) {
+  } else if (lazy && subrack_info->wmp_entry == WMP_ENTRY_UNRESOLVED) {
     subrack_info->wmp_entry = wmp_get_word_entry(
         wmp_move_gen->wmp, &subrack_info->subrack, wmp_move_gen->word_length);
     if (wmp_move_gen->nonplaythrough_wmp_entry_cache != NULL) {

--- a/test/autoplay_test.c
+++ b/test/autoplay_test.c
@@ -448,6 +448,7 @@ void test_autoplay_rit_correctness(void) {
   // produce identical move lists. Runs here because this shard is where the
   // TWL98 RIT exists, and it must run before the cleanup below removes it.
   test_rit_movegen_equality();
+  test_rit_toggle_subrack_cache();
 
   // Build a RIT for TWL98 using the release binary (fast), then run
   // game pairs under ASAN where player 1 uses RIT and player 2 does not.

--- a/test/autoplay_test.c
+++ b/test/autoplay_test.c
@@ -10,6 +10,7 @@
 #include "../src/util/string_util.h"
 #include "test_constants.h"
 #include "test_util.h"
+#include "wmp_move_gen_test.h"
 #include <assert.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -443,6 +444,11 @@ void test_autoplay_wmp_correctness(void) {
 }
 
 void test_autoplay_rit_correctness(void) {
+  // Fast, exact check first: the RIT-backed and plain move generators must
+  // produce identical move lists. Runs here because this shard is where the
+  // TWL98 RIT exists, and it must run before the cleanup below removes it.
+  test_rit_movegen_equality();
+
   // Build a RIT for TWL98 using the release binary (fast), then run
   // game pairs under ASAN where player 1 uses RIT and player 2 does not.
   // Any divergence means the RIT changed move selection.

--- a/test/test_util.h
+++ b/test/test_util.h
@@ -31,6 +31,7 @@ uint64_t string_to_cross_set(const LetterDistribution *ld, const char *letters);
 char *cross_set_to_string(const LetterDistribution *ld, uint64_t input);
 void play_top_n_equity_move(Game *game, int n);
 SortedMoveList *sorted_move_list_create(MoveList *ml);
+void assert_moves_are_equal(const Move *m1, const Move *m2);
 void sorted_move_list_destroy(SortedMoveList *sorted_move_list);
 void print_move_list(const Board *board, const LetterDistribution *ld,
                      const SortedMoveList *sml, int move_list_length);

--- a/test/wmp_move_gen_test.c
+++ b/test/wmp_move_gen_test.c
@@ -1,8 +1,10 @@
 #include "wmp_move_gen_test.h"
 
 #include "../src/def/board_defs.h"
+#include "../src/def/equity_defs.h"
 #include "../src/def/kwg_defs.h"
 #include "../src/def/letter_distribution_defs.h"
+#include "../src/def/move_defs.h"
 #include "../src/def/rack_defs.h"
 #include "../src/ent/anchor.h"
 #include "../src/ent/bit_rack.h"
@@ -11,14 +13,18 @@
 #include "../src/ent/game.h"
 #include "../src/ent/leave_map.h"
 #include "../src/ent/letter_distribution.h"
+#include "../src/ent/move.h"
 #include "../src/ent/player.h"
 #include "../src/ent/rack.h"
 #include "../src/ent/wmp.h"
 #include "../src/impl/config.h"
+#include "../src/impl/gameplay.h"
+#include "../src/impl/move_gen.h"
 #include "../src/impl/wmp_move_gen.h"
 #include "test_util.h"
 #include <assert.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 
 void test_wmp_move_gen_inactive(void) {
@@ -374,4 +380,92 @@ void test_wmp_move_gen(void) {
   test_wit_prune_skips_block_longer_than_anchor_word();
   test_nonplaythrough_existence();
   test_playthrough_bingo_existence();
+}
+
+// The RIT-backed path resolves nonplaythrough WMP entries lazily at record
+// time; the non-RIT path resolves them eagerly during shadow. Move generation
+// must not be able to tell the difference. Two games are driven in lockstep
+// from identical seeds, one with a RIT and one without, and at every
+// position the complete sorted move lists must match move for move.
+//
+// Needs <lexicon>.rit on the data path. The ap_rit CI shard builds it for
+// TWL98 before running this; test_autoplay_rit_correctness removes it after.
+static void generate_all_sorted(Game *game, MoveList *move_list,
+                                SortedMoveList **sorted_out) {
+  const MoveGenArgs args = {
+      .game = game,
+      .move_list = move_list,
+      .eq_margin_movegen = 0,
+      .target_equity = EQUITY_MAX_VALUE,
+      .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+  };
+  generate_moves_for_game(&args);
+  *sorted_out = sorted_move_list_create(move_list);
+}
+
+void test_rit_movegen_equality(void) {
+  const char *settings = "-wmp true -s1 equity -s2 equity -r1 all -r2 all "
+                         "-numplays 100000 -threads 1";
+  char cmd[256];
+  (void)snprintf(cmd, sizeof(cmd), "set -lex TWL98 -rit true %s", settings);
+  Config *rit_config = config_create_or_die(cmd);
+  (void)snprintf(cmd, sizeof(cmd), "set -lex TWL98 -rit false %s", settings);
+  Config *plain_config = config_create_or_die(cmd);
+  Game *rit_game = config_game_create(rit_config);
+  Game *plain_game = config_game_create(plain_config);
+  // The test is only meaningful if the RIT actually loaded on one side and
+  // not the other; assert it so a missing file cannot pass vacuously.
+  assert(player_get_rack_info_table(game_get_player(rit_game, 0)) != NULL);
+  assert(player_get_rack_info_table(game_get_player(plain_game, 0)) == NULL);
+
+  MoveList *rit_list = move_list_create(100000);
+  MoveList *plain_list = move_list_create(100000);
+  int positions = 0;
+  long moves = 0;
+  for (uint64_t seed = 1; seed <= 6; seed++) {
+    game_reset(rit_game);
+    game_reset(plain_game);
+    game_seed(rit_game, seed);
+    game_seed(plain_game, seed);
+    draw_starting_racks(rit_game);
+    draw_starting_racks(plain_game);
+    for (int player_idx = 0; player_idx < 2; player_idx++) {
+      assert(racks_are_equal(
+          player_get_rack(game_get_player(rit_game, player_idx)),
+          player_get_rack(game_get_player(plain_game, player_idx))));
+    }
+    int turn = 0;
+    while (!game_over(plain_game)) {
+      SortedMoveList *rit_sorted = NULL;
+      SortedMoveList *plain_sorted = NULL;
+      generate_all_sorted(rit_game, rit_list, &rit_sorted);
+      generate_all_sorted(plain_game, plain_list, &plain_sorted);
+      assert(rit_sorted->count == plain_sorted->count);
+      assert(plain_sorted->count > 0);
+      for (int move_idx = 0; move_idx < plain_sorted->count; move_idx++) {
+        assert_moves_are_equal(rit_sorted->moves[move_idx],
+                               plain_sorted->moves[move_idx]);
+      }
+      moves += plain_sorted->count;
+      positions++;
+      // Same (asserted-equal) move on both sides keeps the games in lockstep.
+      play_move(rit_sorted->moves[0], rit_game, NULL);
+      play_move(plain_sorted->moves[0], plain_game, NULL);
+      sorted_move_list_destroy(rit_sorted);
+      sorted_move_list_destroy(plain_sorted);
+      turn++;
+      assert(turn < 200);
+    }
+    assert(game_over(rit_game));
+  }
+  assert(positions > 0);
+  printf("RIT movegen equality: %d positions, %ld moves identical\n", positions,
+         moves);
+
+  move_list_destroy(rit_list);
+  move_list_destroy(plain_list);
+  game_destroy(rit_game);
+  game_destroy(plain_game);
+  config_destroy(rit_config);
+  config_destroy(plain_config);
 }

--- a/test/wmp_move_gen_test.c
+++ b/test/wmp_move_gen_test.c
@@ -390,6 +390,22 @@ void test_wmp_move_gen(void) {
 //
 // Needs <lexicon>.rit on the data path. The ap_rit CI shard builds it for
 // TWL98 before running this; test_autoplay_rit_correctness removes it after.
+// Stops at the first recorded play, as inference-mode generation does when a
+// play beats its target. Most subracks are then never asked for their words,
+// which is what leaves their lazily resolved entries unresolved.
+static void generate_until_first_play(Game *game, MoveList *move_list) {
+  const MoveGenArgs args = {
+      .game = game,
+      .move_list = move_list,
+      .move_record_type = MOVE_RECORD_BEST,
+      .move_sort_type = MOVE_SORT_EQUITY,
+      .eq_margin_movegen = 0,
+      .target_equity = EQUITY_MIN_VALUE,
+      .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+  };
+  generate_moves_for_game(&args);
+}
+
 static void generate_all_sorted(Game *game, MoveList *move_list,
                                 SortedMoveList **sorted_out) {
   const MoveGenArgs args = {
@@ -401,6 +417,87 @@ static void generate_all_sorted(Game *game, MoveList *move_list,
   };
   generate_moves_for_game(&args);
   *sorted_out = sorted_move_list_create(move_list);
+}
+
+// The per-thread subrack cache outlives set commands. A rack generated while
+// the RIT was loaded leaves lazily resolved entries in it that the eager path
+// must never see; switching the RIT invalidates the cache, and this keeps it
+// that way: generating the same rack across `set -rit false` and back must
+// match a generator that never had a RIT, from a config whose WMP object --
+// the cache's other key -- does not change across the switch.
+void test_rit_toggle_subrack_cache(void) {
+  const char *settings = "-wmp true -s1 equity -s2 equity -r1 all -r2 all "
+                         "-numplays 100000 -threads 1";
+  char cmd[256];
+  (void)snprintf(cmd, sizeof(cmd), "set -lex TWL98 -rit true %s", settings);
+  Config *config = config_create_or_die(cmd);
+  (void)snprintf(cmd, sizeof(cmd), "set -lex TWL98 -rit false %s", settings);
+  Config *plain_config = config_create_or_die(cmd);
+  static const char *const cgps[] = {
+      "15/15/15/15/15/15/15/15/15/15/15/15/15/15/15 AEINRST/ 0/0 0",
+      "15/15/15/15/15/15/15/6CAT6/15/15/15/15/15/15/15 AEINRST/ 0/0 0",
+      "15/15/15/15/15/15/15/6CAT6/15/15/15/15/15/15/15 ?DEIRTU/ 0/0 0",
+  };
+  // Use each config's own game: `set -rit ...` updates that game's players,
+  // and the config only creates it once a command needs one.
+  char cgp_cmd[256];
+  (void)snprintf(cgp_cmd, sizeof(cgp_cmd), "cgp %s", cgps[0]);
+  load_and_exec_config_or_die(config, cgp_cmd);
+  load_and_exec_config_or_die(plain_config, cgp_cmd);
+  Game *game = config_get_game(config);
+  Game *plain_game = config_get_game(plain_config);
+  assert(game != NULL && plain_game != NULL);
+  assert(player_get_rack_info_table(game_get_player(game, 0)) != NULL);
+  assert(player_get_rack_info_table(game_get_player(plain_game, 0)) == NULL);
+  MoveList *list = move_list_create(100000);
+  MoveList *plain_list = move_list_create(100000);
+  for (size_t cgp_idx = 0; cgp_idx < sizeof(cgps) / sizeof(cgps[0]);
+       cgp_idx++) {
+    (void)snprintf(cgp_cmd, sizeof(cgp_cmd), "cgp %s", cgps[cgp_idx]);
+    load_and_exec_config_or_die(config, cgp_cmd);
+    load_and_exec_config_or_die(plain_config, cgp_cmd);
+    game = config_get_game(config);
+    plain_game = config_get_game(plain_config);
+    SortedMoveList *sorted = NULL;
+    SortedMoveList *plain_sorted = NULL;
+    // RIT on, stopping at the first recorded play: most subracks never reach
+    // record time, so their cached entries stay unresolved -- the state the
+    // switch must not carry over.
+    generate_until_first_play(game, list);
+    // RIT off, same config and WMP, recording everything. A set command
+    // updates players_data only; the next game command refreshes the game's
+    // players from it, so reload the position before reading the game.
+    load_and_exec_config_or_die(config, "set -rit false");
+    load_and_exec_config_or_die(config, cgp_cmd);
+    game = config_get_game(config);
+    assert(player_get_rack_info_table(game_get_player(game, 0)) == NULL);
+    generate_all_sorted(game, list, &sorted);
+    generate_all_sorted(plain_game, plain_list, &plain_sorted);
+    assert(sorted->count == plain_sorted->count);
+    assert(plain_sorted->count > 0);
+    for (int move_idx = 0; move_idx < plain_sorted->count; move_idx++) {
+      assert_moves_are_equal(sorted->moves[move_idx],
+                             plain_sorted->moves[move_idx]);
+    }
+    sorted_move_list_destroy(sorted);
+    // And back on: resolved entries in a lazily resolving generation.
+    load_and_exec_config_or_die(config, "set -rit true");
+    load_and_exec_config_or_die(config, cgp_cmd);
+    game = config_get_game(config);
+    assert(player_get_rack_info_table(game_get_player(game, 0)) != NULL);
+    generate_all_sorted(game, list, &sorted);
+    assert(sorted->count == plain_sorted->count);
+    for (int move_idx = 0; move_idx < plain_sorted->count; move_idx++) {
+      assert_moves_are_equal(sorted->moves[move_idx],
+                             plain_sorted->moves[move_idx]);
+    }
+    sorted_move_list_destroy(sorted);
+    sorted_move_list_destroy(plain_sorted);
+  }
+  move_list_destroy(list);
+  move_list_destroy(plain_list);
+  config_destroy(plain_config);
+  config_destroy(config);
 }
 
 void test_rit_movegen_equality(void) {

--- a/test/wmp_move_gen_test.h
+++ b/test/wmp_move_gen_test.h
@@ -2,5 +2,6 @@
 #define WMP_MOVE_GEN_TEST_H
 
 void test_wmp_move_gen(void);
+void test_rit_movegen_equality(void);
 
 #endif

--- a/test/wmp_move_gen_test.h
+++ b/test/wmp_move_gen_test.h
@@ -3,5 +3,6 @@
 
 void test_wmp_move_gen(void);
 void test_rit_movegen_equality(void);
+void test_rit_toggle_subrack_cache(void);
 
 #endif


### PR DESCRIPTION
## What this does

With a RackInfoTable loaded, the generator already knows, for the rack on turn, whether a word of each length exists and the best leave for each leave size. It nevertheless looked up the WMP entry of **every** canonical subrack up front, before shadow had run, purely to have the pointer ready in case record time wanted that subrack's words — and shadow prunes most candidates before record time ever asks.

**Lazy resolution.** When the RIT is loaded, a subrack's WMP entry is looked up the first time record time actually needs its words, and the result — entry or miss — is kept in the per-rack cache for the next occurrence of the rack. An entry never needed holds a sentinel pointer (`WMP_ENTRY_UNRESOLVED`), only ever compared, never dereferenced. Under simulation the eager walk was 35% of all WMP hash lookups and deferral removes 88% of those; over an export that records every move it saves almost nothing, because record time then reaches nearly every subrack — the saving is entirely a product of pruning.

**Conditional inlining.** Without a RIT, nothing needs resolving, but a sentinel test in the record loop would still cost. So `lazy` is a compile-time constant: `gen_record_scoring_plays` decides once per generation, on `gen->rit_entry`, between two instantiations of the same `always_inline` anchor loop — an eager copy where the test folds away, and the lazy copy for RIT-backed racks. Neither path pays a per-anchor call or a per-subrack test; one binary serves both.

```c
static inline __attribute__((always_inline)) void gen_record_scoring_plays(MoveGen *gen) {
  if (gen->rit_entry == NULL) {
    gen_record_scoring_plays_eager(gen);       // noinline: _impl(gen, /*lazy=*/false)
  } else {
    gen_record_scoring_plays_impl(gen, true);  // inlined
  }
}
```

The eager path asserts it never meets a sentinel, which holds because the per-thread subrack cache is invalidated whenever the RIT changes (`move_gen.c:3014`).

## Performance

Against today's `main` (post #610/#616, WIT on): M4 Mac mini, 8 workers, `no_pgo_release`, `simbench` 0.5 s/turn, seeds 42/24301/1552 × 6 interleaved rounds, paired within-round geometric means, stratified-bootstrap 95% CIs, 18 pairs per row.

| configuration | this PR vs main |
|---|---:|
| **RIT on** (the production configuration) | **≈ +4.0%** — lazy resolution +3.53% [+3.42, +3.62], and the per-generation specialization a further +0.51% [+0.30, +0.74] over that |
| RIT off | **+0.69%** [+0.46, +0.93] |

Both specialization numbers were first measured in a separate session (+0.41% and +0.54%) and replicated here with an independent harness; every seed positive in both. Lazy resolution alone had cost −0.24% with the RIT off; that is gone. The gain is larger than the ~+1.1% first measured on a pre-WIT `main` because the WIT prunes leave even fewer subracks for record time to resolve.

## Correctness

- Move-for-move differential against `main`, RIT on and off: 32 seeded CSW24 games, 712 positions, 967,104 moves per export, all four sorted exports identical.
- `test_rit_movegen_equality` (`ap_rit` shard, TWL98): a RIT game and a plain game in lockstep, complete sorted move lists compared at every position — 134 positions, ~130k moves. With lazy resolution deliberately broken the RIT-on export collapses to a third of its moves and this test fails on the first position; it asserts the RIT actually loaded, so it cannot pass vacuously.
- `test_rit_toggle_subrack_cache` (`ap_rit`): the same rack generated across `set -rit false` and back in one config, compared against a plain generator, with the RIT-backed generation stopped at its first play so that unresolved entries are what would carry over — pins the cache invalidation the eager path's assert relies on.
- Both under ASan/UBSan on the final layout; `witdiff` (32 games, 723 positions) identical; cppcheck, circular-dependency check and `format.py` clean.

## What can build on this

**The conditional-inlining pattern is reusable.** An `always_inline` body taking a `bool` that every call site passes as a constant, instantiated once per mode by a single dispatch at the top of a generation, gives mode-specialized code with no runtime test in the hot loop and no code duplication in the source. Other per-generation switches that are currently tested per anchor or per move and could be specialized the same way, none yet measured:

- **WIT on/off** — `gen->word_info_table != NULL` is tested in `wordmap_gen` and in the shadow early-stop for every anchor.
- **Sort and record type** — `get_wmp_equity_without_move` and the record path switch on `move_sort_type`/`move_record_type` per candidate move; #612's pre-check would fold to a constant.
- **Wordsmog and the small-move record types** — already dispatched per anchor by branches on `gen->is_wordsmog` and `move_record_type`.

Pending PRs on the same path:

- **#612** — skip materializing a WMP move whose equity already loses; +0.45% replicated, no measured cost. Independent of this PR and the most direct candidate for the specialization above.
- **#618–#623** — WMP shadow-side drafts stacked on the now-merged `wit-subrack-pruning`; each needs a `rebase --onto main` as this PR got. #618 itself measured at the noise floor.

Measured and not worth pursuing: memoizing `game_store_wit_block` would save only ~22% of its lookups (~0.1 pp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEZJov4z3ZkZpTsTrLQMd1
