### PR TITLE
Avoid repeated alphabet scans during subrack enumeration

### DIFF
--- a/src/impl/wmp_move_gen.h
+++ b/src/impl/wmp_move_gen.h
@@ -178,8 +178,8 @@ static inline void wmp_move_gen_enumerate_compact_nonplaythrough_subracks(
 static inline void
 wmp_move_gen_enumerate_nonplaythrough_subracks(WMPMoveGen *wmp_move_gen,
                                                LeaveMap *leave_map) {
-  MachineLetter rack_letters[RACK_SIZE];
-  uint8_t rack_letter_counts[RACK_SIZE];
+  MachineLetter rack_letters[RACK_SIZE] = {0};
+  uint8_t rack_letter_counts[RACK_SIZE] = {0};
   int num_rack_letters = 0;
   for (int ml = BLANK_MACHINE_LETTER; ml < BIT_RACK_MAX_ALPHABET_SIZE; ml++) {
     const int count = bit_rack_get_letter(&wmp_move_gen->player_bit_rack, ml);

--- a/src/impl/wmp_move_gen.h
+++ b/src/impl/wmp_move_gen.h
@@ -138,18 +138,14 @@ static inline uint8_t subracks_get_combination_offset(int size) {
   return subracks_combination_offsets[size];
 }
 
-static inline void
-wmp_move_gen_enumerate_nonplaythrough_subracks(WMPMoveGen *wmp_move_gen,
-                                               BitRack *current, int next_ml,
-                                               int count, LeaveMap *leave_map) {
-  int max_num_this = 0;
-  for (; next_ml < BIT_RACK_MAX_ALPHABET_SIZE; next_ml++) {
-    max_num_this = bit_rack_get_letter(&wmp_move_gen->player_bit_rack, next_ml);
-    if (max_num_this > 0) {
-      break;
-    }
-  }
-  if (next_ml >= BIT_RACK_MAX_ALPHABET_SIZE) {
+// Walk only the occupied rack letters. Rescanning every BitRack alphabet lane
+// at each recursion level is expensive when a rack contains at most seven
+// tiles.
+static inline void wmp_move_gen_enumerate_compact_nonplaythrough_subracks(
+    WMPMoveGen *wmp_move_gen, BitRack *current,
+    const MachineLetter *rack_letters, const uint8_t *rack_letter_counts,
+    int num_rack_letters, int rack_letter_idx, int count, LeaveMap *leave_map) {
+  if (rack_letter_idx >= num_rack_letters) {
     const int insert_index = subracks_get_combination_offset(count) +
                              wmp_move_gen->count_by_size[count];
     SubrackInfo *subrack_info =
@@ -160,18 +156,43 @@ wmp_move_gen_enumerate_nonplaythrough_subracks(WMPMoveGen *wmp_move_gen,
     wmp_move_gen->count_by_size[count]++;
     return;
   }
+
+  const MachineLetter ml = rack_letters[rack_letter_idx];
+  const int max_num_this = rack_letter_counts[rack_letter_idx];
   for (int i = 0; i < max_num_this; i++) {
-    wmp_move_gen_enumerate_nonplaythrough_subracks(
-        wmp_move_gen, current, next_ml + 1, count + i, leave_map);
-    bit_rack_add_letter(current, next_ml);
-    leave_map_complement_add_letter(leave_map, next_ml, i);
+    wmp_move_gen_enumerate_compact_nonplaythrough_subracks(
+        wmp_move_gen, current, rack_letters, rack_letter_counts,
+        num_rack_letters, rack_letter_idx + 1, count + i, leave_map);
+    bit_rack_add_letter(current, ml);
+    leave_map_complement_add_letter(leave_map, ml, i);
   }
-  wmp_move_gen_enumerate_nonplaythrough_subracks(
-      wmp_move_gen, current, next_ml + 1, count + max_num_this, leave_map);
+  wmp_move_gen_enumerate_compact_nonplaythrough_subracks(
+      wmp_move_gen, current, rack_letters, rack_letter_counts, num_rack_letters,
+      rack_letter_idx + 1, count + max_num_this, leave_map);
   for (int i = max_num_this - 1; i >= 0; i--) {
-    bit_rack_take_letter(current, next_ml);
-    leave_map_complement_take_letter(leave_map, next_ml, i);
+    bit_rack_take_letter(current, ml);
+    leave_map_complement_take_letter(leave_map, ml, i);
   }
+}
+
+static inline void
+wmp_move_gen_enumerate_nonplaythrough_subracks(WMPMoveGen *wmp_move_gen,
+                                               LeaveMap *leave_map) {
+  MachineLetter rack_letters[RACK_SIZE];
+  uint8_t rack_letter_counts[RACK_SIZE];
+  int num_rack_letters = 0;
+  for (int ml = BLANK_MACHINE_LETTER; ml < BIT_RACK_MAX_ALPHABET_SIZE; ml++) {
+    const int count = bit_rack_get_letter(&wmp_move_gen->player_bit_rack, ml);
+    if (count > 0) {
+      rack_letters[num_rack_letters] = (MachineLetter)ml;
+      rack_letter_counts[num_rack_letters] = (uint8_t)count;
+      num_rack_letters++;
+    }
+  }
+  BitRack empty = bit_rack_create_empty();
+  wmp_move_gen_enumerate_compact_nonplaythrough_subracks(
+      wmp_move_gen, &empty, rack_letters, rack_letter_counts, num_rack_letters,
+      0, 0, leave_map);
 }
 
 static inline void
@@ -365,9 +386,7 @@ static inline void wmp_move_gen_check_nonplaythrough_existence(
                               (1 << wmp_move_gen->full_rack_size) - 1);
   if (!subracks_precomputed) {
     memset(wmp_move_gen->count_by_size, 0, sizeof(wmp_move_gen->count_by_size));
-    BitRack empty = bit_rack_create_empty();
-    wmp_move_gen_enumerate_nonplaythrough_subracks(
-        wmp_move_gen, &empty, BLANK_MACHINE_LETTER, 0, leave_map);
+    wmp_move_gen_enumerate_nonplaythrough_subracks(wmp_move_gen, leave_map);
   }
   for (int size = MINIMUM_WORD_LENGTH; size <= wmp_move_gen->full_rack_size;
        size++) {
@@ -393,9 +412,7 @@ static inline void wmp_move_gen_check_nonplaythrough_existence_with_rit(
                               (1 << wmp_move_gen->full_rack_size) - 1);
   if (!subracks_precomputed) {
     memset(wmp_move_gen->count_by_size, 0, sizeof(wmp_move_gen->count_by_size));
-    BitRack empty = bit_rack_create_empty();
-    wmp_move_gen_enumerate_nonplaythrough_subracks(
-        wmp_move_gen, &empty, BLANK_MACHINE_LETTER, 0, leave_map);
+    wmp_move_gen_enumerate_nonplaythrough_subracks(wmp_move_gen, leave_map);
   }
 
   // Seed has_word_of_length and best_leave_values from the RIT entry. The

--- a/src/impl/wmp_move_gen.h
+++ b/src/impl/wmp_move_gen.h
@@ -93,6 +93,13 @@ static inline void wmp_move_gen_init(WMPMoveGen *wmp_move_gen,
   }
   wmp_move_gen->player_bit_rack = bit_rack_create_from_rack(ld, player_rack);
   wmp_move_gen->full_rack_size = rack_get_total_letters(player_rack);
+  // This whole module is sized off RACK_SIZE: count_by_size,
+  // nonplaythrough_has_word_of_length, nonplaythrough_best_leave_values and
+  // subracks_combination_offsets all have RACK_SIZE + 1 entries, and
+  // nonplaythrough_infos holds 1 << RACK_SIZE. An over-full rack would index
+  // past all of them, so assert the precondition once here rather than
+  // rediscovering it at each use.
+  assert(wmp_move_gen->full_rack_size <= RACK_SIZE);
   memset(wmp_move_gen->nonplaythrough_has_word_of_length, false,
          sizeof(wmp_move_gen->nonplaythrough_has_word_of_length));
   // One-time full anchor slot initialization. wmp_move_gen_reset_anchors()

--- a/src/impl/wmp_move_gen.h
+++ b/src/impl/wmp_move_gen.h
@@ -123,18 +123,14 @@ static inline uint8_t subracks_get_combination_offset(int size) {
   return subracks_combination_offsets[size];
 }
 
-static inline void
-wmp_move_gen_enumerate_nonplaythrough_subracks(WMPMoveGen *wmp_move_gen,
-                                               BitRack *current, int next_ml,
-                                               int count, LeaveMap *leave_map) {
-  int max_num_this = 0;
-  for (; next_ml < BIT_RACK_MAX_ALPHABET_SIZE; next_ml++) {
-    max_num_this = bit_rack_get_letter(&wmp_move_gen->player_bit_rack, next_ml);
-    if (max_num_this > 0) {
-      break;
-    }
-  }
-  if (next_ml >= BIT_RACK_MAX_ALPHABET_SIZE) {
+// Walk only the occupied rack letters. Rescanning every BitRack alphabet lane
+// at each recursion level is unnecessary when there are at most RACK_SIZE
+// occupied letters.
+static inline void wmp_move_gen_enumerate_compact_nonplaythrough_subracks(
+    WMPMoveGen *wmp_move_gen, BitRack *current,
+    const MachineLetter *rack_letters, const uint8_t *rack_letter_counts,
+    int num_rack_letters, int rack_letter_idx, int count, LeaveMap *leave_map) {
+  if (rack_letter_idx >= num_rack_letters) {
     const int insert_index = subracks_get_combination_offset(count) +
                              wmp_move_gen->count_by_size[count];
     SubrackInfo *subrack_info =
@@ -144,18 +140,44 @@ wmp_move_gen_enumerate_nonplaythrough_subracks(WMPMoveGen *wmp_move_gen,
     wmp_move_gen->count_by_size[count]++;
     return;
   }
+
+  const MachineLetter ml = rack_letters[rack_letter_idx];
+  const int max_num_this = rack_letter_counts[rack_letter_idx];
   for (int i = 0; i < max_num_this; i++) {
-    wmp_move_gen_enumerate_nonplaythrough_subracks(
-        wmp_move_gen, current, next_ml + 1, count + i, leave_map);
-    bit_rack_add_letter(current, next_ml);
-    leave_map_complement_add_letter(leave_map, next_ml, i);
+    wmp_move_gen_enumerate_compact_nonplaythrough_subracks(
+        wmp_move_gen, current, rack_letters, rack_letter_counts,
+        num_rack_letters, rack_letter_idx + 1, count + i, leave_map);
+    bit_rack_add_letter(current, ml);
+    leave_map_complement_add_letter(leave_map, ml, i);
   }
-  wmp_move_gen_enumerate_nonplaythrough_subracks(
-      wmp_move_gen, current, next_ml + 1, count + max_num_this, leave_map);
+  wmp_move_gen_enumerate_compact_nonplaythrough_subracks(
+      wmp_move_gen, current, rack_letters, rack_letter_counts, num_rack_letters,
+      rack_letter_idx + 1, count + max_num_this, leave_map);
   for (int i = max_num_this - 1; i >= 0; i--) {
-    bit_rack_take_letter(current, next_ml);
-    leave_map_complement_take_letter(leave_map, next_ml, i);
+    bit_rack_take_letter(current, ml);
+    leave_map_complement_take_letter(leave_map, ml, i);
   }
+}
+
+static inline void
+wmp_move_gen_enumerate_nonplaythrough_subracks(WMPMoveGen *wmp_move_gen,
+                                               LeaveMap *leave_map) {
+  MachineLetter rack_letters[RACK_SIZE] = {0};
+  uint8_t rack_letter_counts[RACK_SIZE] = {0};
+  int num_rack_letters = 0;
+  for (int ml = BLANK_MACHINE_LETTER; ml < BIT_RACK_MAX_ALPHABET_SIZE; ml++) {
+    const int count = bit_rack_get_letter(&wmp_move_gen->player_bit_rack, ml);
+    if (count > 0) {
+      assert(num_rack_letters < RACK_SIZE);
+      rack_letters[num_rack_letters] = (MachineLetter)ml;
+      rack_letter_counts[num_rack_letters] = (uint8_t)count;
+      num_rack_letters++;
+    }
+  }
+  BitRack empty = bit_rack_create_empty();
+  wmp_move_gen_enumerate_compact_nonplaythrough_subracks(
+      wmp_move_gen, &empty, rack_letters, rack_letter_counts, num_rack_letters,
+      0, 0, leave_map);
 }
 
 static inline void
@@ -346,9 +368,7 @@ static inline void wmp_move_gen_check_nonplaythrough_existence(
                               (1 << wmp_move_gen->full_rack_size) - 1);
   if (!subracks_precomputed) {
     memset(wmp_move_gen->count_by_size, 0, sizeof(wmp_move_gen->count_by_size));
-    BitRack empty = bit_rack_create_empty();
-    wmp_move_gen_enumerate_nonplaythrough_subracks(
-        wmp_move_gen, &empty, BLANK_MACHINE_LETTER, 0, leave_map);
+    wmp_move_gen_enumerate_nonplaythrough_subracks(wmp_move_gen, leave_map);
   }
   for (int size = MINIMUM_WORD_LENGTH; size <= wmp_move_gen->full_rack_size;
        size++) {
@@ -379,9 +399,7 @@ static inline void wmp_move_gen_check_nonplaythrough_existence_with_rit(
                               (1 << wmp_move_gen->full_rack_size) - 1);
   if (!subracks_precomputed) {
     memset(wmp_move_gen->count_by_size, 0, sizeof(wmp_move_gen->count_by_size));
-    BitRack empty = bit_rack_create_empty();
-    wmp_move_gen_enumerate_nonplaythrough_subracks(
-        wmp_move_gen, &empty, BLANK_MACHINE_LETTER, 0, leave_map);
+    wmp_move_gen_enumerate_nonplaythrough_subracks(wmp_move_gen, leave_map);
   }
 
   // Seed has_word_of_length and best_leave_values from the RIT entry. The

--- a/test/wmp_move_gen_test.c
+++ b/test/wmp_move_gen_test.c
@@ -40,6 +40,133 @@ void set_dummy_leave_values(LeaveMap *leave_map) {
   }
 }
 
+static void assert_nonplaythrough_subrack_enumeration(
+    const LetterDistribution *ld, const WMP *wmp, const char *rack_string,
+    const int expected_counts[RACK_SIZE + 1]) {
+  Rack *rack = rack_create(ld_get_size(ld));
+  const int rack_size = rack_set_to_string(ld, rack, rack_string);
+  assert(rack_size <= RACK_SIZE);
+
+  WMPMoveGen wmg;
+  wmp_move_gen_init(&wmg, ld, rack, wmp);
+  for (int size = 0; size <= RACK_SIZE; size++) {
+    wmg.count_by_size[size] = 0;
+  }
+
+  LeaveMap leave_map;
+  leave_map_init(rack, &leave_map);
+  const int full_rack_index = (1 << rack_size) - 1;
+  for (int leave_idx = 0; leave_idx <= full_rack_index; leave_idx++) {
+    leave_map_set_current_index(&leave_map, leave_idx);
+    leave_map_set_current_value(&leave_map, int_to_equity(leave_idx));
+  }
+  leave_map_set_current_index(&leave_map, full_rack_index);
+
+  wmp_move_gen_enumerate_nonplaythrough_subracks(&wmg, &leave_map);
+  assert(leave_map_get_current_index(&leave_map) == full_rack_index);
+
+  MachineLetter tiles[RACK_SIZE];
+  int num_tiles = 0;
+  for (int ml = 0; ml < ld_get_size(ld); ml++) {
+    const int count = rack_get_letter(rack, ml);
+    for (int i = 0; i < count; i++) {
+      tiles[num_tiles++] = (MachineLetter)ml;
+    }
+  }
+  assert(num_tiles == rack_size);
+
+  BitRack expected_subracks[1 << RACK_SIZE];
+  int expected_sizes[1 << RACK_SIZE];
+  bool expected_seen[1 << RACK_SIZE] = {false};
+  int num_expected = 0;
+  for (int mask = 0; mask < 1 << rack_size; mask++) {
+    BitRack subrack = bit_rack_create_empty();
+    int size = 0;
+    for (int tile_idx = 0; tile_idx < rack_size; tile_idx++) {
+      if ((mask & (1 << tile_idx)) != 0) {
+        bit_rack_add_letter(&subrack, tiles[tile_idx]);
+        size++;
+      }
+    }
+
+    bool already_expected = false;
+    for (int expected_idx = 0; expected_idx < num_expected; expected_idx++) {
+      if (bit_rack_equals(&subrack, &expected_subracks[expected_idx])) {
+        already_expected = true;
+        break;
+      }
+    }
+    if (!already_expected) {
+      expected_subracks[num_expected] = subrack;
+      expected_sizes[num_expected] = size;
+      num_expected++;
+    }
+  }
+
+  int num_enumerated = 0;
+  for (int size = 0; size <= RACK_SIZE; size++) {
+    assert(wmg.count_by_size[size] == expected_counts[size]);
+    const int offset = subracks_get_combination_offset(size);
+    for (int idx_for_size = 0; idx_for_size < wmg.count_by_size[size];
+         idx_for_size++) {
+      const SubrackInfo *info =
+          &wmg.nonplaythrough_infos[offset + idx_for_size];
+      int expected_idx = -1;
+      for (int i = 0; i < num_expected; i++) {
+        if (bit_rack_equals(&info->subrack, &expected_subracks[i])) {
+          expected_idx = i;
+          break;
+        }
+      }
+      assert(expected_idx >= 0);
+      assert(expected_sizes[expected_idx] == size);
+      assert(!expected_seen[expected_idx]);
+      expected_seen[expected_idx] = true;
+      assert(!info->wmp_entry_is_set);
+
+      Rack expected_leave;
+      rack_copy(&expected_leave, rack);
+      LeaveMap expected_leave_map;
+      leave_map_init(&expected_leave, &expected_leave_map);
+      for (int ml = 0; ml < ld_get_size(ld); ml++) {
+        const int count = bit_rack_get_letter(&info->subrack, ml);
+        for (int i = 0; i < count; i++) {
+          leave_map_take_letter_and_update_current_index(
+              &expected_leave_map, &expected_leave, (MachineLetter)ml);
+        }
+      }
+      assert(info->leave_value ==
+             int_to_equity(leave_map_get_current_index(&expected_leave_map)));
+      num_enumerated++;
+    }
+  }
+
+  assert(num_enumerated == num_expected);
+  for (int expected_idx = 0; expected_idx < num_expected; expected_idx++) {
+    assert(expected_seen[expected_idx]);
+  }
+
+  rack_destroy(rack);
+}
+
+void test_nonplaythrough_subrack_enumeration(void) {
+  Config *config = config_create_or_die("set -lex CSW21 -wmp true");
+  Game *game = config_game_create(config);
+  const Player *player = game_get_player(game, 0);
+  const LetterDistribution *ld = game_get_ld(game);
+  const WMP *wmp = player_get_wmp(player);
+
+  const int full_rack_counts[RACK_SIZE + 1] = {1, 5, 12, 18, 18, 12, 5, 1};
+  assert_nonplaythrough_subrack_enumeration(ld, wmp, "AABEE?Z",
+                                            full_rack_counts);
+
+  const int short_rack_counts[RACK_SIZE + 1] = {1, 3, 4, 3, 1, 0, 0, 0};
+  assert_nonplaythrough_subrack_enumeration(ld, wmp, "AA?Z", short_rack_counts);
+
+  game_destroy(game);
+  config_destroy(config);
+}
+
 void test_nonplaythrough_existence(void) {
   Config *config = config_create_or_die("set -lex CSW21 -wmp true");
   Game *game = config_game_create(config);
@@ -178,6 +305,7 @@ void test_playthrough_bingo_existence(void) {
 
 void test_wmp_move_gen(void) {
   test_wmp_move_gen_inactive();
+  test_nonplaythrough_subrack_enumeration();
   test_nonplaythrough_existence();
   test_playthrough_bingo_existence();
 }

--- a/test/wmp_move_gen_test.c
+++ b/test/wmp_move_gen_test.c
@@ -2,7 +2,9 @@
 #include "wmp_move_gen_test.h"
 
 #include "../src/def/kwg_defs.h"
+#include "../src/def/letter_distribution_defs.h"
 #include "../src/def/rack_defs.h"
+#include "../src/ent/bit_rack.h"
 #include "../src/ent/equity.h"
 #include "../src/ent/game.h"
 #include "../src/ent/leave_map.h"

--- a/test/wmp_move_gen_test.c
+++ b/test/wmp_move_gen_test.c
@@ -2,7 +2,9 @@
 #include "wmp_move_gen_test.h"
 
 #include "../src/def/kwg_defs.h"
+#include "../src/def/letter_distribution_defs.h"
 #include "../src/def/rack_defs.h"
+#include "../src/ent/bit_rack.h"
 #include "../src/ent/equity.h"
 #include "../src/ent/game.h"
 #include "../src/ent/leave_map.h"
@@ -38,6 +40,161 @@ void set_dummy_leave_values(LeaveMap *leave_map) {
     const Equity value = int_to_equity(bits_set);
     leave_map_set_current_value(leave_map, value);
   }
+}
+
+static void assert_nonplaythrough_subrack_enumeration(
+    const LetterDistribution *ld, const WMP *wmp, const char *rack_string,
+    const int expected_counts[RACK_SIZE + 1]) {
+  Rack *rack = rack_create(ld_get_size(ld));
+  const int rack_size = rack_set_to_string(ld, rack, rack_string);
+  assert(rack_size >= 0 && rack_size <= RACK_SIZE);
+
+  WMPMoveGen wmg;
+  wmp_move_gen_init(&wmg, ld, rack, wmp);
+  for (int size = 0; size <= RACK_SIZE; size++) {
+    wmg.count_by_size[size] = 0;
+  }
+
+  LeaveMap leave_map;
+  leave_map_init(rack, &leave_map);
+  const int full_rack_index = (1 << rack_size) - 1;
+  for (int leave_idx = 0; leave_idx <= full_rack_index; leave_idx++) {
+    leave_map_set_current_index(&leave_map, leave_idx);
+    leave_map_set_current_value(&leave_map, int_to_equity(leave_idx));
+  }
+  leave_map_set_current_index(&leave_map, full_rack_index);
+
+  wmp_move_gen_enumerate_nonplaythrough_subracks(&wmg, &leave_map);
+  assert(leave_map_get_current_index(&leave_map) == full_rack_index);
+
+  MachineLetter tiles[RACK_SIZE];
+  int num_tiles = 0;
+  for (int ml = 0; ml < ld_get_size(ld); ml++) {
+    const int count = rack_get_letter(rack, ml);
+    for (int i = 0; i < count; i++) {
+      tiles[num_tiles++] = (MachineLetter)ml;
+    }
+  }
+  assert(num_tiles == rack_size);
+
+  BitRack expected_subracks[1 << RACK_SIZE];
+  int expected_sizes[1 << RACK_SIZE];
+  bool expected_seen[1 << RACK_SIZE] = {false};
+  int num_expected = 0;
+  for (int mask = 0; mask < 1 << rack_size; mask++) {
+    BitRack subrack = bit_rack_create_empty();
+    int size = 0;
+    for (int tile_idx = 0; tile_idx < rack_size; tile_idx++) {
+      if ((mask & (1 << tile_idx)) != 0) {
+        bit_rack_add_letter(&subrack, tiles[tile_idx]);
+        size++;
+      }
+    }
+
+    bool already_expected = false;
+    for (int expected_idx = 0; expected_idx < num_expected; expected_idx++) {
+      if (bit_rack_equals(&subrack, &expected_subracks[expected_idx])) {
+        already_expected = true;
+        break;
+      }
+    }
+    if (!already_expected) {
+      expected_subracks[num_expected] = subrack;
+      expected_sizes[num_expected] = size;
+      num_expected++;
+    }
+  }
+
+  int num_enumerated = 0;
+  for (int size = 0; size <= RACK_SIZE; size++) {
+    assert(wmg.count_by_size[size] == expected_counts[size]);
+    const int offset = subracks_get_combination_offset(size);
+    for (int idx_for_size = 0; idx_for_size < wmg.count_by_size[size];
+         idx_for_size++) {
+      const SubrackInfo *info =
+          &wmg.nonplaythrough_infos[offset + idx_for_size];
+      int expected_idx = -1;
+      for (int i = 0; i < num_expected; i++) {
+        if (bit_rack_equals(&info->subrack, &expected_subracks[i])) {
+          expected_idx = i;
+          break;
+        }
+      }
+      if (idx_for_size > 0) {
+        const BitRack *previous =
+            &wmg.nonplaythrough_infos[offset + idx_for_size - 1].subrack;
+        bool found_difference = false;
+        for (int ml = 0; ml < ld_get_size(ld); ml++) {
+          const int previous_count = bit_rack_get_letter(previous, ml);
+          const int current_count = bit_rack_get_letter(&info->subrack, ml);
+          if (previous_count != current_count) {
+            assert(previous_count < current_count);
+            found_difference = true;
+            break;
+          }
+        }
+        assert(found_difference);
+      }
+      assert(expected_idx >= 0);
+      assert(expected_sizes[expected_idx] == size);
+      assert(!expected_seen[expected_idx]);
+      expected_seen[expected_idx] = true;
+
+      Rack expected_leave;
+      rack_copy(&expected_leave, rack);
+      LeaveMap expected_leave_map;
+      leave_map_init(&expected_leave, &expected_leave_map);
+      for (int ml = 0; ml < ld_get_size(ld); ml++) {
+        const int count = bit_rack_get_letter(&info->subrack, ml);
+        for (int i = 0; i < count; i++) {
+          leave_map_take_letter_and_update_current_index(
+              &expected_leave_map, &expected_leave, (MachineLetter)ml);
+        }
+      }
+      assert(info->leave_value ==
+             int_to_equity(leave_map_get_current_index(&expected_leave_map)));
+      num_enumerated++;
+    }
+  }
+
+  assert(num_enumerated == num_expected);
+  for (int expected_idx = 0; expected_idx < num_expected; expected_idx++) {
+    assert(expected_seen[expected_idx]);
+  }
+
+  rack_destroy(rack);
+}
+
+void test_nonplaythrough_subrack_enumeration(void) {
+  Config *config = config_create_or_die("set -lex CSW21 -wmp true");
+  Game *game = config_game_create(config);
+  const Player *player = game_get_player(game, 0);
+  const LetterDistribution *ld = game_get_ld(game);
+  const WMP *wmp = player_get_wmp(player);
+
+  const int full_rack_counts[RACK_SIZE + 1] = {1, 5, 12, 18, 18, 12, 5, 1};
+  assert_nonplaythrough_subrack_enumeration(ld, wmp, "AABEE?Z",
+                                            full_rack_counts);
+
+  const int short_rack_counts[RACK_SIZE + 1] = {1, 3, 4, 3, 1, 0, 0, 0};
+  assert_nonplaythrough_subrack_enumeration(ld, wmp, "AA?Z", short_rack_counts);
+
+  const int empty_counts[RACK_SIZE + 1] = {1};
+  assert_nonplaythrough_subrack_enumeration(ld, wmp, "", empty_counts);
+  const int single_counts[RACK_SIZE + 1] = {1, 1};
+  assert_nonplaythrough_subrack_enumeration(ld, wmp, "?", single_counts);
+  const int repeated_counts[RACK_SIZE + 1] = {1, 1, 1, 1, 1, 1, 1, 1};
+  assert_nonplaythrough_subrack_enumeration(ld, wmp, "AAAAAAA",
+                                            repeated_counts);
+  const int distinct_counts[RACK_SIZE + 1] = {1, 7, 21, 35, 35, 21, 7, 1};
+  assert_nonplaythrough_subrack_enumeration(ld, wmp, "?AEIOUZ",
+                                            distinct_counts);
+  const int two_blank_counts[RACK_SIZE + 1] = {1, 6, 16, 25, 25, 16, 6, 1};
+  assert_nonplaythrough_subrack_enumeration(ld, wmp, "??AEIOZ",
+                                            two_blank_counts);
+
+  game_destroy(game);
+  config_destroy(config);
 }
 
 void test_nonplaythrough_existence(void) {
@@ -178,6 +335,7 @@ void test_playthrough_bingo_existence(void) {
 
 void test_wmp_move_gen(void) {
   test_wmp_move_gen_inactive();
+  test_nonplaythrough_subrack_enumeration();
   test_nonplaythrough_existence();
   test_playthrough_bingo_existence();
 }


### PR DESCRIPTION
## What this changes

`wmp_move_gen_enumerate_nonplaythrough_subracks` walks every canonical subrack of the player's rack. A `BitRack` has 32 alphabet lanes, but a rack occupies at most `RACK_SIZE` of them.

The old recursion carried a `next_ml` cursor and **rescanned lanes at every node** to find the next occupied letter:

```c
for (; next_ml < BIT_RACK_MAX_ALPHABET_SIZE; next_ml++) {
  max_num_this = bit_rack_get_letter(&wmp_move_gen->player_bit_rack, next_ml);
  if (max_num_this > 0) { break; }
}
if (next_ml >= BIT_RACK_MAX_ALPHABET_SIZE) { /* leaf */ }
```

Now the occupied letters are collected **once** into two `RACK_SIZE` arrays, and the recursion indexes them directly:

```c
for (int ml = BLANK_MACHINE_LETTER; ml < BIT_RACK_MAX_ALPHABET_SIZE; ml++) {
  const int count = bit_rack_get_letter(&wmp_move_gen->player_bit_rack, ml);
  if (count > 0) {
    rack_letters[num_rack_letters] = (MachineLetter)ml;
    rack_letter_counts[num_rack_letters] = (uint8_t)count;
    num_rack_letters++;
  }
}
...
if (rack_letter_idx >= num_rack_letters) { /* leaf */ }
```

### Worked example: `AABEE?Z`

Occupied lanes are `?`=0, `A`=1, `B`=2, `E`=5, `Z`=26, so the compact list is `[?,A,B,E,Z]` with counts `[1,2,1,2,1]`. Walking from `E` to `Z` meant scanning 21 empty lanes — and the old code redid that scan at every node that reached this depth.

| Rack | Distinct letters | Subracks emitted | Recursive calls | Lane reads before | Lane reads after |
|---|---|---|---|---|---|
| `AABEE?Z` | 5 | 72 | 129 | 1,161 | 32 |
| `AEINRST` | 7 | 128 | 255 | 1,634 | 32 |
| `?AEIOUZ` | 7 | 128 | 255 | 1,299 | 32 |
| `QUXZ` | 4 | 16 | 31 | 134 | 32 |
| `AAAAAAA` | 1 | 8 | 9 | 242 | 32 |

Same call count, same subracks, same order — only the repeated lane scanning goes away. Lane reads become a fixed 32 per enumeration instead of growing with the recursion tree.

Everything else is preserved: leaf writes, emission order, size offsets, paired leave-map add/take, and both existing cache-hit paths. The arrays are locals, so no persistent state is added.

**Reviewer note:** writing into `RACK_SIZE`-wide arrays is a precondition the old full-alphabet walk didn't have. It holds — the only production caller passes `gen->player_rack`, so distinct letters ≤ tiles ≤ `RACK_SIZE`.

That precondition was already load-bearing across this module (`count_by_size`, `nonplaythrough_has_word_of_length`, `nonplaythrough_best_leave_values`, `subracks_combination_offsets` and `nonplaythrough_infos` are all sized off `RACK_SIZE` and indexed by rack size), just undocumented. A second commit asserts it once in `wmp_move_gen_init`. Both asserts are debug-only — `cflags.release` sets `-DNDEBUG`, so release builds pay nothing.

An over-full rack is reachable today via CGP (#658), which checks tiles-are-in-bag but not rack size. On `main` that input already SEGVs in `leave_map_set_current_value`, before reaching any of these arrays, so it is not introduced here; the assert just names the violated precondition in debug builds. Unrelated but found the same way: `main` does not build for `RACK_SIZE` 4, 5, 6 or 8 (#659).

## Correctness

- New test derives the expected subrack set independently — it enumerates all `2^rack_size` tile subsets and deduplicates — then checks membership, uniqueness, per-size counts, order, leave values, and leave-map restoration for `AABEE?Z`, `AA?Z`, empty, `?`, `AAAAAAA`, `?AEIOUZ`, `??AEIOZ`.
- Exhaustive differential against a reimplementation of the pre-PR recursion, comparing `count_by_size`, every `nonplaythrough_infos` entry **in slot order**, each leave value, and leave-map restoration: **219,448 racks / 6,407,467 subracks, all identical**. Validated by injecting three mutations into the reference (perturbed leave value, perturbed subrack, swapped slot order) — each aborts, including the order-only one that leaves the subrack set unchanged.
- Full-move differential: 32 seeded CSW24 games, 712 positions, 967,104 moves, baseline/candidate × RIT on/off. All four sorted exports share one SHA-256, `631bf6a9a4e70226f3b54deaf2a7f9eed3f5a758d4322bf5eb3546e0e56f554f`.
- WMP on/off autoplay: 12,000 game pairs across 11 lexica, zero divergent games.
- Full 15×15 and 21×21 release suites pass; ASan/UBSan `wmg` passes; all 17 CI checks pass.

## Performance

Apple M4 Mac mini, Apple Clang 17, `-O3 -flto -march=native`, non-PGO. CSW24, WMP on, 2 plies, 15 candidate moves, 0.5 s/turn, `-minplayiterations 100000`, eight simulation workers (`autoplay games 1 -mtmode igp`). Six seeds × 2 repetitions × RIT on/off = 24 matched pairs per campaign, with baseline/candidate order reversed on the repeat. Paired geometric mean of iterations/sec; 95% bootstrap over seed-level means. Two independent campaigns:

| Configuration | Pairs | Campaign A | Campaign B |
|---|---|---|---|
| RIT enabled | 12 | +1.38%  (+0.43 to +2.40) | +1.21%  (+1.00 to +1.42) |
| RIT disabled | 12 | +0.86%  (+0.51 to +1.16) | +0.72%  (+0.19 to +1.17) |
| Pooled | 24 | **+1.12%**  (+0.54 to +1.71) | **+0.96%**  (+0.61 to +1.26) |

Candidate faster in 42 of 48 pairs across both campaigns.

Isolated enumeration microbenchmark (3M calls over ten rotating racks): **35.9%** and **35.8%** time reduction.

The gap between 36% and ~1% is expected — a sampled profile puts enumeration at 7.9% of non-blocking work, so the Amdahl ceiling is about 2.8%, and the `subracks_precomputed` cache lets many calls skip enumeration entirely.

Measured on one machine, one lexicon, six seeds, non-PGO; the intervals describe this corpus only. Playing strength is unaffected by construction, as the move differential confirms. The old ~2.2% figure was measured on a different stack (PGO release build, WIT, lazy RIT-backed WMP lookups) and is withdrawn.

Full report and raw data: `/Users/olaugh/sources/sep04-pr615-benchmarks/`.
