### PR TITLE
Save WMP shadow state only when needed

### DIFF
--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -2194,7 +2194,9 @@ static inline void shadow_play_right(MoveGen *gen, bool is_unique) {
 
   const int original_current_right_col = gen->current_right_col;
   const int original_tiles_played = gen->tiles_played;
-  wmp_move_gen_save_playthrough_state(&gen->wmp_move_gen);
+  // Playthrough state changes only when this shadow crosses an existing board
+  // block. Avoid snapshotting it for the common empty-rightward path.
+  bool changed_wmp_playthrough_state = false;
 
   while (gen->current_right_col < (BOARD_DIM - 1) &&
          gen->tiles_played < gen->number_of_letters_on_rack) {
@@ -2288,6 +2290,10 @@ static inline void shadow_play_right(MoveGen *gen, bool is_unique) {
       // Adding a letter here would be unsafe if the LetterDistribution's
       // alphabet size exceeded BIT_RACK_MAX_ALPHABET_SIZE.
       if (wmp_move_gen_is_active(&gen->wmp_move_gen)) {
+        if (!changed_wmp_playthrough_state) {
+          wmp_move_gen_save_playthrough_state(&gen->wmp_move_gen);
+          changed_wmp_playthrough_state = true;
+        }
         wmp_move_gen_add_playthrough_letter(&gen->wmp_move_gen,
                                             unblanked_playthrough_ml);
       }
@@ -2350,7 +2356,9 @@ static inline void shadow_play_right(MoveGen *gen, bool is_unique) {
   if (gen->is_wordsmog) {
     rack_copy(&gen->bingo_alpha_rack, &gen->bingo_alpha_rack_shadow_right_copy);
   }
-  wmp_move_gen_restore_playthrough_state(&gen->wmp_move_gen);
+  if (changed_wmp_playthrough_state) {
+    wmp_move_gen_restore_playthrough_state(&gen->wmp_move_gen);
+  }
 
   // The change of shadow_word_multiplier necessitates recalculating effective
   // multipliers.

--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -2112,7 +2112,9 @@ static inline void shadow_play_right(MoveGen *gen, bool is_unique) {
 
   const int original_current_right_col = gen->current_right_col;
   const int original_tiles_played = gen->tiles_played;
-  wmp_move_gen_save_playthrough_state(&gen->wmp_move_gen);
+  // Playthrough state changes only when this shadow crosses an existing board
+  // block. Avoid snapshotting it for the common empty-rightward path.
+  bool changed_wmp_playthrough_state = false;
 
   while (gen->current_right_col < (BOARD_DIM - 1) &&
          gen->tiles_played < gen->number_of_letters_on_rack) {
@@ -2206,6 +2208,10 @@ static inline void shadow_play_right(MoveGen *gen, bool is_unique) {
       // Adding a letter here would be unsafe if the LetterDistribution's
       // alphabet size exceeded BIT_RACK_MAX_ALPHABET_SIZE.
       if (wmp_move_gen_is_active(&gen->wmp_move_gen)) {
+        if (!changed_wmp_playthrough_state) {
+          wmp_move_gen_save_playthrough_state(&gen->wmp_move_gen);
+          changed_wmp_playthrough_state = true;
+        }
         wmp_move_gen_add_playthrough_letter(&gen->wmp_move_gen,
                                             unblanked_playthrough_ml);
       }
@@ -2268,7 +2274,9 @@ static inline void shadow_play_right(MoveGen *gen, bool is_unique) {
   if (gen->is_wordsmog) {
     rack_copy(&gen->bingo_alpha_rack, &gen->bingo_alpha_rack_shadow_right_copy);
   }
-  wmp_move_gen_restore_playthrough_state(&gen->wmp_move_gen);
+  if (changed_wmp_playthrough_state) {
+    wmp_move_gen_restore_playthrough_state(&gen->wmp_move_gen);
+  }
 
   // The change of shadow_word_multiplier necessitates recalculating effective
   // multipliers.

--- a/test/wmp_move_gen_test.c
+++ b/test/wmp_move_gen_test.c
@@ -5,6 +5,7 @@
 #include "../src/def/kwg_defs.h"
 #include "../src/def/letter_distribution_defs.h"
 #include "../src/def/move_defs.h"
+#include "../src/def/players_data_defs.h"
 #include "../src/def/rack_defs.h"
 #include "../src/ent/anchor.h"
 #include "../src/ent/bit_rack.h"
@@ -15,12 +16,15 @@
 #include "../src/ent/letter_distribution.h"
 #include "../src/ent/move.h"
 #include "../src/ent/player.h"
+#include "../src/ent/players_data.h"
 #include "../src/ent/rack.h"
 #include "../src/ent/wmp.h"
+#include "../src/ent/word_info_table.h"
 #include "../src/impl/config.h"
 #include "../src/impl/gameplay.h"
 #include "../src/impl/move_gen.h"
 #include "../src/impl/wmp_move_gen.h"
+#include "../src/impl/word_info_table_maker.h"
 #include "test_constants.h"
 #include "test_util.h"
 #include <assert.h>
@@ -580,8 +584,82 @@ void test_wmp_bounded_record_modes(void) {
   config_destroy(config);
 }
 
+// Shadowing right must restore the leftward playthrough state before the
+// next extension is explored. Compare against the recursive generator on
+// separated blocks, blanks, and edges, then reuse the generator on an empty
+// board. WIT-on also exercises early exits after entering a board block.
+static void test_shadow_playthrough_restoration(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -wmp true -wit false -s1 equity -s2 equity "
+      "-r1 all -r2 all -numplays 100000");
+  Config *reference_config = config_create_or_die(
+      "set -lex CSW21 -wmp false -wit false -s1 equity -s2 equity "
+      "-r1 all -r2 all -numplays 100000");
+  static const char *const positions[] = {
+      "15/15/15/15/15/15/15/6CAT6/15/15/15/15/15/15/15 ??EINRS/ 0/0 0",
+      "15/15/15/15/15/15/15/6CaT6/15/15/15/15/15/15/15 ?DEIRTU/ 0/0 0",
+      "15/15/15/15/15/15/15/4AT2IN5/15/15/15/15/15/15/15 AEIRST?/ 0/0 0",
+      "15/15/15/15/15/15/15/3A1T1I1N5/15/15/15/15/15/15/15 AEIRST?/ 0/0 0",
+      "AT13/15/15/15/15/15/15/15/15/15/15/15/15/15/13IN AEIRST?/ 0/0 0",
+      // This played position takes a WIT early exit after entering a block.
+      ("15/5M9/5I9/5R9/4BI4P4/4ET3JIG3/4AI4N4/4K2TRaNQ1OY/4I5AINEE/4EPAULETS3/"
+       "4R5E4/8ENDEmIC/15/15/15 DEEMORS/AHLOORS 195/206 0"),
+      "15/15/15/15/15/15/15/15/15/15/15/15/15/15/15 AEINRST/ 0/0 0",
+  };
+  MoveList *list = move_list_create(100000);
+  MoveList *reference_list = move_list_create(100000);
+  for (int wit_enabled = 0; wit_enabled <= 1; wit_enabled++) {
+    if (wit_enabled) {
+      PlayersData *players_data = config_get_players_data(config);
+      WordInfoTable *wit =
+          make_word_info_table_from_kwg(players_data_get_kwg(players_data, 0));
+      players_data_set_data(players_data, PLAYERS_DATA_TYPE_WIT, 0, wit);
+      players_data_set_data(players_data, PLAYERS_DATA_TYPE_WIT, 1, wit);
+    }
+    Game *game = config_game_create(config);
+    assert((player_get_word_info_table(game_get_player(game, 0)) != NULL) ==
+           (wit_enabled != 0));
+    Game *reference = config_game_create(reference_config);
+    for (size_t position_idx = 0;
+         position_idx < sizeof(positions) / sizeof(positions[0]);
+         position_idx++) {
+      load_cgp_or_die(game, positions[position_idx]);
+      load_cgp_or_die(reference, positions[position_idx]);
+      const MoveGenArgs args = {
+          .game = game,
+          .move_list = list,
+          .target_equity = EQUITY_MAX_VALUE,
+          .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+      };
+      MoveGenArgs reference_args = args;
+      reference_args.game = reference;
+      reference_args.move_list = reference_list;
+      generate_moves_for_game(&args);
+      generate_moves_for_game(&reference_args);
+      SortedMoveList *sorted = sorted_move_list_create(list);
+      SortedMoveList *reference_sorted =
+          sorted_move_list_create(reference_list);
+      assert(reference_sorted->count > 0);
+      assert(sorted->count == reference_sorted->count);
+      for (int move_idx = 0; move_idx < sorted->count; move_idx++) {
+        assert_moves_are_equal(sorted->moves[move_idx],
+                               reference_sorted->moves[move_idx]);
+      }
+      sorted_move_list_destroy(sorted);
+      sorted_move_list_destroy(reference_sorted);
+    }
+    game_destroy(game);
+    game_destroy(reference);
+  }
+  move_list_destroy(list);
+  move_list_destroy(reference_list);
+  config_destroy(config);
+  config_destroy(reference_config);
+}
+
 void test_wmp_move_gen(void) {
   test_wmp_move_gen_inactive();
+  test_shadow_playthrough_restoration();
   test_nonplaythrough_subrack_enumeration();
   test_wit_prune_skips_block_longer_than_anchor_word();
   test_nonplaythrough_existence();


### PR DESCRIPTION
## What this does

`shadow_play_right` explores rightward extensions and then restores the state needed to continue exploring to the left. It previously saved the WMP playthrough rack and its tile/block counts on every call, even when the rightward path crossed no existing tiles and could not change them.

This PR saves those three fields immediately before the first playthrough tile is added, and restores them only when that save occurred. Multiple tiles and blocks share one snapshot. WIT's dead-block early exit still runs the common cleanup. Paths that never mutate WMP state avoid both copies, including when WMP is disabled.

This follows the lazy-backup pattern already used for rack and multiplier state in the same function. It introduces no allocation or persistent cache. This targets regular WMP-backed move generation.

## Performance

Against `main` at `fb0fc7f7`, WMP/WIT enabled: M4 Mac mini, 4 workers, production static-trained PGO, `simbench` 0.5 s/turn, seeds 42/24301/1552 × 6 interleaved rounds, paired within-round geometric means, seed-stratified bootstrap 95% CIs (20,000 resamples), **18 pairs per row**. Both revisions were freshly trained on the production 16-game static workload, then held fixed for the campaign. AB/BA order is balanced within each seed and configuration. Configuration-loading time is excluded.

| configuration | this PR vs `main` | 95% CI |
|---|---:|---:|
| **RIT on** | **+0.58%** | [+0.23%, +0.98%] |
| RIT off | +0.27% | [+0.09%, +0.47%] |

The gain is small but positive in both configurations. All three RIT-on seed averages are positive (+0.50%, +0.43%, +0.80%). A conventional paired-t interval also stays above zero: [+0.16%, +1.00%] RIT on and [+0.03%, +0.50%] RIT off. All planned pairs were retained. Host load was recorded; no thermal or performance warnings were reported. Four workers leave headroom for background FileProvider/iCloud activity.

**Why it pays.** In a 16-game, single-worker CSW24 static workload with RIT/WIT enabled, 41,234 calls to `shadow_play_right` needed only 7,684 saves and 7,684 restores: **81.4% of snapshot/restore pairs were avoided**. The sample included 70 WIT early exits. The saved data is a 128-bit `BitRack` plus two integer counts. Counters were collected in a separate instrumented build and are absent from timing binaries.

The PGO assembly puts the save behind the first-mutation branch. It also grows `shadow_play_right` from 5,032 to 5,528 bytes and its stack frame from 304 to 352 bytes; fewer copies do not make the entire routine proportionally faster. The throughput table measures the net result.

### Profiling: affected functions

Separate five-second macOS `sample` captures used `BUILD=profile`, CSW24 `simbench`, seed 42, four workers, 0.5 s/turn, and WMP/WIT/RIT enabled. The sampled call path is `generate_moves` → `gen_shadow` → `shadow_by_orientation` → `shadow_play_for_anchor` → `shadow_play_right`.

| function | baseline self samples | PR self samples | relationship to this change |
|---|---:|---:|---|
| `shadow_play_right` | 1,358 | 1,462 | Directly changed: saves WMP state immediately before its first mutation and restores only if saved. |
| `shadow_play_for_anchor` | 1,334 | 1,275 | Calls the rightward exploration through the leftward shadow paths; benefits through reduced descendant work. |
| `gen_shadow` | 464 | 459 | Enclosing shadow phase; its own logic is unchanged. |

The work removed is in the inline helpers `wmp_move_gen_save_playthrough_state` and `wmp_move_gen_restore_playthrough_state`, so they do not appear as separate entries in these profiles. Both `nonplaythrough_shadow_play_left` and `playthrough_shadow_play_left` reach the modified routine. The separate call counters above quantify the reduction in save/restore work.

These captures locate the affected path, **not a per-function speedup**: `shadow_play_right` self samples actually increase in this short pair. Self samples exclude descendants, and the profile build suppresses inlining and differs from production PGO. The repeated PGO throughput measurements above establish the net gain; these samples cannot attribute its magnitude to individual functions.

## Correctness

- **New default-suite regression** `test_shadow_playthrough_restoration` (`wmg`): complete WMP move lists are compared with the independent recursive generator on split blocks, board/rack blanks, edge words, a played position verified to take the WIT early exit, and return to an empty board. Both WIT modes run, and the test asserts that the table is actually attached when enabled. Move identity, score, and equity must match.
- **Mutation checks:** moving the snapshot after the first mutation fails the new test's list-equality assertion; omitting restoration is caught by ASan while the test runs. The correct implementation passes.
- **Full recursive oracle:** 32 seeded CSW24 games, 712 positions and 967,104 complete equity-sorted moves per RIT/WIT combination, identical in all four combinations on the freshly trained PGO candidate.
- **State reuse:** WIT differential across 32 games/723 positions, comparing complete lists before and after copy and undo.
- Final `wmg`, `movegen`, `shadow`, and `witdiff` suites pass under ASan/UBSan. Formatting and circular-dependency checks pass; changed-file cppcheck and host-adapted clang-tidy checks are clean. Full repository checks run in CI.

## What can build on this

The remaining snapshot still writes into `WMPMoveGen` backup fields. Local temporaries or different branch placement could reduce that traffic, but the larger PGO stack frame shows why register pressure needs measuring too. Any such refinement should preserve the first-mutation/one-restore invariant and be compared with paired production-PGO runs; no additional speedup is claimed here.
