### PR TITLE
Check WMP playthrough letters before cross sets

### DIFF
--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -905,9 +905,49 @@ void record_wmp_plays_for_word(MoveGen *gen, int subrack_idx, int start_col,
 }
 
 bool wordmap_gen_check_playthrough_and_crosses(MoveGen *gen, int word_idx,
-                                               int start_col) {
+                                               int start_col,
+                                               uint32_t playthrough_positions) {
   const WMPMoveGen *wgen = &gen->wmp_move_gen;
   const MachineLetter *word = wmp_move_gen_get_word(wgen, word_idx);
+  if (playthrough_positions != 0) {
+    // WMP words are anagrams of the rack plus the playthrough tiles, but most
+    // anagrams do not put those tiles at the board's fixed positions. Check
+    // every fixed position before spending time on cross sets at empty
+    // squares. The positions were collected while building the playthrough
+    // BitRack, so this phase visits only actual board tiles.
+    uint32_t positions = playthrough_positions;
+    while (positions != 0) {
+      const int board_col = __builtin_ctz(positions);
+      const int letter_idx = board_col - start_col;
+      assert(board_col < BOARD_DIM);
+      assert(board_col >= 0);
+      assert(letter_idx >= 0);
+      assert(letter_idx < wgen->word_length);
+      const MachineLetter board_letter =
+          get_unblanked_machine_letter(gen_cache_get_letter(gen, board_col));
+      assert(board_letter != ALPHABET_EMPTY_SQUARE_MARKER);
+      assert(
+          !bonus_square_is_brick(gen_cache_get_bonus_square(gen, board_col)));
+      if (board_letter != word[letter_idx]) {
+        return false;
+      }
+      gen->playthrough_marked[letter_idx] = PLAYED_THROUGH_MARKER;
+      positions &= positions - 1;
+    }
+    for (int letter_idx = 0; letter_idx < wgen->word_length; letter_idx++) {
+      const int board_col = start_col + letter_idx;
+      if ((playthrough_positions & (1U << board_col)) != 0) {
+        continue;
+      }
+      const MachineLetter word_letter = word[letter_idx];
+      if (!board_is_letter_allowed_in_cross_set(
+              gen_cache_get_cross_set(gen, board_col), word_letter)) {
+        return false;
+      }
+      gen->playthrough_marked[letter_idx] = word_letter;
+    }
+    return true;
+  }
   for (int letter_idx = 0; letter_idx < wgen->word_length; letter_idx++) {
     const int board_col = start_col + letter_idx;
     assert(board_col < BOARD_DIM);
@@ -961,7 +1001,7 @@ void wordmap_gen(MoveGen *gen, const Anchor *anchor) {
         wgen->num_words = 1;
         for (int start_col = anchor->leftmost_start_col;
              start_col <= anchor->rightmost_start_col; start_col++) {
-          if (wordmap_gen_check_playthrough_and_crosses(gen, 0, start_col)) {
+          if (wordmap_gen_check_playthrough_and_crosses(gen, 0, start_col, 0)) {
             record_wmp_plays_for_word(gen, 0, start_col, 0, 0);
             if (gen->threshold_exceeded) {
               return;
@@ -1063,8 +1103,8 @@ void wordmap_gen(MoveGen *gen, const Anchor *anchor) {
     for (int word_idx = 0; word_idx < wgen->num_words; word_idx++) {
       for (int start_col = anchor->leftmost_start_col;
            start_col <= anchor->rightmost_start_col; start_col++) {
-        if (wordmap_gen_check_playthrough_and_crosses(gen, word_idx,
-                                                      start_col)) {
+        if (wordmap_gen_check_playthrough_and_crosses(
+                gen, word_idx, start_col, wgen->playthrough_positions)) {
           record_wmp_plays_for_word(gen, subrack_idx, start_col, 0, 0);
           if (gen->threshold_exceeded) {
             return;

--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -973,27 +973,18 @@ bool wordmap_gen_check_playthrough_and_crosses(MoveGen *gen, int word_idx,
     }
     return true;
   }
+  // A zero mask means this anchor has no fixed letters. Check only crosses.
   for (int letter_idx = 0; letter_idx < wgen->word_length; letter_idx++) {
-    const int board_col = start_col + letter_idx;
-    assert(board_col < BOARD_DIM);
-    assert(board_col >= 0);
+    assert(start_col + letter_idx >= 0);
+    assert(start_col + letter_idx < BOARD_DIM);
+    assert(gen_cache_is_empty(gen, start_col + letter_idx));
     const MachineLetter word_letter = word[letter_idx];
-    if (gen_cache_is_empty(gen, board_col)) {
-      if (!board_is_letter_allowed_in_cross_set(
-              gen_cache_get_cross_set(gen, board_col), word_letter)) {
-        return false;
-      }
-      gen->playthrough_marked[letter_idx] = word_letter;
-      continue;
-    }
-    const MachineLetter board_letter =
-        get_unblanked_machine_letter(gen_cache_get_letter(gen, board_col));
-    assert(board_letter != ALPHABET_EMPTY_SQUARE_MARKER);
-    assert(!bonus_square_is_brick(gen_cache_get_bonus_square(gen, board_col)));
-    if (board_letter != word_letter) {
+    if (!board_is_letter_allowed_in_cross_set(
+            gen_cache_get_cross_set(gen, start_col + letter_idx),
+            word_letter)) {
       return false;
     }
-    gen->playthrough_marked[letter_idx] = PLAYED_THROUGH_MARKER;
+    gen->playthrough_marked[letter_idx] = word_letter;
   }
   return true;
 }

--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -913,10 +913,66 @@ void record_wmp_plays_for_word(MoveGen *gen, int subrack_idx, int start_col,
   }
 }
 
+// Index of the lowest set bit of a nonzero bitset, following
+// get_single_bit_index's guarded-intrinsic pattern. Undefined for zero, so
+// callers loop on `bitset != 0`.
+static inline int lowest_set_bit_index(uint32_t bitset) {
+#if defined(__has_builtin) && __has_builtin(__builtin_ctz)
+  return __builtin_ctz(bitset);
+#else
+  int index = 0;
+  while ((bitset & 1U) == 0) {
+    bitset >>= 1U;
+    index++;
+  }
+  return index;
+#endif
+}
+
 bool wordmap_gen_check_playthrough_and_crosses(MoveGen *gen, int word_idx,
-                                               int start_col) {
+                                               int start_col,
+                                               uint32_t playthrough_positions) {
   const WMPMoveGen *wgen = &gen->wmp_move_gen;
   const MachineLetter *word = wmp_move_gen_get_word(wgen, word_idx);
+  if (playthrough_positions != 0) {
+    // WMP words are anagrams of the rack plus the playthrough tiles, but most
+    // anagrams do not put those tiles at the board's fixed positions. Check
+    // every fixed position before spending time on cross sets at empty
+    // squares. The positions were collected while building the playthrough
+    // BitRack, so this phase visits only actual board tiles.
+    uint32_t positions = playthrough_positions;
+    while (positions != 0) {
+      const int board_col = lowest_set_bit_index(positions);
+      const int letter_idx = board_col - start_col;
+      assert(board_col < BOARD_DIM);
+      assert(board_col >= 0);
+      assert(letter_idx >= 0);
+      assert(letter_idx < wgen->word_length);
+      const MachineLetter board_letter =
+          get_unblanked_machine_letter(gen_cache_get_letter(gen, board_col));
+      assert(board_letter != ALPHABET_EMPTY_SQUARE_MARKER);
+      assert(
+          !bonus_square_is_brick(gen_cache_get_bonus_square(gen, board_col)));
+      if (board_letter != word[letter_idx]) {
+        return false;
+      }
+      gen->playthrough_marked[letter_idx] = PLAYED_THROUGH_MARKER;
+      positions &= positions - 1;
+    }
+    for (int letter_idx = 0; letter_idx < wgen->word_length; letter_idx++) {
+      const int board_col = start_col + letter_idx;
+      if ((playthrough_positions & (1U << board_col)) != 0) {
+        continue;
+      }
+      const MachineLetter word_letter = word[letter_idx];
+      if (!board_is_letter_allowed_in_cross_set(
+              gen_cache_get_cross_set(gen, board_col), word_letter)) {
+        return false;
+      }
+      gen->playthrough_marked[letter_idx] = word_letter;
+    }
+    return true;
+  }
   for (int letter_idx = 0; letter_idx < wgen->word_length; letter_idx++) {
     const int board_col = start_col + letter_idx;
     assert(board_col < BOARD_DIM);
@@ -981,7 +1037,8 @@ wordmap_gen_record_subrack(MoveGen *gen, const Anchor *anchor, int subrack_idx,
   for (int word_idx = 0; word_idx < wgen->num_words; word_idx++) {
     for (int start_col = anchor->leftmost_start_col;
          start_col <= anchor->rightmost_start_col; start_col++) {
-      if (wordmap_gen_check_playthrough_and_crosses(gen, word_idx, start_col)) {
+      if (wordmap_gen_check_playthrough_and_crosses(
+              gen, word_idx, start_col, wgen->playthrough_positions)) {
         record_wmp_plays_for_word(gen, subrack_idx, start_col, 0, 0);
         if (gen->threshold_exceeded) {
           return true;
@@ -1017,22 +1074,6 @@ wordmap_gen_forbidden_subracks(MoveGen *gen, const Anchor *anchor,
       return;
     }
   }
-}
-
-// Index of the lowest set bit of a nonzero bitset, following
-// get_single_bit_index's guarded-intrinsic pattern. Undefined for zero, so
-// callers loop on `bitset != 0`.
-static inline int lowest_set_bit_index(uint32_t bitset) {
-#if defined(__has_builtin) && __has_builtin(__builtin_ctz)
-  return __builtin_ctz(bitset);
-#else
-  int index = 0;
-  while ((bitset & 1U) == 0) {
-    bitset >>= 1U;
-    index++;
-  }
-  return index;
-#endif
 }
 
 // Clears the lowest set bit, so a loop can visit each set bit in turn:
@@ -1074,7 +1115,7 @@ wordmap_gen(MoveGen *gen, const Anchor *anchor, bool lazy) {
         wgen->num_words = 1;
         for (int start_col = anchor->leftmost_start_col;
              start_col <= anchor->rightmost_start_col; start_col++) {
-          if (wordmap_gen_check_playthrough_and_crosses(gen, 0, start_col)) {
+          if (wordmap_gen_check_playthrough_and_crosses(gen, 0, start_col, 0)) {
             record_wmp_plays_for_word(gen, 0, start_col, 0, 0);
             if (gen->threshold_exceeded) {
               return;

--- a/src/impl/wmp_move_gen.h
+++ b/src/impl/wmp_move_gen.h
@@ -83,6 +83,9 @@ typedef struct WMPMoveGen {
   // be one of these letters, so move generation can skip the whole anchor when
   // the rack cannot supply enough of them. All-ones when no table is loaded.
   uint32_t playthrough_addable;
+  // Absolute row positions occupied by this anchor's playthrough tiles.
+  // Collected during the same block scan as playthrough_bit_rack.
+  uint32_t playthrough_positions;
 } WMPMoveGen;
 
 static inline void wmp_move_gen_reset_anchors(WMPMoveGen *wmp_move_gen) {
@@ -577,6 +580,7 @@ static inline void wmp_move_gen_set_playthrough_bit_rack(
     const uint32_t *const *wit_row_lane, const uint8_t *wit_len_lane) {
   wmp_move_gen_reset_playthrough(wmp_move_gen);
   wmp_move_gen->playthrough_addable = 0xFFFFFFFFu;
+  wmp_move_gen->playthrough_positions = 0;
   if (anchor->playthrough_blocks == 0) {
     return;
   }
@@ -595,6 +599,7 @@ static inline void wmp_move_gen_set_playthrough_bit_rack(
     }
     const MachineLetter unblanked_ml = get_unblanked_machine_letter(ml);
     wmp_move_gen_add_playthrough_letter(wmp_move_gen, unblanked_ml);
+    wmp_move_gen->playthrough_positions |= 1U << col;
     if (!in_block) {
       in_block = true;
       blocks_found++;

--- a/src/impl/wmp_move_gen.h
+++ b/src/impl/wmp_move_gen.h
@@ -84,6 +84,9 @@ typedef struct WMPMoveGen {
   // be one of these letters, so move generation can skip the whole anchor when
   // the rack cannot supply enough of them. All-ones when no table is loaded.
   uint32_t playthrough_addable;
+  // Absolute row positions occupied by this anchor's playthrough tiles.
+  // Collected during the same block scan as playthrough_bit_rack.
+  uint32_t playthrough_positions;
   // When the caller has an active per-rack cache, lazily resolved
   // nonplaythrough WMP entries are written through to it for the next
   // occurrence of the rack. The cache stores the same three-state pointers.
@@ -610,6 +613,7 @@ static inline void wmp_move_gen_set_playthrough_bit_rack(
     const uint32_t *const *wit_row_lane, const uint8_t *wit_len_lane) {
   wmp_move_gen_reset_playthrough(wmp_move_gen);
   wmp_move_gen->playthrough_addable = 0xFFFFFFFFu;
+  wmp_move_gen->playthrough_positions = 0;
   if (anchor->playthrough_blocks == 0) {
     return;
   }
@@ -628,6 +632,7 @@ static inline void wmp_move_gen_set_playthrough_bit_rack(
     }
     const MachineLetter unblanked_ml = get_unblanked_machine_letter(ml);
     wmp_move_gen_add_playthrough_letter(wmp_move_gen, unblanked_ml);
+    wmp_move_gen->playthrough_positions |= 1U << col;
     if (!in_block) {
       in_block = true;
       blocks_found++;

--- a/test/wmp_move_gen_test.c
+++ b/test/wmp_move_gen_test.c
@@ -680,10 +680,66 @@ static void test_shadow_playthrough_restoration(void) {
   config_destroy(reference_config);
 }
 
+// Compare complete move sets against the independent recursive generator.
+// Reuse the same generator across empty boards, split blocks, board blanks,
+// edge words, and racks containing one or two blanks.
+static void test_playthrough_moves_against_recursive(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -wmp true -s1 equity -s2 equity -r1 all -r2 all "
+      "-numplays 100000");
+  Config *reference = config_create_or_die(
+      "set -lex CSW21 -wmp false -s1 equity -s2 equity -r1 all -r2 all "
+      "-numplays 100000");
+  static const char *const positions[] = {
+      "15/15/15/15/15/15/15/15/15/15/15/15/15/15/15 AEINRST/ 0/0 0",
+      "15/15/15/15/15/15/15/6CAT6/15/15/15/15/15/15/15 ??EINRS/ 0/0 0",
+      "15/15/15/15/15/15/15/6CaT6/15/15/15/15/15/15/15 ?DEIRTU/ 0/0 0",
+      "15/15/15/15/15/15/15/4AT1IN6/15/15/15/15/15/15/15 AEIRST?/ 0/0 0",
+      "AT13/15/15/15/15/15/15/15/15/15/15/15/15/15/13IN AEIRST?/ 0/0 0",
+      "15/15/15/15/15/15/15/15/15/15/15/15/15/15/15 AEINRST/ 0/0 0",
+  };
+  MoveList *list = move_list_create(100000);
+  MoveList *reference_list = move_list_create(100000);
+  for (size_t position_idx = 0;
+       position_idx < sizeof(positions) / sizeof(positions[0]);
+       position_idx++) {
+    char command[256];
+    (void)snprintf(command, sizeof(command), "cgp %s", positions[position_idx]);
+    load_and_exec_config_or_die(config, command);
+    load_and_exec_config_or_die(reference, command);
+    const MoveGenArgs args = {
+        .game = config_get_game(config),
+        .move_list = list,
+        .target_equity = EQUITY_MAX_VALUE,
+        .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+    };
+    MoveGenArgs reference_args = args;
+    reference_args.game = config_get_game(reference);
+    reference_args.move_list = reference_list;
+    generate_moves_for_game(&args);
+    generate_moves_for_game(&reference_args);
+    SortedMoveList *sorted = sorted_move_list_create(list);
+    SortedMoveList *reference_sorted = sorted_move_list_create(reference_list);
+    assert(reference_sorted->count > 0);
+    assert(sorted->count == reference_sorted->count);
+    for (int move_idx = 0; move_idx < sorted->count; move_idx++) {
+      assert_moves_are_equal(sorted->moves[move_idx],
+                             reference_sorted->moves[move_idx]);
+    }
+    sorted_move_list_destroy(sorted);
+    sorted_move_list_destroy(reference_sorted);
+  }
+  move_list_destroy(list);
+  move_list_destroy(reference_list);
+  config_destroy(config);
+  config_destroy(reference);
+}
+
 void test_wmp_move_gen(void) {
   test_wmp_move_gen_inactive();
   test_shadow_playthrough_restoration();
   test_playthrough_positions_reset();
+  test_playthrough_moves_against_recursive();
   test_nonplaythrough_subrack_enumeration();
   test_wit_prune_skips_block_longer_than_anchor_word();
   test_nonplaythrough_existence();
@@ -745,7 +801,7 @@ void test_rit_toggle_subrack_cache(void) {
   static const char *const cgps[] = {
       "15/15/15/15/15/15/15/15/15/15/15/15/15/15/15 AEINRST/ 0/0 0",
       "15/15/15/15/15/15/15/6CAT6/15/15/15/15/15/15/15 AEINRST/ 0/0 0",
-      "15/15/15/15/15/15/15/6CAT6/15/15/15/15/15/15/15 ?DEIRTU/ 0/0 0",
+      "15/15/15/15/15/15/15/6CAT6/15/15/15/15/15/15/15 ??EINRS/ 0/0 0",
   };
   // Use each config's own game: `set -rit ...` updates that game's players,
   // and the config only creates it once a command needs one.

--- a/test/wmp_move_gen_test.c
+++ b/test/wmp_move_gen_test.c
@@ -73,6 +73,29 @@ void test_wit_prune_skips_block_longer_than_anchor_word(void) {
   assert(wmg.num_tiles_played_through == 3);
 }
 
+// Reusing the generator for a different anchor must replace every mask bit,
+// including when the new anchor has no fixed tiles.
+static void test_playthrough_positions_reset(void) {
+  WMPMoveGen wmg = {0};
+  Square row_cache[BOARD_DIM] = {0};
+  row_cache[1].letter = 1;
+  row_cache[3].letter = get_blanked_machine_letter(2);
+  Anchor anchor = {.playthrough_blocks = 2, .rightmost_start_col = 0};
+  wmp_move_gen_set_playthrough_bit_rack(&wmg, &anchor, row_cache, NULL, NULL);
+  assert(wmg.playthrough_positions == ((1U << 1) | (1U << 3)));
+  assert(wmg.num_tiles_played_through == 2);
+  anchor.playthrough_blocks = 1;
+  anchor.rightmost_start_col = BOARD_DIM - 1;
+  row_cache[BOARD_DIM - 1].letter = 3;
+  wmp_move_gen_set_playthrough_bit_rack(&wmg, &anchor, row_cache, NULL, NULL);
+  assert(wmg.playthrough_positions == (1U << (BOARD_DIM - 1)));
+  assert(wmg.num_tiles_played_through == 1);
+  anchor.playthrough_blocks = 0;
+  wmp_move_gen_set_playthrough_bit_rack(&wmg, &anchor, row_cache, NULL, NULL);
+  assert(wmg.playthrough_positions == 0);
+  assert(wmg.num_tiles_played_through == 0);
+}
+
 // Set empty leave to 0.0, all one-tile leaves to +1.0, two-tile leaves to +2.0,
 // etc.
 void set_dummy_leave_values(LeaveMap *leave_map) {
@@ -660,6 +683,7 @@ static void test_shadow_playthrough_restoration(void) {
 void test_wmp_move_gen(void) {
   test_wmp_move_gen_inactive();
   test_shadow_playthrough_restoration();
+  test_playthrough_positions_reset();
   test_nonplaythrough_subrack_enumeration();
   test_wit_prune_skips_block_longer_than_anchor_word();
   test_nonplaythrough_existence();


### PR DESCRIPTION
## What this does

WMP returns anagrams of the rack plus any letters already on the board. Most candidates that play through an existing tile put that letter in the wrong position. Previously the validator walked the word from left to right, checking cross sets on empty squares before it necessarily reached the mismatched fixed letter.

This PR collects an absolute fixed-position mask during the existing anchor block scan, checks those positions first, and only then checks cross sets on the newly placed tiles. Board blanks are unblanked for the fixed-letter comparison. The mask is reset before the no-block early return, so a reused generator cannot carry fixed positions into another anchor.

The refinement is the zero-mask path: when an anchor has no fixed letters, including the special RIT bingo path, every square in the span is empty and validation only needs cross sets. It skips the old per-letter occupancy reads; debug assertions pin the invariant. The existing portable nonzero set-bit helper handles the fixed-position scan. #614's lazy subrack resolution and per-generation specialization remain intact.

Based independently on `main` at `fb0fc7f7`, with #614 merged; no dependency on #618.

## Performance

Against `main` at `fb0fc7f7`, WMP/WIT on: M4 Mac mini, 4 workers, **production static-trained PGO**, `simbench` 0.5 s/turn, seeds 42/24301/1552 × 6 interleaved rounds, paired within-round geometric means, seed-stratified bootstrap 95% CIs (20,000 resamples), **18 pairs per row**. Each revision was trained separately on the production 16-game static workload, and those binaries were held fixed throughout the campaign. AB/BA order is balanced for each seed and RIT setting; seed order rotates and RIT order alternates between rounds. Configuration-loading time is excluded.

| configuration | this PR vs `main` | 95% CI |
|---|---:|---:|
| **RIT on** | **+2.31%** | [+2.07%, +2.56%] |
| RIT off | **+1.71%** | [+1.49%, +1.94%] |

All three seeds and every paired comparison are positive in both rows. This was a fresh, fixed-size confirmation; the earlier three-pair pilot is not pooled into it. All planned pairs were retained. Four workers leave CPU headroom for the host's ongoing FileProvider/iCloud activity; load was logged, and no thermal or performance warnings were recorded.

The earlier **non-PGO** comparison (six pairs per row; paired-t 95% intervals) measured **+1.63% [+1.08%, +2.18%] with RIT on**, and +0.86% [−0.01%, +1.74%] with RIT off. These are separate measurements, not pooled with PGO. The gain is present in both the production PGO and non-PGO RIT-on measurements.

**Why this can pay.** The change rejects misplaced anagrams before cross-set work and removes occupancy reads from empty spans. Equal five-second `BUILD=profile` captures had 904 validator self samples on main and 783 on the candidate. A synthetic validator benchmark also reduced cost, but these are mechanism checks, not the end-to-end speedup claim. Those captures use different inlining settings from production builds.

**Refinements tested.** The original fixed-first patch did not consistently improve RIT-on throughput in its exploratory screen. The zero-mask specialization was retained. Caching fixed columns and unblanked letters in extra per-anchor arrays passed the recursive oracle, but improved the three-pair non-PGO RIT-on screen less than the simpler specialization (+0.46% versus +1.66%); those arrays were not retained.

## Correctness

- **New default-suite mask regression:** reuse one generator across separated fixed tiles, a board blank, the last column, and an anchor with no fixed tiles. It checks mask replacement and the no-block reset.
- **New recursive-generator regression:** compare complete WMP and non-WMP lists on six CSW21 fixtures covering an empty board, two rack blanks, a board blank, split blocks, edge words, and return to an empty board. Move identity, score, and equity must agree.
- **Full recursive oracle:** 32 seeded CSW24 games, 712 positions, 967,104 complete moves per RIT/WIT combination. All four combinations agree, including on the freshly trained PGO candidate.
- **State reuse:** WIT differential across 32 games/723 positions, before and after copy and undo; WIT sweep across 16 games/353 positions. Complete lists agree.
- Final ASan/UBSan suites `wmg movegen shadow witdiff` pass. All 17 final-head CI checks pass, including cppcheck, clang-tidy, formatting, unit-test shards, super-board tests, and WASM.

The score-sort leave-bound defect tracked in #674 is separate; the full-game oracle here uses complete equity-sorted lists and does not claim to fix that baseline issue.

## What can build on this

- **Control inlining explicitly in an experiment.** PGO leaves a validator call in main's special RIT bingo path but inlines the candidate. The candidate's larger generated routines could change code layout and instruction-cache behavior. The larger benchmark shows a PGO gain despite this difference; matching the inlining policy would be a separate experiment to test whether more speed is available.
- **Check training coverage separately.** Production PGO trained each version on the same 16 static games (368 moves, RIT/WIT enabled). The benchmark measures simulation rollouts. A larger static corpus or a simulation-trained profile is a separate experiment; the measurements above hold the trained binaries fixed.
