### PR TITLE
Skip redundant shadow reductions for WMP

### DIFF
--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -1960,6 +1960,10 @@ static inline void shadow_record(MoveGen *gen) {
                                        word_length, gen->current_left_col,
                                        score, equity);
     }
+    // WMP move generation consumes the per-slot bounds above. The global
+    // reductions below are only used to construct a legacy recursive-movegen
+    // anchor, so maintaining them here would duplicate the same maxima.
+    return;
   }
   if (equity > gen->highest_shadow_equity) {
     gen->highest_shadow_equity = equity;
@@ -2989,19 +2993,22 @@ void shadow_play_for_anchor(MoveGen *gen, int col) {
   wmp_move_gen_reset_anchors(&gen->wmp_move_gen);
 
   shadow_start(gen);
-  if (gen->max_tiles_to_play == 0) {
-    return;
-  }
-
   if (wmp_move_gen_is_active(&gen->wmp_move_gen)) {
+    // A zero touched-anchor mask is already a no-op. In particular, a
+    // one-square perpendicular shadow may record a legacy max without
+    // producing a WMP slot in this orientation; its legal playthrough anchor
+    // is emitted in the opposite orientation.
     wmp_move_gen_add_anchors(&gen->wmp_move_gen, gen->current_row_index, col,
                              gen->last_anchor_col, gen->dir,
                              gen->target_equity_cutoff, &gen->anchor_heap);
-  } else {
-    anchor_heap_add_unheaped_anchor(
-        &gen->anchor_heap, gen->current_row_index, col, gen->last_anchor_col,
-        gen->dir, gen->highest_shadow_equity, gen->highest_shadow_score);
+    return;
   }
+  if (gen->max_tiles_to_play == 0) {
+    return;
+  }
+  anchor_heap_add_unheaped_anchor(
+      &gen->anchor_heap, gen->current_row_index, col, gen->last_anchor_col,
+      gen->dir, gen->highest_shadow_equity, gen->highest_shadow_score);
 }
 
 // Simplified shadow_play_for_anchor for small move types (BEST_SMALL).

--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -1695,9 +1695,10 @@ void go_on_alpha(MoveGen *gen, int current_col, MachineLetter L, int leftstrip,
   }
 }
 
-static inline void shadow_record(MoveGen *gen) {
+static inline __attribute__((always_inline)) void
+shadow_record_impl(MoveGen *gen, bool wmp_active) {
   const Equity *best_leaves = gen->best_leaves;
-  if (wmp_move_gen_is_active(&gen->wmp_move_gen)) {
+  if (wmp_active) {
     if (wmp_move_gen_has_playthrough(&gen->wmp_move_gen)) {
       // RIT fast path for single-playthrough anchors: the RIT's
       // playthrough_union[leave_size] holds a uint32 bitmask of letters L
@@ -1830,7 +1831,7 @@ static inline void shadow_record(MoveGen *gen) {
         gen->full_rack_descending_tile_scores, gen->number_of_tiles_in_bag,
         gen->number_of_letters_on_rack, gen->tiles_played);
   }
-  if (wmp_move_gen_is_active(&gen->wmp_move_gen)) {
+  if (wmp_active) {
     const int word_length =
         gen->wmp_move_gen.num_tiles_played_through + gen->tiles_played;
     if (word_length >= MINIMUM_WORD_LENGTH) {
@@ -1838,6 +1839,10 @@ static inline void shadow_record(MoveGen *gen) {
                                        word_length, gen->current_left_col,
                                        score, equity);
     }
+    // WMP move generation consumes the per-slot bounds above. The global
+    // reductions below are only used to construct a legacy recursive-movegen
+    // anchor, so maintaining them here would duplicate the same maxima.
+    return;
   }
   if (equity > gen->highest_shadow_equity) {
     gen->highest_shadow_equity = equity;
@@ -1847,6 +1852,22 @@ static inline void shadow_record(MoveGen *gen) {
   }
   if (gen->tiles_played > gen->max_tiles_to_play) {
     gen->max_tiles_to_play = gen->tiles_played;
+  }
+}
+
+static __attribute__((noinline)) void shadow_record_wmp(MoveGen *gen) {
+  shadow_record_impl(gen, true);
+}
+
+static __attribute__((noinline)) void shadow_record_recursive(MoveGen *gen) {
+  shadow_record_impl(gen, false);
+}
+
+static inline void shadow_record(MoveGen *gen) {
+  if (wmp_move_gen_is_active(&gen->wmp_move_gen)) {
+    shadow_record_wmp(gen);
+  } else {
+    shadow_record_recursive(gen);
   }
 }
 
@@ -2863,19 +2884,24 @@ void shadow_play_for_anchor(MoveGen *gen, int col) {
   wmp_move_gen_reset_anchors(&gen->wmp_move_gen);
 
   shadow_start(gen);
-  if (gen->max_tiles_to_play == 0) {
-    return;
-  }
-
   if (wmp_move_gen_is_active(&gen->wmp_move_gen)) {
+    // The WMP slots carry their own bounds. A one-square perpendicular
+    // shadow may produce no slot here; its playthrough anchor is emitted
+    // in the opposite orientation. Avoid scanning an empty slot array.
+    if (gen->wmp_move_gen.num_touched_anchor_slots == 0) {
+      return;
+    }
     wmp_move_gen_add_anchors(&gen->wmp_move_gen, gen->current_row_index, col,
                              gen->last_anchor_col, gen->dir,
                              gen->target_equity_cutoff, &gen->anchor_heap);
-  } else {
-    anchor_heap_add_unheaped_anchor(
-        &gen->anchor_heap, gen->current_row_index, col, gen->last_anchor_col,
-        gen->dir, gen->highest_shadow_equity, gen->highest_shadow_score);
+    return;
   }
+  if (gen->max_tiles_to_play == 0) {
+    return;
+  }
+  anchor_heap_add_unheaped_anchor(
+      &gen->anchor_heap, gen->current_row_index, col, gen->last_anchor_col,
+      gen->dir, gen->highest_shadow_equity, gen->highest_shadow_score);
 }
 
 // Simplified shadow_play_for_anchor for small move types (BEST_SMALL).

--- a/test/shadow_test.c
+++ b/test/shadow_test.c
@@ -677,6 +677,16 @@ void test_shadow_wmp_one_tile(void) {
   assert(ah.anchors[1].leftmost_start_col == 6);
   assert(ah.anchors[1].rightmost_start_col == 6);
 
+  // Reuse the generator on a position with no WMP slot, then return to the
+  // one-tile playthrough. Emission must use this position's per-slot bounds,
+  // without requiring the recursive generator's global tile-count reduction.
+  load_and_shadow(game, player, EMPTY_CGP, "Q", &ah);
+  assert(ah.count == 0);
+  load_and_shadow(game, player, QI_QI_CGP, "D", &ah);
+  assert(ah.count == 2);
+  assert_anchor_score(&ah, 0, 6);
+  assert_anchor_score(&ah, 1, 3);
+
   game_destroy(game);
   config_destroy(config);
 }


### PR DESCRIPTION
## What this does

WMP shadow recording already stores bounds in the slot for each tile count and word length. It now returns after that update, avoiding the additional global `highest_shadow_equity`, `highest_shadow_score`, and `max_tiles_to_play` reductions used by recursive move generation.

`shadow_record_impl` is specialized into WMP and recursive functions with constant mode arguments. The shared source keeps the score/equity calculation in one place, while each compiled function omits the other mode's work. `shadow_play_for_anchor` emits WMP slots before the recursive generator's zero-tile gate and checks the touched-slot count to avoid scanning an empty array.

WMP recording loads its tile count from the selected anchor before using it. Recursive generation and the small-move path retain their reductions. Per-slot bounds, cutoff checks and emission order are unchanged.

## Performance

Against `main` at `fb0fc7f7`: M4 Mac mini, CSW24, four workers, WIT enabled, production static-trained PGO, `simbench` 0.5 s/turn and two plies. Seeds 42/24301/1552 × six interleaved rounds, **18 pairs per configuration**, balanced AB/BA order within each seed. Results are geometric means of paired throughput ratios with seed-stratified bootstrap 95% CIs (20,000 resamples).

| configuration | this PR vs `main` | 95% CI |
|---|---:|---:|
| **WMP on, RIT on** | **+3.70%** | [+3.25%, +4.16%] |
| WMP on, RIT off | **+2.97%** | [+2.75%, +3.19%] |
| WMP off, RIT off | **+0.10%** | [-0.31%, +0.48%] |

All 36 WMP-enabled pairs improved. Both binaries were independently trained with `make release PGO_TRAIN_THREADS=4` on the production 16-game static workload, then held fixed. Configuration loading is excluded. All planned pairs were retained. These intervals describe run variation on this host with these binaries, not retraining or cross-hardware variation. The separate WMP-disabled campaign uses the same protocol and sample size; its interval spans zero, so it does not resolve a gain or regression. Host snapshots recorded no thermal warnings, but macOS File Provider was consuming substantial background CPU; the host was not otherwise idle. Balanced pairing helps account for run variation but cannot remove all background-load effects.

Supplementary `no_pgo_release` comparison: the same WMP/WIT-enabled workload, three seeds × two balanced rounds, **six pairs per RIT setting**, using paired-t 95% intervals:

| configuration | this PR vs `main` | 95% CI |
|---|---:|---:|
| non-PGO, RIT on | **+2.67%** | [+2.44%, +2.90%] |
| non-PGO, RIT off | **+2.81%** | [+1.62%, +4.01%] |

### Profiling: affected functions

The affected path is `generate_moves` → `gen_shadow` → `shadow_play_for_anchor` and its left/right exploration → shadow recording. Separate 20-second macOS `sample` captures used `BUILD=profile`, seed 42, four workers, 2 s/turn, and WMP/WIT/RIT on.

| function | baseline self samples | PR self samples |
|---|---:|---:|
| shadow recording (`shadow_record` / `shadow_record_wmp`) | 7,826 | 6,877 |
| `shadow_play_for_anchor` | 4,602 | 4,875 |
| `shadow_play_right` | 5,038 | 5,197 |

These captures locate the affected work; a single pair is not a per-function speedup measurement, and the profile build differs from production PGO. The repeated throughput comparison measures the net effect.

Production PGO assembly shows a 24-byte tail dispatch to the specialized record routines. The old shared routine has a 64-byte stack frame; WMP uses 48 bytes and recursive recording uses 32. Specialization changes inlining and increases the combined record-routine code from 1,432 to 2,980 bytes; the PGO test binary’s total `__text` section is 2,732 bytes smaller (1,414,316 → 1,411,584). The smaller frames are supporting evidence, not a standalone performance measurement.

Separate single-worker instrumentation of 16 CSW24 static games counts **100,935 WMP shadow records bypassing the three global reductions**, with 15,860 nonempty WMP emissions and 11,914 empty passes. Empty passes include cases already skipped by the original gate, so they are not an incremental scan-saving estimate. Counters are absent from timing binaries.

## Correctness

- **Strengthened default-suite regression:** `test_shadow_wmp_one_tile` checks legal one-tile playthrough anchors, reuses the generator on an empty position with no slot, and returns to the original position with the same expected bounds. One-square perpendicular shadows can legitimately have no slot in that orientation; the legal playthrough anchor is emitted in the other orientation.
- **Mutation check:** deliberately restoring the old `max_tiles_to_play == 0` gate ahead of WMP emission fails the shadow suite. The correct version passes.
- **Full recursive oracle:** 32 seeded CSW24 games, 712 positions and 967,104 complete moves per RIT/WIT combination on the PGO candidate. Move identity, score and equity agree in all four combinations.
- **Exact shadow bounds:** baseline and PR agree on all 116,902 anchors with RIT on and 124,595 with RIT off, WIT enabled, across the same 32 games. Anchor metadata and both score/equity bounds match.
- **State reuse and cutoffs:** ASan/UBSan `shadow`, `movegen`, `wmg`, `witdiff`, and `infer` suites pass with UBSan configured to halt on errors. These also exercise wordsmog, small moves and score sorting. WIT differential covers 32 games/723 positions before and after copy/undo.
- Formatting, circular dependencies, changed-file cppcheck and host-adapted clang-tidy pass; **all 17 CI checks pass** on `1ca54f01`, including board-21, optimized and sanitizer suites, WASM, lint, clang-tidy and cppcheck.

## What can build on this

The WMP slot array remains the authoritative source of bounds. Sparse emission can independently reduce the work inside `wmp_move_gen_add_anchors`; any change must preserve the existing slot order for deterministic ties. This PR keeps the current emission order and representation.
