### PR TITLE
Use root PVS for top-one endgame searches

### DIFF
--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -2473,6 +2473,14 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
   }
   const int multi_pv_k = worker->solver->num_top_moves;
   const bool multi_pv = is_root && multi_pv_k > 1;
+  // Multi-PV and reporting callbacks expose values for multiple root moves, so
+  // those callers need full-width searches at the root. A top-1 solve without
+  // either callback only needs the best move: later roots can use the normal
+  // PVS null-window probe and are re-searched at full width only if they
+  // improve alpha.
+  const bool exact_all_root_moves =
+      is_root && (multi_pv || worker->solver->per_ply_callback != NULL ||
+                  worker->solver->per_root_move_callback != NULL);
   // Sized for the live multi-PV leaderboard breadth (up to
   // MAX_ENDGAME_DISPLAY_PVS root moves), not the per-line depth. num_top_moves
   // is clamped to MAX_ENDGAME_DISPLAY_PVS in endgame_ctx_reset so topk_insert
@@ -2631,7 +2639,8 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
       // ID iteration. This gives accurate values for all root moves (needed for
       // multi-PV) while still benefiting from narrow windows.
       const bool use_root_aspiration =
-          is_root && depth >= 2 && worker->solver->iterative_deepening_optim &&
+          exact_all_root_moves && depth >= 2 &&
+          worker->solver->iterative_deepening_optim &&
           !worker->solver->first_win_optim &&
           !worker->solver->initial_window_optim;
 
@@ -2670,7 +2679,8 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
             break;
           }
         }
-      } else if (idx == 0 || !worker->solver->negascout_optim || is_root) {
+      } else if (idx == 0 || !worker->solver->negascout_optim ||
+                 exact_all_root_moves) {
         value =
             abdada_negamax(worker, child_key, depth - 1, -beta, -alpha,
                            &child_pv, pv_node, child_exclusive, opp_stuck_frac);
@@ -2947,7 +2957,15 @@ void iterative_deepening(EndgameCtxWorker *worker, int plies) {
   // value hasn't changed — result is stable and we can bank the remaining time.
   // INT32_MIN is the sentinel meaning "not yet crossed the soft limit".
   int32_t soft_limit_pv_value = INT32_MIN;
-  bool use_aspiration = (worker->solver->threads > 1);
+  // Single-thread multi-PV/per-root reporting already gives every root move a
+  // private aspiration window in abdada_negamax.  Top-1 searches use PVS at
+  // the root, so a narrow window around the preceding IDS value can prune the
+  // whole tree without sacrificing an exact result (failures are widened and
+  // re-searched below).
+  bool use_aspiration = worker->solver->threads > 1 ||
+                        (worker->solver->num_top_moves == 1 &&
+                         worker->solver->per_ply_callback == NULL &&
+                         worker->solver->per_root_move_callback == NULL);
 
   if (worker->solver->first_win_optim) {
     // search a very small window centered around 0; we're just trying to find

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -310,6 +310,14 @@ struct EndgameCtxWorker {
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #endif
 
+// These consumers need root values beyond the best move and must share the
+// same search-mode decision in root PVS and outer aspiration setup.
+static bool solver_needs_exact_root_values(const EndgameCtx *solver) {
+  return solver->num_top_moves > 1 || solver->actual_move != NULL ||
+         solver->per_ply_callback != NULL ||
+         solver->per_root_move_callback != NULL;
+}
+
 // Insert a value into a sorted (descending) top-K array.
 // Returns the Kth-best value (or -LARGE_VALUE if fewer than K values stored).
 static inline int32_t topk_insert(int32_t *topk, int *n, int k, int32_t val) {
@@ -2552,9 +2560,7 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
   // PVS null-window probe and are re-searched at full width only if they
   // improve alpha.
   const bool exact_all_root_moves =
-      is_root && (multi_pv || worker->solver->actual_move != NULL ||
-                  worker->solver->per_ply_callback != NULL ||
-                  worker->solver->per_root_move_callback != NULL);
+      is_root && solver_needs_exact_root_values(worker->solver);
   // Sized for the live multi-PV leaderboard breadth (up to
   // MAX_ENDGAME_DISPLAY_PVS root moves), not the per-line depth. num_top_moves
   // is clamped to MAX_ENDGAME_DISPLAY_PVS in endgame_ctx_reset so topk_insert
@@ -3007,11 +3013,9 @@ void iterative_deepening(EndgameCtxWorker *worker, int plies) {
   // the root, so a narrow window around the preceding IDS value can prune the
   // whole tree without sacrificing an exact result (failures are widened and
   // re-searched below).
-  bool use_aspiration = worker->solver->threads > 1 ||
-                        (worker->solver->num_top_moves == 1 &&
-                         worker->solver->actual_move == NULL &&
-                         worker->solver->per_ply_callback == NULL &&
-                         worker->solver->per_root_move_callback == NULL);
+  const bool use_aspiration = worker->solver->threads > 1 ||
+                              (worker->solver->num_top_moves == 1 &&
+                               !solver_needs_exact_root_values(worker->solver));
 
   if (worker->solver->first_win_optim) {
     // search a very small window centered around 0; we're just trying to find
@@ -3585,9 +3589,12 @@ static int extract_multi_pvs(EndgameCtx *solver, EndgameCtxWorker *best_worker,
   const int num_lines = (num_top < num_root_moves) ? num_top : num_root_moves;
   SmallMove *root_moves = (SmallMove *)best_worker->small_move_arena->memory;
 
-  // The estimated_value of each root move is the negamax value the search
-  // returned for it (small_move_set_estimated_value(small_move, -value) in
-  // the root move loop).
+  // Root estimated values can be fail-soft bounds. In top-one PVS mode,
+  // later roots that fail low retain upper bounds for next-iteration ordering.
+  // This extractor is only called for num_top_moves > 1, which selects
+  // solver_needs_exact_root_values and excludes that top-one PVS path.
+  // Multi-PV cutoffs and interrupted depths can still leave bounds or mixed
+  // depths; the sorting and full-window resolution below handle those cases.
 
   // Ensure the displayed best move is at root_moves[0] to avoid duplicates.
   // qsort is not stable, so tied values may place it elsewhere.

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -2545,6 +2545,14 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
   }
   const int multi_pv_k = worker->solver->num_top_moves;
   const bool multi_pv = is_root && multi_pv_k > 1;
+  // Multi-PV and reporting callbacks expose values for multiple root moves, so
+  // those callers need full-width searches at the root. A top-1 solve without
+  // either callback only needs the best move: later roots can use the normal
+  // PVS null-window probe and are re-searched at full width only if they
+  // improve alpha.
+  const bool exact_all_root_moves =
+      is_root && (multi_pv || worker->solver->per_ply_callback != NULL ||
+                  worker->solver->per_root_move_callback != NULL);
   // Sized for the live multi-PV leaderboard breadth (up to
   // MAX_ENDGAME_DISPLAY_PVS root moves), not the per-line depth. num_top_moves
   // is clamped to MAX_ENDGAME_DISPLAY_PVS in endgame_ctx_reset so topk_insert
@@ -2657,7 +2665,8 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
       // ID iteration. This gives accurate values for all root moves (needed for
       // multi-PV) while still benefiting from narrow windows.
       const bool use_root_aspiration =
-          is_root && depth >= 2 && worker->solver->iterative_deepening_optim &&
+          exact_all_root_moves && depth >= 2 &&
+          worker->solver->iterative_deepening_optim &&
           !worker->solver->first_win_optim &&
           !worker->solver->initial_window_optim;
 
@@ -2696,7 +2705,8 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
             break;
           }
         }
-      } else if (idx == 0 || !worker->solver->negascout_optim || is_root) {
+      } else if (idx == 0 || !worker->solver->negascout_optim ||
+                 exact_all_root_moves) {
         value =
             abdada_negamax(worker, child_key, depth - 1, -beta, -alpha,
                            &child_pv, pv_node, child_exclusive, opp_stuck_frac);
@@ -2990,7 +3000,15 @@ void iterative_deepening(EndgameCtxWorker *worker, int plies) {
   // value hasn't changed — result is stable and we can bank the remaining time.
   // INT32_MIN is the sentinel meaning "not yet crossed the soft limit".
   int32_t soft_limit_pv_value = INT32_MIN;
-  bool use_aspiration = (worker->solver->threads > 1);
+  // Single-thread multi-PV/per-root reporting already gives every root move a
+  // private aspiration window in abdada_negamax.  Top-1 searches use PVS at
+  // the root, so a narrow window around the preceding IDS value can prune the
+  // whole tree without sacrificing an exact result (failures are widened and
+  // re-searched below).
+  bool use_aspiration = worker->solver->threads > 1 ||
+                        (worker->solver->num_top_moves == 1 &&
+                         worker->solver->per_ply_callback == NULL &&
+                         worker->solver->per_root_move_callback == NULL);
 
   if (worker->solver->first_win_optim) {
     // search a very small window centered around 0; we're just trying to find

--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -2545,13 +2545,15 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
   }
   const int multi_pv_k = worker->solver->num_top_moves;
   const bool multi_pv = is_root && multi_pv_k > 1;
-  // Multi-PV and reporting callbacks expose values for multiple root moves, so
+  // Multi-PV, actual-move extraction, and reporting callbacks expose values
+  // for multiple root moves, so
   // those callers need full-width searches at the root. A top-1 solve without
   // either callback only needs the best move: later roots can use the normal
   // PVS null-window probe and are re-searched at full width only if they
   // improve alpha.
   const bool exact_all_root_moves =
-      is_root && (multi_pv || worker->solver->per_ply_callback != NULL ||
+      is_root && (multi_pv || worker->solver->actual_move != NULL ||
+                  worker->solver->per_ply_callback != NULL ||
                   worker->solver->per_root_move_callback != NULL);
   // Sized for the live multi-PV leaderboard breadth (up to
   // MAX_ENDGAME_DISPLAY_PVS root moves), not the per-line depth. num_top_moves
@@ -3007,6 +3009,7 @@ void iterative_deepening(EndgameCtxWorker *worker, int plies) {
   // re-searched below).
   bool use_aspiration = worker->solver->threads > 1 ||
                         (worker->solver->num_top_moves == 1 &&
+                         worker->solver->actual_move == NULL &&
                          worker->solver->per_ply_callback == NULL &&
                          worker->solver->per_root_move_callback == NULL);
 

--- a/test/benchmark_endgame_test.c
+++ b/test/benchmark_endgame_test.c
@@ -989,12 +989,14 @@ void test_endgame_root_bench(void) {
         continue;
       }
       char *cgp = game_get_cgp(game, true);
-      assert(fprintf(output, "%s\n", cgp) > 0);
+      const int written = fprintf(output, "%s\n", cgp);
+      assert(written > 0);
       free(cgp);
       found++;
     }
     assert(found == count);
-    assert(fclose(output) == 0);
+    const int close_status = fclose(output);
+    assert(close_status == 0);
     move_list_destroy(moves);
     config_destroy(config);
     return;
@@ -1003,7 +1005,8 @@ void test_endgame_root_bench(void) {
   assert(input != NULL);
   char cgp[4096];
   for (int position = 0; position < count; position++) {
-    assert(fgets(cgp, sizeof(cgp), input) != NULL);
+    const char *line = fgets(cgp, sizeof(cgp), input);
+    assert(line != NULL);
     ErrorStack *errors = error_stack_create();
     game_load_cgp(game, cgp, errors);
     assert(error_stack_is_empty(errors));
@@ -1025,6 +1028,10 @@ void test_endgame_root_bench(void) {
     };
     Timer timer;
     ctimer_start(&timer);
+    if (args.hard_time_limit > 0) {
+      args.external_deadline_ns =
+          ctimer_monotonic_ns() + (int64_t)(args.hard_time_limit * 1e9);
+    }
     endgame_solve(&solver, &args, results, errors);
     const double elapsed = ctimer_elapsed_seconds(&timer);
     assert(error_stack_is_empty(errors));
@@ -1042,6 +1049,7 @@ void test_endgame_root_bench(void) {
     endgame_results_destroy(results);
     error_stack_destroy(errors);
   }
-  assert(fclose(input) == 0);
+  const int close_status = fclose(input);
+  assert(close_status == 0);
   config_destroy(config);
 }

--- a/test/benchmark_endgame_test.c
+++ b/test/benchmark_endgame_test.c
@@ -944,3 +944,104 @@ void test_endgame_move1(void) {
   endgame_results_destroy(results);
   config_destroy(config);
 }
+
+// Reproducible corpus and solver measurements for root-search changes. Each
+// record is a separate solve with a fresh TT; output includes values and moves
+// so timing comparisons cannot silently hide changed answers.
+void test_endgame_root_bench(void) {
+  log_set_level(LOG_FATAL);
+  const char *path = getenv("MAGPIE_ROOT_FILE");
+  assert(path != NULL);
+  const int count = env_int("MAGPIE_ROOT_COUNT", 64);
+  const int threads = env_int("MAGPIE_ROOT_THREADS", 1);
+  char settings[256];
+  (void)snprintf(settings, sizeof(settings),
+                 "set -lex CSW24 -threads %d -wmp true -rit true -wit true "
+                 "-s1 equity -s2 equity",
+                 threads);
+  Config *config = config_create_or_die(settings);
+  exec_config_quiet(config, "new");
+  Game *game = config_get_game(config);
+  if (env_int("MAGPIE_ROOT_GENERATE", 0)) {
+    FILE *output = fopen(path, "we");
+    assert(output != NULL);
+    MoveList *moves = move_list_create(1);
+    int found = 0;
+    const int seed = env_int("MAGPIE_ROOT_SEED", 420000103);
+    for (int attempt = 0; found < count && attempt < count * 100; attempt++) {
+      game_reset(game);
+      game_seed(game, (uint64_t)seed + (uint64_t)attempt);
+      draw_starting_racks(game);
+      if (!play_until_bag_empty(game, moves)) {
+        continue;
+      }
+      if (env_int("MAGPIE_ROOT_SMALL", 0)) {
+        while (
+            rack_get_total_letters(player_get_rack(game_get_player(game, 0))) +
+                    rack_get_total_letters(
+                        player_get_rack(game_get_player(game, 1))) >
+                6 &&
+            game_get_game_end_reason(game) == GAME_END_REASON_NONE) {
+          play_move(get_top_equity_move(game, moves), game, NULL);
+        }
+      }
+      if (game_get_game_end_reason(game) != GAME_END_REASON_NONE) {
+        continue;
+      }
+      char *cgp = game_get_cgp(game, true);
+      assert(fprintf(output, "%s\n", cgp) > 0);
+      free(cgp);
+      found++;
+    }
+    assert(found == count);
+    assert(fclose(output) == 0);
+    move_list_destroy(moves);
+    config_destroy(config);
+    return;
+  }
+  FILE *input = fopen(path, "re");
+  assert(input != NULL);
+  char cgp[4096];
+  for (int position = 0; position < count; position++) {
+    assert(fgets(cgp, sizeof(cgp), input) != NULL);
+    ErrorStack *errors = error_stack_create();
+    game_load_cgp(game, cgp, errors);
+    assert(error_stack_is_empty(errors));
+    EndgameCtx *solver = NULL;
+    EndgameResults *results = endgame_results_create();
+    EndgameArgs args = {
+        .game = game,
+        .thread_control = config_get_thread_control(config),
+        .plies = env_int("MAGPIE_ROOT_PLIES", 4),
+        .tt_fraction_of_mem = 0.01,
+        .initial_small_move_arena_size = DEFAULT_INITIAL_SMALL_MOVE_ARENA_SIZE,
+        .num_threads = threads,
+        .num_top_moves = env_int("MAGPIE_ROOT_TOPK", 1),
+        .use_heuristics = true,
+        .forced_pass_bypass = true,
+        .first_win = env_int("MAGPIE_ROOT_FIRSTWIN", 0) != 0,
+        .hard_time_limit = env_double("MAGPIE_ROOT_SECONDS", 0),
+        .seed = 42,
+    };
+    Timer timer;
+    ctimer_start(&timer);
+    endgame_solve(&solver, &args, results, errors);
+    const double elapsed = ctimer_elapsed_seconds(&timer);
+    assert(error_stack_is_empty(errors));
+    const PVLine *pv = endgame_results_get_pvline(results, ENDGAME_RESULT_BEST);
+    printf(
+        "ROOTROW %d value=%d spread=%d depth=%d nodes=%llu seconds=%.9f "
+        "move=%llu\n",
+        position, pv->score,
+        endgame_results_get_spread(results, ENDGAME_RESULT_BEST, game),
+        endgame_results_get_depth(results, ENDGAME_RESULT_BEST),
+        (unsigned long long)endgame_ctx_get_nodes_searched(solver), elapsed,
+        (unsigned long long)(pv->num_moves > 0 ? pv->moves[0].tiny_move : 0));
+    (void)fflush(stdout);
+    endgame_ctx_destroy(solver);
+    endgame_results_destroy(results);
+    error_stack_destroy(errors);
+  }
+  assert(fclose(input) == 0);
+  config_destroy(config);
+}

--- a/test/benchmark_endgame_test.h
+++ b/test/benchmark_endgame_test.h
@@ -11,4 +11,6 @@ void test_endgame_speed_bench(void);
 void test_endgame_playout_bench(void);
 void test_endgame_move1(void);
 
+void test_endgame_root_bench(void);
+
 #endif

--- a/test/endgame_test.c
+++ b/test/endgame_test.c
@@ -1488,7 +1488,63 @@ void test_endgame_progress_stream(void) {
   prng_destroy(prng);
 }
 
+// An actual historical move can be much worse than the best root. Its value
+// must remain exact even when top-1 searches use an outer aspiration window.
+static void test_root_pvs_actual_pass(void) {
+  Config *config = config_create_or_die("set -lex CSW24 -threads 1");
+  load_and_exec_config_or_die(
+      config, "cgp 2ABERRaNT4G/5HE6FE/5OS5CUR/5DI5OMA/1HARPIST4WEN/"
+              "5ET2Q3TI/6E1VIVO2A/4JUDY2ABOIL/4I2ERASERS1/1DOWLY8M/"
+              "4TaLEGGIO2I/7Z6C/7I3PUNK/7NONTONAL/7E2AX2E AD/EFU 467/497 0");
+  Game *game = config_get_game(config);
+  Move pass_move;
+  move_set_as_pass(&pass_move);
+  EndgameArgs args = {
+      .game = game,
+      .thread_control = config_get_thread_control(config),
+      .plies = 10,
+      .tt_fraction_of_mem = 0.0001,
+      .initial_small_move_arena_size = DEFAULT_INITIAL_SMALL_MOVE_ARENA_SIZE,
+      .num_threads = 1,
+      .num_top_moves = 1,
+      .use_heuristics = true,
+      .forced_pass_bypass = true,
+      .seed = 42,
+  };
+  EndgameResults *results = endgame_results_create();
+  EndgameCtx *solver = NULL;
+  ErrorStack *errors = error_stack_create();
+  endgame_solve(&solver, &args, results, errors);
+  assert(error_stack_is_empty(errors));
+  const int32_t best_value =
+      endgame_results_get_value(results, ENDGAME_RESULT_BEST);
+  args.actual_move = &pass_move;
+  endgame_solve(&solver, &args, results, errors);
+  assert(error_stack_is_empty(errors));
+  assert(endgame_results_get_actual_move_found(results));
+  assert(endgame_results_get_value(results, ENDGAME_RESULT_BEST) == best_value);
+  const int32_t pass_value =
+      endgame_results_get_value(results, ENDGAME_RESULT_ACTUAL);
+  assert(pass_value < best_value);
+  // Independent child solve: after our pass the opponent owns the move, so
+  // negate its net spread change to obtain the exact value of our pass.
+  play_move(&pass_move, game, NULL);
+  args.actual_move = NULL;
+  args.plies--;
+  endgame_ctx_destroy(solver);
+  solver = NULL;
+  endgame_solve(&solver, &args, results, errors);
+  assert(error_stack_is_empty(errors));
+  assert(pass_value ==
+         -endgame_results_get_value(results, ENDGAME_RESULT_BEST));
+  endgame_ctx_destroy(solver);
+  endgame_results_destroy(results);
+  error_stack_destroy(errors);
+  config_destroy(config);
+}
+
 void test_endgame(void) {
+  test_root_pvs_actual_pass();
   test_before_search_callback();
   test_single_pv_display();
   test_ctx_reuse();

--- a/test/test.c
+++ b/test/test.c
@@ -180,6 +180,7 @@ static TestEntry on_demand_test_table[] = {
     {"benchns", test_benchmark_nonstuck},
     {"benchns3v3", test_benchmark_nonstuck_3v3},
     {"egspeedbench", test_endgame_speed_bench},
+    {"egrootbench", test_endgame_root_bench},
     {"egplayout", test_endgame_playout_bench},
     {"egmove1", test_endgame_move1},
     {"multipv", test_multi_pv},


### PR DESCRIPTION
## What this does

Use principal-variation search at the root when only the best endgame move is requested. After the first move, later moves receive a null-window probe and are searched again with a wider window when they improve alpha. Single-thread top-one searches also use an aspiration window around the previous completed depth's value, widening and re-searching failures.

Multi-PV, per-ply/per-root reporting, and historical actual-move extraction retain their existing search paths. Actual-move callers are excluded from the new single-thread aspiration path so a low-valued played move is not reported as a bound.

## Performance

**+6.44% geometric-mean speedup; +2.54% paired median.** Measured against main `64019d5d` on an Apple M4 Mac mini (10 cores, 16 GiB), macOS 15.7.4, Apple Clang 17. Both sources received independent production PGO training from 16 static CSW24 games with four training workers. WMP/RIT/WIT were enabled with identical CSW24 assets.

The primary workload contains **64 fresh, unfiltered bag-empty positions**, generated by static-equity self-play with seed `420000103`. Four paired rounds alternate whole-arm order. Each solve uses one thread, depth four, seed 42, and a fresh owned TT (256 MiB minimum). Solver allocation/reset is timed; configuration/data loading and destruction are outside the timer. All 512 timed solves are retained.

| Measurement | Result |
|---|---:|
| Geometric mean of per-position median speed ratios | **+6.44%** |
| Nominal paired 95% interval | **[+2.98%, +10.02%]** |
| Median across positions | **+2.54%** |
| Positions favoring this change | **48/64** |
| Per-position range | −6.55% to +103.27% |
| Total-time speedup across all four rounds | +8.13% |
| Nodes per full corpus | 38,634,528 → 36,458,119 (**−5.63%**) |

The interval is a Student-t interval over 64 paired log ratios, using each position's median ratio across rounds. Repeated rounds are not treated as independent positions. Background iCloud activity occupied roughly one core in boundary snapshots; continuous thermal/frequency telemetry was not collected. These figures describe this host and pair of trained binaries, not cross-hardware or repeated-training uncertainty.

Secondary controls are descriptive single paired runs:

- Eight-thread depth-four corpus: 73.77 → 62.26 seconds, with all 64 values matching. Parallel scheduling adds variability, so this is not the headline estimate.
- Top-three depth-three control: 115.44 → 115.84 seconds, with identical nodes, values, and moves. The optimization is disabled for this path.
- Sixty-four fresh small positions (at most six rack tiles): values agree at both 12 and 24 plies; geometric speedups are +1.60% and +1.74%. Stability across these depths is not a terminal-proof claim.
- Eight-thread, 100 ms deadline control: the candidate completes a greater depth on 30/64 positions, main on none. This measures progress, not decision quality against an oracle.

Primary timing/profiles use engine commit `fc7143b1`. Final head `fc6dff1d` changes only the benchmark driver to enforce timed-control deadlines and keep I/O outside assertions. The corrected deadline control was measured separately; its raw results are distinct from the fixed-depth campaign.

### Profiling: affected functions

Six captures sample the frozen production-PGO executables for six seconds each, after one second of startup, using three corpus rotations. Exclusive shares among named engine leaf samples were:

| Function/path | Main | This PR |
|---|---:|---:|
| `recursive_gen_small` + `go_on_small` | 34.44% | 33.54% |
| `shadow_play_for_anchor_small`, `shadow_play_right_small`, `shadow_by_orientation_small` | 28.64% | 28.55% |
| `game_gen_cross_set` + `game_gen_cross_set_tracked` | 10.06% | 10.50% |
| `abdada_negamax` + `negamax_greedy_leaf_playout` self | 2.20% | 2.03% |

`abdada_negamax` and `iterative_deepening` change the search windows; the benefit comes from visiting fewer descendants. Small-move generation, shadow, and cross-set updates dominate the remaining search work. Their implementations are unchanged. These normalized sample shares are not per-function speedups or call counts; fixed capture windows can cover different roots. System/wait samples and functions with fewer than five samples per capture are excluded from this table.

## Correctness

- All **256 primary paired values** agree; all 64 parallel values agree.
- Different selected moves occur at two primary positions and seven parallel positions. Sixteen independent main-branch actual-move solves verify every distinct selected move is tied with the best value at the measured depth.
- Optimized and ASan/UBSan endgame suites pass, including existing reporting, multi-PV, interruption, and dual-lexicon coverage.
- A new default-suite regression compares a historical pass with an independently solved child position. Removing the actual-move exclusions makes that regression fail at the expected value assertion.
- Full cppcheck 2.17.1, formatting, dependency-cycle checks, and `git diff --check` pass. Full platform CI is attached to the PR.

The on-demand `egrootbench` driver supports reproducible corpus generation and fixed-depth/deadline controls. Use the same driver on both sources, fresh PGO profiles, and separate TTs.

## What can build on this

Root ordering and aspiration-width tuning may reduce re-searches further. Any follow-up should retain the actual-move/reporting exclusions and measure nodes, elapsed time, and completed values independently.
