### PR TITLE
Tolerate print-quantum jitter in fast-TC sim budget audit

### DIFF
--- a/tools/run_time_manager_match.py
+++ b/tools/run_time_manager_match.py
@@ -505,13 +505,19 @@ def parse_pair(
         if policy == "timemanager" and mode == "sim":
             planned = float(turn["budget_ms"])
             legacy = float(turn["legacy_budget_ms"])
-            assert planned + 0.001 >= legacy, (
+            # Budgets are printed to 0.001 ms, so a truly-equal planned/legacy
+            # pair can differ by one print quantum; at fast time controls the
+            # tiny per-turn budgets sit exactly on that boundary. Tolerate 0.01
+            # ms (well above the quantum + IEEE754 slack, far below any real
+            # ms-scale shortening) so a 1 us artifact is not read as the
+            # TimeManager shortening the sim below the equal slice.
+            assert planned + 0.01 >= legacy, (
                 f"TimeManager shortened sim budget at game {turn['game']} "
                 f"turn {turn['turn']}: {planned} < {legacy}"
             )
             tm_sim_planned_budget_ms += planned
             tm_sim_legacy_budget_ms += legacy
-            if planned > legacy + 0.001:
+            if planned > legacy + 0.01:
                 tm_sim_released_turns += 1
         if (
             policy == "timemanager"


### PR DESCRIPTION
## Summary

- The match runner's sim-budget audit asserted `planned + 0.001 >= legacy`, exactly one print quantum (budgets are printed to 0.001 ms). At fast time controls (e.g. game in 15s) per-turn budgets are ~1.2s and a truly equal planned/legacy pair can land on the quantum boundary, where IEEE-754 rounding trips the assertion on a 1 microsecond artifact: `1255.293 < 1255.294`.
- Raise the tolerance to 0.01 ms (well above the quantum + rounding slack, far below any real ms-scale budget shortening) and use the same threshold for the released-turn counter.

## Testing

- Before: `--clock-ms 15000` aborts on pair 1 with the assertion above.
- After: 30-pair pilots at both 180s and 15s clocks complete with `trace_audit=pass`, zero penalties/drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014H9CrHHEadpFHs9wYHEjbS