### PR TITLE
Record Rule-of-Zero risk-set membership at checkpoints

### DIFF
--- a/src/ent/analysis_progress.h
+++ b/src/ent/analysis_progress.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#define ANALYSIS_PROGRESS_SCHEMA_VERSION 6U
+#define ANALYSIS_PROGRESS_SCHEMA_VERSION 7U
 #define ANALYSIS_PROGRESS_ELAPSED_NOW INT64_C(-1)
 #define ANALYSIS_PROGRESS_CPU_NOW INT64_C(-1)
 #define ANALYSIS_PROGRESS_SCORE_SPREAD_UNSET INT32_MIN
@@ -133,6 +133,15 @@ typedef struct AnalysisProgressEvent {
   // reaches the incumbent. SIM populates this at checkpoints and FINISH;
   // other solvers leave it at -1.
   int near_tie_challengers;
+  // Risk-set membership bitmask matching near_tie_challengers: bit arm_index
+  // is set for each counted near-tie challenger (arm indices 0..63; the
+  // incumbent's bit is never set — it is implicit via best_index). Arms at
+  // index 64 and above cannot be represented; the count stays authoritative.
+  // SIM populates this on CHECKPOINT events only (FINISH reports the count
+  // recorded at stop and leaves the mask 0); other solvers leave it 0. Bits
+  // are raw BAI arm indices — consumers that need candidate ranks must remap
+  // through their own arm-to-rank tables (see the thinking-curve harness).
+  uint64_t near_tie_member_mask;
 
   // Copy-safe identity for the event's move/arm. SIM uses the arm index,
   // endgame uses tiny_move, and PEG/PlayChooser use a stable Move fingerprint.

--- a/src/ent/analysis_trace.c
+++ b/src/ent/analysis_trace.c
@@ -120,30 +120,30 @@ bool analysis_trace_write_tsv(AnalysisTrace *trace, FILE *stream) {
   cpthread_mutex_unlock(&trace->mutex);
 
   bool ok =
-      fprintf(
-          stream,
-          "schema_version\tsequence\trun_id\tparent_run_id\tmode\tevent\t"
-          "status\t"
-          "elapsed_ns\tcpu_ns\tbudget_seconds\tworkers\twork_units\tnodes\t"
-          "iterations\tscenarios\titem_work_units\titem_nodes\t"
-          "expected_next_work_units\tcompletion_bound_work_units\t"
-          "expected_next_nodes\tcompletion_bound_nodes\t"
-          "expected_next_scenarios\tcompletion_bound_scenarios\t"
-          "expected_next_candidates\tcompletion_bound_candidates\t"
-          "expected_next_seconds\tcompletion_bound_seconds\t"
-          "completion_confidence\tadmission\t"
-          "admission_safe_to_enforce\tadmission_enforced\t"
-          "has_time_manager_plan\texpected_regret_reduction\t"
-          "current_value_per_second\tfuture_value_per_second\t"
-          "maximum_current_seconds\tdeposit_seconds\tphase\t"
-          "depth\tcandidate_index\t"
-          "candidates_completed\tcandidates_total\t"
-          "subcandidates_completed\tsubcandidates_total\tbest_index\t"
-          "challenger_index\tnear_tie_challengers\titem_id\tvalue\tbest_value\t"
-          "challenger_value\tsecondary_value\tplayer_on_turn\tbag_tiles\t"
-          "player_rack_tiles\topponent_rack_tiles\t"
-          "consecutive_scoreless_turns\t"
-          "score_spread\tclock_seconds_remaining\n") >= 0;
+      fprintf(stream,
+              "schema_version\tsequence\trun_id\tparent_run_id\tmode\tevent\t"
+              "status\t"
+              "elapsed_ns\tcpu_ns\tbudget_seconds\tworkers\twork_units\tnodes\t"
+              "iterations\tscenarios\titem_work_units\titem_nodes\t"
+              "expected_next_work_units\tcompletion_bound_work_units\t"
+              "expected_next_nodes\tcompletion_bound_nodes\t"
+              "expected_next_scenarios\tcompletion_bound_scenarios\t"
+              "expected_next_candidates\tcompletion_bound_candidates\t"
+              "expected_next_seconds\tcompletion_bound_seconds\t"
+              "completion_confidence\tadmission\t"
+              "admission_safe_to_enforce\tadmission_enforced\t"
+              "has_time_manager_plan\texpected_regret_reduction\t"
+              "current_value_per_second\tfuture_value_per_second\t"
+              "maximum_current_seconds\tdeposit_seconds\tphase\t"
+              "depth\tcandidate_index\t"
+              "candidates_completed\tcandidates_total\t"
+              "subcandidates_completed\tsubcandidates_total\tbest_index\t"
+              "challenger_index\tnear_tie_challengers\tnear_tie_member_mask\t"
+              "item_id\tvalue\tbest_value\t"
+              "challenger_value\tsecondary_value\tplayer_on_turn\tbag_tiles\t"
+              "player_rack_tiles\topponent_rack_tiles\t"
+              "consecutive_scoreless_turns\t"
+              "score_spread\tclock_seconds_remaining\n") >= 0;
   for (size_t i = 0; ok && i < count; i++) {
     const AnalysisProgressEvent *event = &events[i];
     ok = fprintf(stream,
@@ -185,15 +185,16 @@ bool analysis_trace_write_tsv(AnalysisTrace *trace, FILE *stream) {
                  event->candidates_total, event->subcandidates_completed,
                  event->subcandidates_total, event->best_index,
                  event->challenger_index, event->near_tie_challengers) >= 0;
-    ok = ok && fprintf(stream,
-                       "\t%" PRIu64 "\t%.17g\t%.17g\t%.17g\t%.17g"
-                       "\t%d\t%d\t%d\t%d\t%d\t%d\t%.17g\n",
-                       event->item_id, event->value, event->best_value,
-                       event->challenger_value, event->secondary_value,
-                       event->player_on_turn, event->bag_tiles,
-                       event->player_rack_tiles, event->opponent_rack_tiles,
-                       event->consecutive_scoreless_turns, event->score_spread,
-                       event->clock_seconds_remaining) >= 0;
+    ok = ok &&
+         fprintf(stream,
+                 "\t%" PRIu64 "\t%" PRIu64 "\t%.17g\t%.17g\t%.17g\t%.17g"
+                 "\t%d\t%d\t%d\t%d\t%d\t%d\t%.17g\n",
+                 event->near_tie_member_mask, event->item_id, event->value,
+                 event->best_value, event->challenger_value,
+                 event->secondary_value, event->player_on_turn,
+                 event->bag_tiles, event->player_rack_tiles,
+                 event->opponent_rack_tiles, event->consecutive_scoreless_turns,
+                 event->score_spread, event->clock_seconds_remaining) >= 0;
   }
   free(events);
   return ok;

--- a/src/impl/bai.h
+++ b/src/impl/bai.h
@@ -439,10 +439,20 @@ bai_estimate_joint_expected_regret(const BAISyncData *bai_sync_data,
 
 // Number of challengers whose two-sided 99% Gaussian upper confidence bound
 // on U_i - U_astar reaches zero. This is a diagnostic for the dimension of the
-// live near-tie set, not a stopping rule.
+// live near-tie set, not a stopping rule. When mask_out is non-NULL it
+// additionally receives the risk-set membership bitmask: bit arm_index set for
+// each counted challenger (arm indices 0..63; the incumbent's own bit is never
+// set — it is implicit via best_index). Arms at index 64 and above cannot be
+// represented in the mask; the count remains authoritative and such arms only
+// affect the count. On missing minimum evidence the mask is 0 and the count is
+// -1, matching the existing fail-closed convention.
 static inline int
-bai_count_near_tie_challengers(const BAISyncData *bai_sync_data) {
+bai_count_near_tie_challengers_with_mask(const BAISyncData *bai_sync_data,
+                                         uint64_t *mask_out) {
   static const double z_99_two_sided = 2.5758293035489004;
+  if (mask_out != NULL) {
+    *mask_out = 0;
+  }
   if (!bai_regret_has_minimum_evidence(bai_sync_data)) {
     return -1;
   }
@@ -459,9 +469,17 @@ bai_count_near_tie_challengers(const BAISyncData *bai_sync_data) {
         bai_difference_standard_deviation(bai_sync_data, best_index, arm_index);
     if (difference_mean + z_99_two_sided * difference_sd >= 0.0) {
       count++;
+      if (mask_out != NULL && arm_index < 64) {
+        *mask_out |= ((uint64_t)1 << arm_index);
+      }
     }
   }
   return count;
+}
+
+static inline int
+bai_count_near_tie_challengers(const BAISyncData *bai_sync_data) {
+  return bai_count_near_tie_challengers_with_mask(bai_sync_data, NULL);
 }
 
 static inline double bai_regret_stop_estimate(const BAISyncData *bai_sync_data,
@@ -877,7 +895,8 @@ bai_sync_data_add_sample_with_progress(BAISampleArgs *args, const int arm_index,
     progress.value = bai_estimate_expected_regret(sync_data, args->rvs);
     progress.secondary_value =
         bai_estimate_joint_expected_regret(sync_data, args->rvs);
-    progress.near_tie_challengers = bai_count_near_tie_challengers(sync_data);
+    progress.near_tie_challengers = bai_count_near_tie_challengers_with_mask(
+        sync_data, &progress.near_tie_member_mask);
     const uint64_t interval = sync_data->progress_listener->checkpoint_interval;
     do {
       const uint64_t old_next = sync_data->next_progress_sample;

--- a/src/impl/endgame_admission_model_default_data.h
+++ b/src/impl/endgame_admission_model_default_data.h
@@ -162,7 +162,10 @@ static const EndgameAdmissionDepthModel
 static const EndgameAdmissionModel ENDGAME_ADMISSION_DEFAULT_MODEL = {
     .artifact_version = ENDGAME_ADMISSION_MODEL_ARTIFACT_VERSION,
     .feature_schema_version = ENDGAME_ADMISSION_FEATURE_SCHEMA_VERSION,
-    .source_progress_schema_version = ANALYSIS_PROGRESS_SCHEMA_VERSION,
+    // Provenance: this artifact was calibrated from schema-6 progress events.
+    // Pinned rather than tracking ANALYSIS_PROGRESS_SCHEMA_VERSION so later
+    // additive schema bumps do not silently misdescribe the training source.
+    .source_progress_schema_version = 6U,
     .artifact_id = "csw24-eg-ridge-p99-10t-v1-20260729",
     .workers = 10,
     .tt_fraction_of_mem = 0.050000000000000003,

--- a/test/thinking_curve_test.c
+++ b/test/thinking_curve_test.c
@@ -838,6 +838,22 @@ thinking_curve_normalize_checkpoint(AnalysisProgressEvent *checkpoint,
     checkpoint->item_id =
         move_get_fingerprint(&candidates[checkpoint->best_index].move);
   }
+  // Remap the risk-set membership bitmask from BAI arm-index bits to
+  // statically sorted candidate-rank bits, matching the other normalized
+  // indices. After this call the mask's bits are candidate ranks.
+  uint64_t rank_mask = 0;
+  for (int arm_index = 0; arm_index < num_plays && arm_index < 64;
+       arm_index++) {
+    if ((checkpoint->near_tie_member_mask & ((uint64_t)1 << arm_index)) == 0) {
+      continue;
+    }
+    const int rank =
+        thinking_curve_checkpoint_rank(arm_index, rank_by_arm, num_plays);
+    if (rank >= 0 && rank < 64) {
+      rank_mask |= ((uint64_t)1 << rank);
+    }
+  }
+  checkpoint->near_tie_member_mask = rank_mask;
 }
 
 static ThinkingCurveJudgeResult thinking_curve_run_judge(
@@ -1121,6 +1137,16 @@ static void thinking_curve_print_rule_zero_checkpoints(
                           checkpoint->nodes >= minimum_nodes &&
                           stable_checkpoints >= minimum_stable_checkpoints &&
                           checkpoint->near_tie_challengers == 0;
+    // Risk-set membership (packet section 6): the mask holds candidate-rank
+    // bits after normalization; the incumbent is implicit via selected_rank.
+    // The full-horizon selection is in the risk set when it is the incumbent
+    // itself or a near-tie challenger at this checkpoint.
+    const int full_rank = result->decision.best_index;
+    const bool full_in_risk_set =
+        counters_valid && full_rank >= 0 &&
+        (full_rank == selected ||
+         (full_rank < 64 && (checkpoint->near_tie_member_mask &
+                             ((uint64_t)1 << full_rank)) != 0));
     printf("THINKING_CURVE_RULE_ZERO_CHECKPOINT source_index=%d position=%d "
            "game=%d bag=%d plies=%d arm_plays=%d checkpoint=%zu "
            "iterations=%" PRIu64 " nodes=%" PRIu64
@@ -1130,7 +1156,8 @@ static void thinking_curve_print_rule_zero_checkpoints(
            "estimated_best=%.12f estimated_challenger=%.12f "
            "estimated_regret=%.12f joint_estimated_regret=%.12f "
            "near_tie_challengers=%d counters_valid=%d rule_eligible=%d "
-           "rule_selected=%d\n",
+           "rule_selected=%d risk_set_ranks=0x%" PRIx64
+           " full_horizon_rank_in_risk_set=%d\n",
            source_index, position, game_index, bag_tiles, plies, num_plays,
            index, checkpoint->iterations, checkpoint->nodes, selected,
            checkpoint->item_id, stable_checkpoints, stable_iterations,
@@ -1138,7 +1165,8 @@ static void thinking_curve_print_rule_zero_checkpoints(
            checkpoint->best_value, checkpoint->challenger_value,
            checkpoint->value, checkpoint->secondary_value,
            checkpoint->near_tie_challengers, counters_valid, eligible,
-           !stop->capped && index == stop->checkpoint_index);
+           !stop->capped && index == stop->checkpoint_index,
+           checkpoint->near_tie_member_mask, full_in_risk_set ? 1 : 0);
   }
 }
 
@@ -1818,7 +1846,8 @@ static void thinking_curve_finish_rule_zero_position(
       "matched_modulus=%d matched_remainder=%d audit_selected=%d "
       "audit_modulus=%d audit_remainder=%d judge_performed=%d "
       "horizon_mismatch=%d equal_horizon_mismatch=%d "
-      "matched_mismatch=%d\n",
+      "matched_mismatch=%d stop_risk_set_ranks=0x%" PRIx64
+      " stop_full_horizon_rank_in_risk_set=%d\n",
       source_index, position, game_index, bag_tiles, plies, num_plays,
       full->checkpoint_count, checkpoint_interval, minimum_nodes,
       minimum_stable_checkpoints, stop.checkpoint_index,
@@ -1838,7 +1867,16 @@ static void thinking_curve_finish_rule_zero_position(
           : "top_two_ids",
       matched_modulus, matched_remainder, audit_selected, audit_modulus,
       audit_remainder, judge_performed, horizon_mismatch,
-      equal_horizon_mismatch, matched_mismatch);
+      equal_horizon_mismatch, matched_mismatch,
+      stop.decision.near_tie_member_mask,
+      (stop.decision.near_tie_challengers >= 0 &&
+       full->decision.best_index >= 0 &&
+       (full->decision.best_index == stop.decision.best_index ||
+        (full->decision.best_index < 64 &&
+         (stop.decision.near_tie_member_mask &
+          ((uint64_t)1 << full->decision.best_index)) != 0)))
+          ? 1
+          : 0);
 
   const ThinkingCurveArmResult stopped = thinking_curve_result_from_checkpoint(
       &stop.decision,

--- a/tools/analyze_rule_zero_panel.py
+++ b/tools/analyze_rule_zero_panel.py
@@ -130,6 +130,8 @@ def analyze(log: Path, manifest: Path) -> dict[str, object]:
     stopped_early = 0
     judged = 0
     audit = 0
+    stop_in_risk_set = 0
+    stop_out_of_risk_set_mismatches = 0
     strata: dict[tuple[str, str], list[int]] = defaultdict(list)
     for source in sorted(roots):
         rule = rules[source]
@@ -161,6 +163,15 @@ def analyze(log: Path, manifest: Path) -> dict[str, object]:
         stopped_early += int(rule["capped"]) == 0
         judged += int(rule["judge_performed"])
         audit += int(rule["audit_selected"])
+        # Risk-set membership at the stopping checkpoint (packet section 6):
+        # count uncapped stops whose full-horizon selection was in the risk
+        # set, and mismatches where it was not (the ambiguity class the p2
+        # panel could not resolve).
+        if int(rule["capped"]) == 0:
+            in_risk_set = int(rule["stop_full_horizon_rank_in_risk_set"])
+            stop_in_risk_set += in_risk_set
+            if horizon_mismatch and not in_risk_set:
+                stop_out_of_risk_set_mismatches += 1
         if int(rule["matched_control"]):
             matched = root_points.get("matched")
             if matched is None:
@@ -200,6 +211,12 @@ def analyze(log: Path, manifest: Path) -> dict[str, object]:
         "judged_roots": judged,
         "random_audit_roots": audit,
         "shadow_checkpoint_rows": shadow_rows,
+        "stop_full_horizon_rank_in_risk_set": {
+            "in_risk_set": stop_in_risk_set,
+            "stops": stopped_early,
+            "rate": stop_in_risk_set / stopped_early if stopped_early else None,
+            "out_of_risk_set_mismatches": stop_out_of_risk_set_mismatches,
+        },
         "horizon_3m_mismatch": horizon,
         "equal_slice_landmark_mismatch": equal,
         "horizon_3m_judged_missed_value": horizon_value,

--- a/tools/run_rule_zero_panel.py
+++ b/tools/run_rule_zero_panel.py
@@ -357,6 +357,48 @@ def validate_rule_zero_chunk_accounting(
             for key, value in expected.items():
                 if _int(checkpoint, key) != value:
                     raise ValueError(f"source {source} checkpoint {key} differs")
+            # Risk-set membership (packet section 6): required as of progress
+            # schema 7. The mask holds candidate-rank bits; the incumbent's
+            # own bit is never set, the popcount must equal the near-tie
+            # count, and the full-horizon indicator must be derivable from
+            # the mask plus the incumbent rank. Fail-closed rows report 0/0.
+            if "risk_set_ranks" not in checkpoint or (
+                "full_horizon_rank_in_risk_set" not in checkpoint
+            ):
+                raise ValueError(
+                    f"source {source} checkpoint lacks risk-set telemetry"
+                )
+            risk_mask = int(checkpoint["risk_set_ranks"], 16)
+            in_risk_set = _int(checkpoint, "full_horizon_rank_in_risk_set")
+            full_rank_at_checkpoint = _int(checkpoint, "full_selected_rank")
+            if valid:
+                if bin(risk_mask).count("1") != near_ties:
+                    raise ValueError(
+                        f"source {source} risk-set popcount differs"
+                    )
+                if (risk_mask >> rank) & 1:
+                    raise ValueError(
+                        f"source {source} risk set contains the incumbent"
+                    )
+                if width < 64 and risk_mask >> width:
+                    raise ValueError(
+                        f"source {source} risk set exceeds the panel width"
+                    )
+                expected_in_risk_set = int(
+                    full_rank_at_checkpoint == rank
+                    or (
+                        full_rank_at_checkpoint < 64
+                        and (risk_mask >> full_rank_at_checkpoint) & 1
+                    )
+                )
+                if in_risk_set != expected_in_risk_set:
+                    raise ValueError(
+                        f"source {source} risk-set indicator differs"
+                    )
+            elif risk_mask != 0 or in_risk_set != 0:
+                raise ValueError(
+                    f"source {source} invalid checkpoint reports a risk set"
+                )
             if eligible and first_eligible is None:
                 first_eligible = checkpoint
             selected = _int(checkpoint, "rule_selected")
@@ -370,6 +412,22 @@ def validate_rule_zero_chunk_accounting(
         stop_checkpoint = len(root_checkpoints) if capped else _int(chosen, "checkpoint")
         if _int(rule, "capped") != int(capped) or _int(rule, "stop_checkpoint") != stop_checkpoint:
             raise ValueError(f"source {source} cap/stop checkpoint differs")
+        # Summary risk-set fields must mirror the replay-selected stopping
+        # checkpoint. Capped roots reuse the full decision, whose mask is 0
+        # (FINISH events carry no mask); the keys must still be present.
+        if "stop_risk_set_ranks" not in rule or (
+            "stop_full_horizon_rank_in_risk_set" not in rule
+        ):
+            raise ValueError(f"source {source} summary lacks risk-set fields")
+        if not capped:
+            if int(rule["stop_risk_set_ranks"], 16) != int(
+                chosen["risk_set_ranks"], 16
+            ) or _int(rule, "stop_full_horizon_rank_in_risk_set") != _int(
+                chosen, "full_horizon_rank_in_risk_set"
+            ):
+                raise ValueError(
+                    f"source {source} summary risk-set fields differ"
+                )
         full_iterations = _int(rule, "full_iterations")
         full_nodes = _int(rule, "full_nodes")
         full_rank = _int(rule, "full_rank")

--- a/tools/test_run_rule_zero_panel.py
+++ b/tools/test_run_rule_zero_panel.py
@@ -30,7 +30,8 @@ def synthetic_chunk() -> str:
         "full_selected_rank=0 estimated_best=.52 estimated_challenger=.50 "
         "estimated_regret=.0001 joint_estimated_regret=.0002 "
         "near_tie_challengers=0 counters_valid=1 rule_eligible={eligible} "
-        "rule_selected={selected}\n"
+        "rule_selected={selected} risk_set_ranks=0x0 "
+        "full_horizon_rank_in_risk_set=1\n"
     )
     checkpoints = checkpoint_template.format(
         checkpoint=0,
@@ -63,7 +64,8 @@ def synthetic_chunk() -> str:
         "matched_min_play_iterations=0 matched_sampling_rule=top_two_ids "
         "matched_modulus=3 matched_remainder=0 audit_selected=0 "
         "audit_modulus=10 audit_remainder=0 judge_performed=0 "
-        "horizon_mismatch=0 equal_horizon_mismatch=0 matched_mismatch=0\n"
+        "horizon_mismatch=0 equal_horizon_mismatch=0 matched_mismatch=0 "
+        "stop_risk_set_ranks=0x0 stop_full_horizon_rank_in_risk_set=1\n"
     )
     point_template = (
         "THINKING_CURVE_POINT source_index=1 position=1 game=1 bag=40 plies=6 "


### PR DESCRIPTION
## Summary

Stacked on #640. Implements the packet section 6 telemetry prerequisite for the fresh exact-topology panel: stopping-checkpoint **risk-set membership** plus a `full_horizon_rank_in_risk_set` indicator, so a miss can no longer be ambiguous between "the full-horizon winner was outside the risk set" and "its variance was underestimated".

- `AnalysisProgressEvent.near_tie_member_mask` (schema 6→7): bit per near-tie challenger arm, computed in the same pass as the existing count under the sync lock at checkpoint emission (`bai_count_near_tie_challengers_with_mask`); incumbent implicit via `best_index`; fail-closed rows report 0. Membership rides every checkpoint because the exact-topology harness replays the stop rule offline — no new event/row types, no accounting-count changes.
- Thinking-curve harness normalizes arm-index bits → candidate-rank bits and appends `risk_set_ranks=0x…` / `full_horizon_rank_in_risk_set=` to existing `RULE_ZERO_CHECKPOINT` rows, plus `stop_*` variants on the `RULE_ZERO` summary.
- Panel runner validates popcount==count, incumbent exclusion, width bounds, indicator derivability, and summary↔stop-row consistency; analyzer reports the in-risk-set rate over uncapped stops and out-of-risk-set mismatches.
- Default endgame admission model pins `source_progress_schema_version` to 6 (honest provenance — its calibration data predates the bump).

## Verification

- Harness smokes (1 and 2 positions, 520/1040 checkpoint rows): popcount(mask) == `near_tie_challengers`, incumbent bit never set, indicator exactly derivable, fail-closed rows 0/0 — all rows.
- Panel tool unit tests extended with the new fields and passing (4/4).
- cppcheck / clang-format / circular-deps clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014H9CrHHEadpFHs9wYHEjbS