### PR TITLE
Preregister the fresh exact-topology certification panel

### DIFF
--- a/notes/rule_zero_exact_topology_preregistration.json
+++ b/notes/rule_zero_exact_topology_preregistration.json
@@ -1,0 +1,111 @@
+{
+  "artifact_kind": "rule_zero_prospective_preregistration",
+  "schema_version": 2,
+  "frozen_before_fresh_trajectory_generation": true,
+  "evidence_class": "certification_exact_topology_panel",
+  "purpose": "certify_p2_top15_rule_zero_on_fresh_match_topology_roots_under_the_frozen_primary_gate",
+  "primary_gate_decision": "notes/rule_zero_primary_gate_decision.md",
+  "known_divergences_from_certification": {
+    "threads": "10_match_machine_m4",
+    "sampling_floor": "uniform_floor_per_mille_100_matching_the_frozen_rule_calibration_production_prefix_is_regret_min_samples_per_arm_32",
+    "exclusions": "fresh_seed_blocks_8404001_and_8504001_disjoint_from_p2_panel_8204001_8304001_and_match_runner_pilot_blocks_25001_25030_31001_31040",
+    "shadow_model": "absent_logged_shadow_disabled"
+  },
+  "decision": "gates_armed_as_preregistered_primary_judged_missed_value",
+  "target": "same_arm_horizon_choice_and_signed_common_judge_improvement",
+  "rule": {
+    "checkpoint_interval_iterations": 256,
+    "minimum_nodes": 100000,
+    "minimum_stable_checkpoints": 2,
+    "near_tie_challengers": 0,
+    "near_tie_definition": "two_sided_99_percent_gaussian_difference_upper_bound_reaches_zero",
+    "missing_or_invalid_counters": "run_to_slice",
+    "scope": "early_stop_only_never_extend"
+  },
+  "panel": {
+    "roots": 320,
+    "source_games": 320,
+    "roots_per_policy_bag_stratum": 40,
+    "policies": ["static", "playchooser-g3000ms"],
+    "bag_bands": [
+      "late_5_15",
+      "middle_late_16_35",
+      "middle_early_36_60",
+      "early_61_100"
+    ],
+    "selection_seed": 81057,
+    "selection_unit": "one_root_per_complete_source_game_without_oracle_outcomes",
+    "panel_order": "sha256_ranked"
+  },
+  "fresh_trajectory_generation": {
+    "games_per_policy": 160,
+    "games_per_resumable_chunk": 16,
+    "threads": 10,
+    "static": {
+      "base_seed": 8404001,
+      "clock_ms": 1,
+      "play_analyzed_moves": false
+    },
+    "playchooser": {
+      "base_seed": 8504001,
+      "clock_ms": 3000,
+      "play_analyzed_moves": true
+    }
+  },
+  "exclusions": [],
+  "arm": {
+    "plies": 2,
+    "sorted_candidate_width": 15,
+    "maximum_nodes": 8000000,
+    "threads": 10,
+    "uniform_floor_per_mille": 100,
+    "sampling_rule": "top_two_ids_after_initial_round_robin"
+  },
+  "matched_control": {
+    "membership": "panel_source_index_mod_3_equals_0",
+    "expected_roots": 107,
+    "budget": "independent_exact_stopped_iteration_count",
+    "scheduler": "round_robin_if_stop_precedes_full_uniform_floor_otherwise_top_two_ids_with_full_absolute_floor"
+  },
+  "selective_judge": {
+    "plies": 10,
+    "samples_per_distinct_nominee": 100000,
+    "risk_plays": 8,
+    "audit_membership": "panel_source_index_mod_10_equals_0",
+    "expected_random_audit_roots": 32,
+    "also_judge": "every_landmark_or_matched_choice_mismatch"
+  },
+  "horizons": {
+    "same_arm_full_nodes": 8000000,
+    "equal_slice_historical_minimum_nodes": 3652554,
+    "equal_slice_landmark_nodes": 6000000,
+    "equal_slice_rule": "historical_median_6M_gate_with_3652554_and_8M_reported_sensitivities"
+  },
+  "risk_set_telemetry": {
+    "required": true,
+    "minimum_progress_schema_version": 7,
+    "fields": [
+      "risk_set_ranks_on_every_checkpoint_row",
+      "full_horizon_rank_in_risk_set_on_every_checkpoint_row",
+      "stop_risk_set_ranks_and_stop_full_horizon_rank_in_risk_set_on_the_summary_row"
+    ],
+    "consequence": "panel_invalid_without_it_per_packet_section_6"
+  },
+  "gates": {
+    "primary": "complete_game_student_t_95_percent_upper_bound_on_judged_missed_value_at_most_0_001_at_the_6M_gate_landmark_and_the_8M_full_horizon",
+    "usefulness_floor": "stop_rate_at_least_0_30_and_node_savings_at_least_0_25_at_the_6M_gate_landmark",
+    "matched_subset": "no_harmful_optional_stopping_bias",
+    "secondary_reported_not_gated": "each_landmark_exact_one_sided_95_percent_mismatch_upper_bound",
+    "sensitivities": "mismatch_reported_at_3652554_and_8M_landmarks",
+    "pass": "primary_and_usefulness_floor_and_matched_subset_and_clean_accounting"
+  },
+  "accounting": {
+    "required_prefix": "0_through_319_contiguous",
+    "dropped": 0,
+    "private_partial_chunks": "never_append",
+    "inference_unit": "complete_source_game",
+    "nonanticipating": true
+  },
+  "live_allocation": "disabled",
+  "terminal_game_gate": "separate_mirrored_preregistered_gate_remains_mandatory"
+}

--- a/notes/rule_zero_primary_gate_decision.md
+++ b/notes/rule_zero_primary_gate_decision.md
@@ -37,3 +37,11 @@ Decision date: 2026-08-06. Decided by the owner; recorded verbatim:
   the 0.001 primary; the secondary imposes no sizing requirement.
 - All other packet section 7 conditions (usefulness floor of >=30% stops and
   >=25% node savings at the 6M landmark, freezes, review) are unchanged.
+
+## Applied by
+
+- notes/rule_zero_exact_topology_preregistration.json — the fresh section 7.2
+  exact-topology certification panel preregistration (fresh seeds 8404001 /
+  8504001; primary judged-missed-value gate; secondary mismatch reported;
+  usefulness floor at the 6M landmark; risk-set telemetry required at
+  progress schema >= 7).

--- a/tools/analyze_rule_zero_panel.py
+++ b/tools/analyze_rule_zero_panel.py
@@ -23,6 +23,11 @@ except ModuleNotFoundError:  # Direct execution from tools/.
     )
     from extract_time_value_positions import fields  # type: ignore[no-redef]
 
+# Historical-minimum equal-slice landmark (preregistered): reported mismatch
+# sensitivity only, never gated. The 6M gate landmark and 8M full horizon come
+# from the harness's own equal_horizon and full points.
+SENSITIVITY_LANDMARK_NODES = 3652554
+
 
 def clopper_pearson_upper(events: int, trials: int, confidence: float = 0.95) -> float:
     """Exact one-sided binomial upper confidence limit."""
@@ -92,9 +97,15 @@ def analyze(log: Path, manifest: Path) -> dict[str, object]:
     points: dict[int, dict[str, dict[str, str]]] = defaultdict(dict)
     done: dict[int, dict[str, str]] = {}
     shadow_rows = 0
+    checkpoint_marks: dict[int, list[tuple[int, int]]] = defaultdict(list)
     with log.open(encoding="utf-8") as stream:
         for line in stream:
-            if line.startswith("THINKING_CURVE_RULE_ZERO "):
+            if line.startswith("THINKING_CURVE_RULE_ZERO_CHECKPOINT "):
+                row = fields(line)
+                checkpoint_marks[int(row["source_index"])].append(
+                    (int(row["nodes"]), int(row["selected_rank"]))
+                )
+            elif line.startswith("THINKING_CURVE_RULE_ZERO "):
                 row = fields(line)
                 source = int(row["source_index"])
                 if source in rules:
@@ -126,6 +137,8 @@ def analyze(log: Path, manifest: Path) -> dict[str, object]:
     horizon_missed_values: list[float] = []
     equal_missed_values: list[float] = []
     node_savings: list[float] = []
+    landmark_savings: list[float] = []
+    sensitivity_mismatches: list[int] = []
     matched_bias: list[float] = []
     stopped_early = 0
     judged = 0
@@ -160,6 +173,25 @@ def analyze(log: Path, manifest: Path) -> dict[str, object]:
         if full_nodes <= 0:
             raise ValueError("full arm has no work")
         node_savings.append(1.0 - int(stopped["nodes"]) / full_nodes)
+        equal_nodes = int(equal["nodes"])
+        if equal_nodes <= 0:
+            raise ValueError("equal-slice landmark has no work")
+        # Usefulness-floor savings are measured against the 6M gate landmark
+        # (the equal-slice point), not the full 8M horizon.
+        landmark_savings.append(1.0 - int(stopped["nodes"]) / equal_nodes)
+        # Reported sensitivity: mismatch against the historical-minimum
+        # landmark, derived from checkpoint rows with the same first-
+        # checkpoint-at-or-past-target rule the harness uses for landmarks.
+        marks = sorted(checkpoint_marks.get(source, []))
+        sensitivity_rank = int(full["selected_rank"])
+        if SENSITIVITY_LANDMARK_NODES < full_nodes:
+            for mark_nodes, mark_rank in marks:
+                if mark_nodes >= SENSITIVITY_LANDMARK_NODES:
+                    sensitivity_rank = mark_rank
+                    break
+        sensitivity_mismatches.append(
+            int(int(stopped["selected_rank"]) != sensitivity_rank)
+        )
         stopped_early += int(rule["capped"]) == 0
         judged += int(rule["judge_performed"])
         audit += int(rule["audit_selected"])
@@ -186,14 +218,15 @@ def analyze(log: Path, manifest: Path) -> dict[str, object]:
 
     horizon = mismatch_summary(horizon_mismatches)
     equal = mismatch_summary(equal_mismatches)
+    sensitivity = mismatch_summary(sensitivity_mismatches)
     horizon_value = mean_interval(horizon_missed_values)
     equal_value = mean_interval(equal_missed_values)
     savings = mean_interval(node_savings)
+    savings_at_landmark = mean_interval(landmark_savings)
     matched = mean_interval(matched_bias)
-    mismatch_gate = (
-        float(horizon["one_sided_95_upper"]) <= 0.015
-        and float(equal["one_sided_95_upper"]) <= 0.015
-    )
+    # Primary gate (notes/rule_zero_primary_gate_decision.md): judged missed
+    # value at the 0.001 threshold. Mismatch counts are reported secondaries
+    # with exact bounds and are never gated.
     value_gate = (
         float(horizon_value["ci95"][1]) <= 0.001
         and float(equal_value["ci95"][1]) <= 0.001
@@ -202,7 +235,12 @@ def analyze(log: Path, manifest: Path) -> dict[str, object]:
         float(matched["ci95"][0]) <= 0.0 <= float(matched["ci95"][1])
         and float(matched["ci95"][1]) <= 0.001
     )
-    savings_gate = float(savings["mean"]) >= 0.50
+    # Usefulness floor (packet section 7.2): the rule must stop at least 30%
+    # of roots and save at least 25% of nodes at the 6M gate landmark.
+    stop_rate = stopped_early / len(roots)
+    usefulness_floor = (
+        stop_rate >= 0.30 and float(savings_at_landmark["mean"]) >= 0.25
+    )
     return {
         "artifact_kind": "rule_zero_prospective_analysis",
         "roots": len(roots),
@@ -217,25 +255,32 @@ def analyze(log: Path, manifest: Path) -> dict[str, object]:
             "rate": stop_in_risk_set / stopped_early if stopped_early else None,
             "out_of_risk_set_mismatches": stop_out_of_risk_set_mismatches,
         },
-        "horizon_3m_mismatch": horizon,
+        "full_horizon_mismatch": horizon,
         "equal_slice_landmark_mismatch": equal,
-        "horizon_3m_judged_missed_value": horizon_value,
+        "historical_minimum_landmark_mismatch_sensitivity": sensitivity,
+        "full_horizon_judged_missed_value": horizon_value,
         "equal_slice_judged_missed_value": equal_value,
-        "node_savings": savings,
+        "node_savings_vs_full_horizon": savings,
+        "node_savings_at_gate_landmark": savings_at_landmark,
+        "stop_rate": stop_rate,
         "matched_optional_stopping_bias": matched,
         "strata": {
             "|".join(key): mismatch_summary(values)
             for key, values in sorted(strata.items())
         },
         "gates": {
-            "mismatch_upper_at_most_0.015": mismatch_gate,
-            "judged_missed_value_upper_at_most_0.001": value_gate,
-            "mean_node_savings_at_least_0.50": savings_gate,
+            "primary_judged_missed_value_upper_at_most_0.001": value_gate,
+            "usefulness_floor_stop_rate_0.30_savings_0.25_at_landmark": (
+                usefulness_floor
+            ),
             "matched_subset_no_harmful_bias": matched_gate,
-            "surrogate_pass": mismatch_gate
-            and value_gate
-            and savings_gate
-            and matched_gate,
+            "secondary_mismatch_reported_not_gated": {
+                "full_horizon_one_sided_95_upper": horizon[
+                    "one_sided_95_upper"
+                ],
+                "equal_slice_one_sided_95_upper": equal["one_sided_95_upper"],
+            },
+            "panel_pass": value_gate and usefulness_floor and matched_gate,
         },
         "live_allocation": "disabled_pending_separate_terminal_game_gate",
     }


### PR DESCRIPTION
## Summary

Stacked on #641 (which stacks on #640). Freezes the packet §7.2 fresh exact-topology panel preregistration under the recorded primary-gate decision, and rewires the analyzer to the preregistered gates.

**Preregistration** (`notes/rule_zero_exact_topology_preregistration.json`):
- Primary gate: judged-missed-value 95% upper ≤ 0.001 (6M gate landmark + 8M full horizon); secondary: landmark mismatch counts reported with exact CP bounds, never gated; usefulness floor: stop rate ≥ 30% and node savings ≥ 25% at the 6M landmark; 3.65M/6M/8M landmarks scored, gate at 6M.
- Fresh trajectory seeds 8404001/8504001 (disjoint from p2 panel 8204001/8304001 and match-runner pilot blocks); stratified 8×40 = 320 roots; frozen p2/top-15 rule unchanged; match-machine threads (10).
- Risk-set telemetry (progress schema ≥ 7, from #641) mandatory per packet §6 — panel invalid without it.
- Validated consumable against `prepare_rule_zero_panel.py` and `run_rule_zero_panel.py` contracts (required CLI: `--plies 2 --max-nodes 8000000 ... --equal-slice-nodes 6000000`).

**Analyzer** (`tools/analyze_rule_zero_panel.py`):
- `panel_pass` = primary judged-missed-value gate ∧ usefulness floor ∧ matched no-harm (replaces the hardcoded mean-savings ≥ 0.50 gate and the gated mismatch bound).
- Node savings additionally scored against the 6M gate landmark; historical-minimum 3652554 landmark reported as a mismatch sensitivity derived from checkpoint rows (same first-checkpoint-at-or-past-target rule as the harness).
- Tool unit tests pass (4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014H9CrHHEadpFHs9wYHEjbS