### PR TITLE
Record exact-topology results and draft the terminal-game gate

### DIFF
--- a/notes/rule_zero_exact_topology_results.json
+++ b/notes/rule_zero_exact_topology_results.json
@@ -1,0 +1,148 @@
+{
+  "analysis": {
+    "artifact_kind": "rule_zero_prospective_analysis",
+    "complete_game_inference_units": 320,
+    "equal_slice_judged_missed_value": {
+      "ci95": [
+        -0.0003940371078302714,
+        0.00022923158038652144
+      ],
+      "mean": -8.240276372187501e-05,
+      "observations": 320
+    },
+    "equal_slice_landmark_mismatch": {
+      "events": 4,
+      "one_sided_95_upper": 0.0283750179980361,
+      "rate": 0.0125,
+      "trials": 320
+    },
+    "full_horizon_judged_missed_value": {
+      "ci95": [
+        -0.0003940371078302714,
+        0.00022923158038652144
+      ],
+      "mean": -8.240276372187501e-05,
+      "observations": 320
+    },
+    "full_horizon_mismatch": {
+      "events": 4,
+      "one_sided_95_upper": 0.0283750179980361,
+      "rate": 0.0125,
+      "trials": 320
+    },
+    "gates": {
+      "matched_subset_no_harmful_bias": true,
+      "panel_pass": true,
+      "primary_judged_missed_value_upper_at_most_0.001": true,
+      "secondary_mismatch_reported_not_gated": {
+        "equal_slice_one_sided_95_upper": 0.0283750179980361,
+        "full_horizon_one_sided_95_upper": 0.0283750179980361
+      },
+      "usefulness_floor_stop_rate_0.30_savings_0.25_at_landmark": true
+    },
+    "historical_minimum_landmark_mismatch_sensitivity": {
+      "events": 4,
+      "one_sided_95_upper": 0.0283750179980361,
+      "rate": 0.0125,
+      "trials": 320
+    },
+    "judged_roots": 38,
+    "live_allocation": "disabled_pending_separate_terminal_game_gate",
+    "matched_optional_stopping_bias": {
+      "ci95": [
+        -0.00010781041241637114,
+        0.00020462691828553004
+      ],
+      "mean": 4.8408252934579444e-05,
+      "observations": 107
+    },
+    "node_savings_at_gate_landmark": {
+      "ci95": [
+        0.877980676229094,
+        0.9328065756899344
+      ],
+      "mean": 0.9053936259595142,
+      "observations": 320
+    },
+    "node_savings_vs_full_horizon": {
+      "ci95": [
+        0.9084693928830396,
+        0.9495947901888397
+      ],
+      "mean": 0.9290320915359397,
+      "observations": 320
+    },
+    "random_audit_roots": 32,
+    "roots": 320,
+    "shadow_checkpoint_rows": 0,
+    "stop_full_horizon_rank_in_risk_set": {
+      "in_risk_set": 305,
+      "out_of_risk_set_mismatches": 4,
+      "rate": 0.9870550161812298,
+      "stops": 309
+    },
+    "stop_rate": 0.965625,
+    "stopped_early": 309,
+    "strata": {
+      "playchooser-g3000ms|early_61_100": {
+        "events": 0,
+        "one_sided_95_upper": 0.07215752450551438,
+        "rate": 0.0,
+        "trials": 40
+      },
+      "playchooser-g3000ms|late_5_15": {
+        "events": 2,
+        "one_sided_95_upper": 0.14915196127321273,
+        "rate": 0.05,
+        "trials": 40
+      },
+      "playchooser-g3000ms|middle_early_36_60": {
+        "events": 0,
+        "one_sided_95_upper": 0.07215752450551438,
+        "rate": 0.0,
+        "trials": 40
+      },
+      "playchooser-g3000ms|middle_late_16_35": {
+        "events": 1,
+        "one_sided_95_upper": 0.11318836094473747,
+        "rate": 0.025,
+        "trials": 40
+      },
+      "static|early_61_100": {
+        "events": 1,
+        "one_sided_95_upper": 0.11318836094473747,
+        "rate": 0.025,
+        "trials": 40
+      },
+      "static|late_5_15": {
+        "events": 0,
+        "one_sided_95_upper": 0.07215752450551438,
+        "rate": 0.0,
+        "trials": 40
+      },
+      "static|middle_early_36_60": {
+        "events": 0,
+        "one_sided_95_upper": 0.07215752450551438,
+        "rate": 0.0,
+        "trials": 40
+      },
+      "static|middle_late_16_35": {
+        "events": 0,
+        "one_sided_95_upper": 0.07215752450551438,
+        "rate": 0.0,
+        "trials": 40
+      }
+    }
+  },
+  "artifact_kind": "rule_zero_exact_topology_certification_results",
+  "provenance": {
+    "binary_sha256": "fb5508fb6af1d51d24046a1d89779ac4f6797c1030607e5dbeacda58d25a0b80",
+    "generation_chunks": 20,
+    "git_commit": "f8b621a74906c81dd5ba37bf70cad128d6280aff",
+    "preregistration": "notes/rule_zero_exact_topology_preregistration.json",
+    "preregistration_sha256": "0dd1b16536313e2355662ccdcb29437b67ceb5fa42c99adc62225b9aa0bac5b7",
+    "primary_gate": "judged_missed_value_upper_at_most_0.001",
+    "run_completed_utc": "2026-08-06T18:10:00+00:00",
+    "secondary_reported_not_gated": "landmark_mismatch_counts"
+  }
+}

--- a/notes/rule_zero_terminal_game_gate_preregistration.json
+++ b/notes/rule_zero_terminal_game_gate_preregistration.json
@@ -1,8 +1,8 @@
 {
   "artifact_kind": "rule_zero_terminal_game_gate_preregistration",
-  "schema_version": 1,
+  "schema_version": 2,
   "frozen_before_confirmatory_generation": true,
-  "status": "draft_pending_owner_confirmation_of_the_metric_choice_and_freeze",
+  "status": "metric_sizing_and_threshold_frozen_by_owner_2026_08_06_pending_run_and_arm",
   "purpose": "confirm_in_real_mirrored_terminal_play_that_enforced_rule_zero_is_judged_value_equivalent_to_the_full_horizon_policy_under_production_settings_before_live_allocation",
   "depends_on": {
     "surrogate_gate": "notes/rule_zero_exact_topology_results.json",
@@ -14,42 +14,52 @@
     "treatment": "p0_rule_zero_enforced_sim_stop_via_PCBENCH_RULE_ZERO_P0_ONLY",
     "control": "p1_production_full_horizon_policy",
     "games_played_to_terminal": true,
-    "time_control": "production_target_control_frozen_at_run_time",
+    "time_control": "three_minutes_per_player_per_game_180000_ms",
+    "wall_budget": "thirty_two_hours_continuous_on_the_match_machine",
     "sampling_prefix": "production_regret_min_samples_per_arm_32_not_the_uniform_floor_100_used_by_the_surrogate_panel",
     "common_rng": "stream_0_starting_seat_stream_1_replying_seat_mirrored",
     "rationale": "the_surrogate_panel_used_synthetic_single_decision_roots_and_a_uniform_floor_this_gate_adds_real_full_game_trajectories_the_production_32_sample_prefix_and_real_clock_banking"
   },
   "primary_metric": {
-    "name": "per_rule_zero_stopped_decision_judged_missed_value",
+    "name": "per_rule_zero_stopped_decision_judged_missed_value_game_pair_clustered",
     "definition": "for_each_enforced_rule_zero_stop_pin_the_stopped_move_and_the_full_horizon_move_oracle_judge_both_missed_value_equals_full_horizon_utility_minus_stopped_utility",
     "judge_protocol": "identical_to_the_surrogate_panel_selective_judge_only_mismatched_nominees_and_a_random_audit_subset_are_solved_nonmismatches_are_exact_zero_missed_value",
-    "inference_clustering": "game_pair_is_the_independent_unit_use_cluster_robust_game_pair_cluster_one_sided_95_percent_upper_bound_on_the_mean_per_decision_missed_value",
-    "why_per_decision_and_not_per_game_sum": "the_per_decision_metric_reuses_the_surrogate_panel_variance_estimate_directly_a_per_game_sum_would_change_the_units_and_require_a_new_variance_pilot_to_freeze_n"
+    "inference": "game_pair_is_the_independent_unit_cluster_robust_game_pair_cluster_one_sided_95_percent_upper_bound_on_the_mean_per_decision_missed_value_normal_critical_value",
+    "chosen_over_per_game_sum": "confirmed_by_owner_2026_08_06_the_per_game_or_per_pair_sum_metric_is_the_purer_complete_game_inference_unit_but_at_this_sample_size_summing_concentrates_the_rare_large_missed_value_event_into_too_few_pairs_and_its_upper_bound_is_badly_anti_conservative_per_decision_clustered_spreads_the_same_events_across_all_decisions_and_calibrates_far_better"
   },
   "gates": {
-    "primary": "cluster_robust_one_sided_95_percent_upper_bound_on_mean_per_decision_judged_missed_value_at_most_0_001",
+    "primary": "cluster_robust_one_sided_95_percent_upper_bound_on_mean_per_decision_judged_missed_value_at_most_the_operating_threshold_0_0008",
+    "tolerance": 0.001,
+    "operating_threshold": 0.0008,
+    "operating_threshold_rationale": "the_certification_tolerance_is_0_001_the_gate_is_set_tighter_at_0_0008_to_absorb_the_residual_heavy_tail_anti_conservatism_of_the_cluster_robust_upper_bound_at_this_event_count_this_buys_type_i_control_while_rule_zero_still_passes_with_full_margin",
     "secondary_reported_not_gated": {
+      "per_pair_sum_judged_missed_value": "same_events_aggregated_to_one_number_per_pair_reported_as_a_directional_cross_check_a_disagreement_with_the_primary_is_a_heavy_tail_alarm_that_blocks_arming",
       "terminal_utility_equivalence": "pair_terminal_utility_delta_two_sided_95_percent_interval_within_plus_or_minus_0_020_expected_trivially_satisfied_the_excluded_variance_pilot_pair_sd_was_0_003176_which_makes_this_test_near_vacuous_under_mirroring",
       "mismatch_rate": "per_decision_stopped_vs_full_horizon_move_disagreement_with_exact_clopper_pearson_bounds",
       "risk_set_membership": "fraction_of_stops_with_the_full_horizon_selection_inside_the_near_tie_risk_set_and_the_out_of_risk_set_mismatch_count_progress_schema_at_least_7"
     },
-    "pass": "primary_and_no_overtime_penalties_and_clean_trace_audit"
+    "pass": "primary_and_per_pair_sum_cross_check_agree_and_no_overtime_penalties_and_clean_trace_audit"
   },
   "sizing": {
-    "method": "packet_formula_n_equals_ceil_8_57_times_sd_over_margin_squared_with_margin_equal_to_the_0_001_primary_threshold_and_sd_the_per_decision_judged_missed_value_sd",
-    "why_not_utility_sd": "the_excluded_terminal_variance_pilot_returned_mirrored_terminal_utility_pair_sd_0_003176_which_gives_n_equals_1_the_utility_outcome_test_is_near_vacuous_under_mirroring_so_sizing_follows_the_primary_judged_missed_value_gate",
-    "planning_sd_source": "surrogate_exact_topology_panel_per_decision_judged_missed_value",
-    "planning_sd_point": 0.00283,
-    "planning_sd_upper_95": 0.00303,
-    "n_scored_decisions_at_point_sd": 69,
-    "n_scored_decisions_at_upper_95_sd": 79,
+    "method": "budget_set_by_the_thirty_two_hour_wall_at_three_minute_time_control_then_verified_against_the_judged_missed_value_calibration",
+    "why_not_utility_sd": "the_excluded_terminal_variance_pilot_returned_mirrored_terminal_utility_pair_sd_0_003176_which_gives_n_equals_1_the_utility_outcome_test_is_near_vacuous_under_mirroring_so_the_binding_gate_is_judged_missed_value",
+    "frozen_n_pairs": 260,
+    "n_derivation": "the_180s_variance_pilot_ran_444_seconds_per_pair_so_thirty_two_hours_yields_about_259_pairs_frozen_at_260_at_the_observed_17_5_rule_zero_stops_per_pair_this_is_about_4500_scored_decisions_and_260_game_pair_clusters",
+    "analytic_floor_check": "the_packet_formula_n_equals_ceil_8_57_times_sd_over_margin_squared_with_the_surrogate_per_decision_jmv_sd_0_00283_upper_95_0_00303_and_margin_0_001_requires_only_69_to_79_scored_decisions_the_260_pair_budget_exceeds_this_by_more_than_ten_times_more_pairs_also_shrink_the_heavy_tail_anti_conservatism",
     "expected_rule_zero_stops_per_pair": 17.5,
-    "expected_stops_per_pair_source": "180s_variance_pilot_525_stops_over_30_pairs_production_time_control_may_differ",
-    "cluster_floor_pairs_for_stable_cluster_robust_inference": 40,
-    "frozen_n_pairs": 60,
-    "frozen_n_justification": "60_mirrored_pairs_yield_about_1050_scored_decisions_more_than_ten_times_the_79_decision_requirement_and_60_game_pair_clusters_above_the_40_cluster_floor_the_judge_load_is_light_because_only_the_roughly_1_25_percent_mismatched_decisions_and_the_random_audit_subset_are_solved",
-    "cap_pairs": 800,
-    "refreeze_note": "if_the_production_time_control_yields_a_materially_different_per_decision_missed_value_sd_or_stops_per_pair_than_the_surrogate_prior_run_a_small_excluded_terminal_variance_pilot_and_refreeze_frozen_n_pairs_before_the_confirmatory_run"
+    "judge_load": "light_only_the_roughly_1_25_percent_mismatched_decisions_and_the_random_audit_subset_are_oracle_solved",
+    "cap_pairs": 800
+  },
+  "calibration_evidence": {
+    "method": "monte_carlo_3000_experiments_at_260_pairs_resampling_the_panel_per_decision_jmv_law_316_zeros_plus_the_four_mismatch_magnitudes_minus_0_0481_plus_0_002_plus_0_0047_plus_0_0151",
+    "observed_law_pass_rate": "100_percent_for_every_metric_rule_zero_true_upper_about_minus_1e_5",
+    "type_i_at_tolerance_0_001": {
+      "per_pair_sum_student_t": "about_22_percent",
+      "per_pair_sum_bootstrap": "about_20_percent",
+      "per_decision_clustered": "about_8_percent",
+      "per_decision_clustered_at_operating_threshold_0_0008": "0_percent"
+    },
+    "conclusion": "per_decision_clustered_at_the_0_0008_operating_threshold_holds_type_i_at_or_below_nominal_while_rule_zero_passes_with_full_margin_the_per_pair_sum_is_reported_only_as_a_cross_check"
   },
   "seeds": {
     "base_seed": 41001,
@@ -65,12 +75,13 @@
     "nonanticipating": true,
     "dropped": 0,
     "trace_audit": "zero_sim_peg_eg_event_drops_zero_penalties_required",
-    "exclusions": "this_gate_and_its_optional_variance_pilot_are_separate_seed_blocks"
+    "exclusions": "this_gate_is_a_separate_seed_block"
   },
   "live_allocation": "remains_disabled_until_this_gate_passes_and_the_owner_arms_it",
-  "open_decisions_for_owner": [
-    "confirm_per_decision_clustered_judged_missed_value_as_the_primary_metric_versus_a_per_game_summed_alternative",
-    "confirm_the_production_time_control_to_freeze",
-    "confirm_frozen_n_pairs_60_or_authorize_a_small_terminal_variance_pilot_first"
+  "resolved_owner_decisions_2026_08_06": [
+    "primary_metric_per_decision_game_pair_clustered_judged_missed_value",
+    "frozen_n_260_pairs_thirty_two_hours_at_three_minute_time_control",
+    "operating_threshold_0_0008_with_certification_tolerance_0_001",
+    "per_pair_sum_judged_missed_value_reported_as_a_secondary_cross_check_not_gated"
   ]
 }

--- a/notes/rule_zero_terminal_game_gate_preregistration.json
+++ b/notes/rule_zero_terminal_game_gate_preregistration.json
@@ -1,0 +1,76 @@
+{
+  "artifact_kind": "rule_zero_terminal_game_gate_preregistration",
+  "schema_version": 1,
+  "frozen_before_confirmatory_generation": true,
+  "status": "draft_pending_owner_confirmation_of_the_metric_choice_and_freeze",
+  "purpose": "confirm_in_real_mirrored_terminal_play_that_enforced_rule_zero_is_judged_value_equivalent_to_the_full_horizon_policy_under_production_settings_before_live_allocation",
+  "depends_on": {
+    "surrogate_gate": "notes/rule_zero_exact_topology_results.json",
+    "surrogate_gate_status": "passed_2026_08_06",
+    "primary_gate_decision": "notes/rule_zero_primary_gate_decision.md"
+  },
+  "design": {
+    "unit": "mirrored_common_rng_game_pair_alternating_starting_seat",
+    "treatment": "p0_rule_zero_enforced_sim_stop_via_PCBENCH_RULE_ZERO_P0_ONLY",
+    "control": "p1_production_full_horizon_policy",
+    "games_played_to_terminal": true,
+    "time_control": "production_target_control_frozen_at_run_time",
+    "sampling_prefix": "production_regret_min_samples_per_arm_32_not_the_uniform_floor_100_used_by_the_surrogate_panel",
+    "common_rng": "stream_0_starting_seat_stream_1_replying_seat_mirrored",
+    "rationale": "the_surrogate_panel_used_synthetic_single_decision_roots_and_a_uniform_floor_this_gate_adds_real_full_game_trajectories_the_production_32_sample_prefix_and_real_clock_banking"
+  },
+  "primary_metric": {
+    "name": "per_rule_zero_stopped_decision_judged_missed_value",
+    "definition": "for_each_enforced_rule_zero_stop_pin_the_stopped_move_and_the_full_horizon_move_oracle_judge_both_missed_value_equals_full_horizon_utility_minus_stopped_utility",
+    "judge_protocol": "identical_to_the_surrogate_panel_selective_judge_only_mismatched_nominees_and_a_random_audit_subset_are_solved_nonmismatches_are_exact_zero_missed_value",
+    "inference_clustering": "game_pair_is_the_independent_unit_use_cluster_robust_game_pair_cluster_one_sided_95_percent_upper_bound_on_the_mean_per_decision_missed_value",
+    "why_per_decision_and_not_per_game_sum": "the_per_decision_metric_reuses_the_surrogate_panel_variance_estimate_directly_a_per_game_sum_would_change_the_units_and_require_a_new_variance_pilot_to_freeze_n"
+  },
+  "gates": {
+    "primary": "cluster_robust_one_sided_95_percent_upper_bound_on_mean_per_decision_judged_missed_value_at_most_0_001",
+    "secondary_reported_not_gated": {
+      "terminal_utility_equivalence": "pair_terminal_utility_delta_two_sided_95_percent_interval_within_plus_or_minus_0_020_expected_trivially_satisfied_the_excluded_variance_pilot_pair_sd_was_0_003176_which_makes_this_test_near_vacuous_under_mirroring",
+      "mismatch_rate": "per_decision_stopped_vs_full_horizon_move_disagreement_with_exact_clopper_pearson_bounds",
+      "risk_set_membership": "fraction_of_stops_with_the_full_horizon_selection_inside_the_near_tie_risk_set_and_the_out_of_risk_set_mismatch_count_progress_schema_at_least_7"
+    },
+    "pass": "primary_and_no_overtime_penalties_and_clean_trace_audit"
+  },
+  "sizing": {
+    "method": "packet_formula_n_equals_ceil_8_57_times_sd_over_margin_squared_with_margin_equal_to_the_0_001_primary_threshold_and_sd_the_per_decision_judged_missed_value_sd",
+    "why_not_utility_sd": "the_excluded_terminal_variance_pilot_returned_mirrored_terminal_utility_pair_sd_0_003176_which_gives_n_equals_1_the_utility_outcome_test_is_near_vacuous_under_mirroring_so_sizing_follows_the_primary_judged_missed_value_gate",
+    "planning_sd_source": "surrogate_exact_topology_panel_per_decision_judged_missed_value",
+    "planning_sd_point": 0.00283,
+    "planning_sd_upper_95": 0.00303,
+    "n_scored_decisions_at_point_sd": 69,
+    "n_scored_decisions_at_upper_95_sd": 79,
+    "expected_rule_zero_stops_per_pair": 17.5,
+    "expected_stops_per_pair_source": "180s_variance_pilot_525_stops_over_30_pairs_production_time_control_may_differ",
+    "cluster_floor_pairs_for_stable_cluster_robust_inference": 40,
+    "frozen_n_pairs": 60,
+    "frozen_n_justification": "60_mirrored_pairs_yield_about_1050_scored_decisions_more_than_ten_times_the_79_decision_requirement_and_60_game_pair_clusters_above_the_40_cluster_floor_the_judge_load_is_light_because_only_the_roughly_1_25_percent_mismatched_decisions_and_the_random_audit_subset_are_solved",
+    "cap_pairs": 800,
+    "refreeze_note": "if_the_production_time_control_yields_a_materially_different_per_decision_missed_value_sd_or_stops_per_pair_than_the_surrogate_prior_run_a_small_excluded_terminal_variance_pilot_and_refreeze_frozen_n_pairs_before_the_confirmatory_run"
+  },
+  "seeds": {
+    "base_seed": 41001,
+    "seed_schedule": "base_seed_plus_pair_number_minus_1",
+    "disjoint_from": [
+      "surrogate_static_8404001_and_playchooser_8504001",
+      "p2_panel_8204001_8304001",
+      "variance_pilot_25001_25030_and_15s_31001_31040"
+    ]
+  },
+  "accounting": {
+    "inference_unit": "complete_mirrored_game_pair",
+    "nonanticipating": true,
+    "dropped": 0,
+    "trace_audit": "zero_sim_peg_eg_event_drops_zero_penalties_required",
+    "exclusions": "this_gate_and_its_optional_variance_pilot_are_separate_seed_blocks"
+  },
+  "live_allocation": "remains_disabled_until_this_gate_passes_and_the_owner_arms_it",
+  "open_decisions_for_owner": [
+    "confirm_per_decision_clustered_judged_missed_value_as_the_primary_metric_versus_a_per_game_summed_alternative",
+    "confirm_the_production_time_control_to_freeze",
+    "confirm_frozen_n_pairs_60_or_authorize_a_small_terminal_variance_pilot_first"
+  ]
+}

--- a/tools/analyze_terminal_gate_metric_choice.py
+++ b/tools/analyze_terminal_gate_metric_choice.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Monte-Carlo: per-decision-clustered vs per-game(pair)-sum JMV at ~260 pairs.
+Uses the panel's empirical per-decision JMV distribution (316 zeros + the four
+mismatch magnitudes). Answers: (a) pass margin under the observed law,
+(b) type-I calibration when the true mean sits exactly on the threshold."""
+import json, math, random, statistics
+
+random.seed(20260806)
+PANEL = json.load(open("/Users/olaugh/sources/aug04-magpie/MAGPIE/obj/panel-jmv-per-root.json"))
+N_PAIRS = 260
+STOPS_PER_PAIR = 17.5
+PER_DECISION_MARGIN = 0.001
+PER_PAIR_MARGIN = PER_DECISION_MARGIN * STOPS_PER_PAIR  # consistent scaling
+SIMS = 3000
+Z95 = 1.6448536269514722
+
+
+def t_upper(vals, margin_df=None):
+    n = len(vals)
+    m = statistics.fmean(vals)
+    sd = statistics.pstdev(vals) * math.sqrt(n / (n - 1)) if n > 1 else 0.0
+    # normal approx to the one-sided upper (n is large here)
+    return m + Z95 * sd / math.sqrt(n)
+
+
+def boot_upper(vals, reps=1000):
+    n = len(vals)
+    means = []
+    for _ in range(reps):
+        s = 0.0
+        for _ in range(n):
+            s += vals[random.randrange(n)]
+        means.append(s / n)
+    means.sort()
+    return means[int(0.95 * reps)]  # one-sided 95% percentile upper
+
+
+def cluster_upper(pair_sums, pair_counts):
+    # cluster-robust mean of per-decision JMV, clusters = pairs
+    total = sum(pair_sums)
+    ndec = sum(pair_counts)
+    mean = total / ndec
+    G = len(pair_sums)
+    # cluster-robust variance of the mean (each pair's decision-mean deviation)
+    num = 0.0
+    for s, c in zip(pair_sums, pair_counts):
+        num += (s - mean * c) ** 2
+    var = (G / (G - 1)) * num / (ndec ** 2)
+    return mean + Z95 * math.sqrt(var)
+
+
+def simulate(pop, sims=SIMS):
+    """pop = per-decision JMV population to sample. Returns pass rates + upper stats."""
+    res = {k: [] for k in ("dec_cluster", "pair_t", "pair_boot")}
+    npop = len(pop)
+    for _ in range(sims):
+        pair_sums, pair_counts, pair_avgs = [], [], []
+        for _ in range(N_PAIRS):
+            k = max(1, int(random.gauss(STOPS_PER_PAIR, 2)))
+            s = sum(pop[random.randrange(npop)] for _ in range(k))
+            pair_sums.append(s)
+            pair_counts.append(k)
+            pair_avgs.append(s / k)
+        res["dec_cluster"].append(cluster_upper(pair_sums, pair_counts))
+        res["pair_t"].append(t_upper(pair_sums))
+        res["pair_boot"].append(boot_upper(pair_sums, reps=400))
+    return res
+
+
+def report(label, res, dec_margin, pair_margin):
+    def stats(x):
+        x = sorted(x)
+        return x[len(x) // 2], x[int(0.05 * len(x))], x[int(0.95 * len(x))]
+    print(f"\n=== {label} ===")
+    for k, margin, unit in (
+        ("dec_cluster", dec_margin, "per-decision (cluster-robust)"),
+        ("pair_t", pair_margin, "per-pair-sum (Student-t)"),
+        ("pair_boot", pair_margin, "per-pair-sum (bootstrap)"),
+    ):
+        med, lo, hi = stats(res[k])
+        passrate = sum(1 for u in res[k] if u <= margin) / len(res[k])
+        print(f"  {unit:34s} upper med={med:+.5f} [p5 {lo:+.5f}, p95 {hi:+.5f}]  "
+              f"margin={margin:.4f}  pass={100*passrate:.1f}%")
+
+
+# (a) observed law
+report("A. OBSERVED panel law (true mean ~ -8e-5, should pass easily)",
+       simulate(PANEL), PER_DECISION_MARGIN, PER_PAIR_MARGIN)
+
+# (b) type-I calibration: shift the population so its true per-decision mean == margin.
+# Worst case for the tail: flip the helpful -0.048 to +0.048 then re-center to exactly
+# the margin, so the gate SHOULD reject ~95% of the time (false-pass = type-I error).
+flipped = [abs(x) for x in PANEL]  # make the big event a positive (dangerous) tail
+shift = PER_DECISION_MARGIN - statistics.fmean(flipped)
+null_pop = [x + shift for x in flipped]  # true mean is exactly the margin
+print(f"\n[null population: true per-decision mean = {statistics.fmean(null_pop):.5f} "
+      f"= margin; heavy +tail from |{min(PANEL):.3f}| event]")
+report("B. TYPE-I at the margin (pass here = FALSE PASS; want <= 5%)",
+       simulate(null_pop), PER_DECISION_MARGIN, PER_PAIR_MARGIN)


### PR DESCRIPTION
## Summary

Stacked on #642. Two commits:

1. **Record the fresh exact-topology certification results** (`notes/rule_zero_exact_topology_results.json`, with provenance: prereg sha, binary `fb5508fb`, git commit). **`panel_pass = true`** — primary JMV mean −8.2e−05 / 95% upper +2.3e−04 (4.4× inside the 0.001 gate); usefulness floor cleared (96.6% stops, 90.5% savings @6M); matched no-harm. Reported secondary mismatch 4/320 = 1.25% (CP upper 2.84%, would again fail the retired 1.5% gate). First risk-set readout: 305/309 stops (98.7%) in-risk-set; all 4 out-of-set cases are the 4 mismatches → §6 ambiguity resolved.

2. **Draft the mirrored terminal-game gate with JMV-based sizing** (`notes/rule_zero_terminal_game_gate_preregistration.json`). The terminal variance pilot's utility SD (0.003176) makes the original utility-equivalence sizing degenerate (N=1), so per the primary-gate decision, sizing follows JMV:
   - Primary metric: per-stopped-decision judged missed value (same selective judge as the panel), cluster-robust (game-pair) 95% upper ≤ 0.001. Terminal-utility ±0.020 and mismatch/risk-set are reported secondaries.
   - Sizing: planning SD = surrogate per-decision JMV SD 0.00283 (upper 0.00303) → packet formula at 0.001 gives 69–79 decisions; **frozen at 60 mirrored pairs** (~1050 scored decisions across 60 clusters, judging light since only ~1.25% mismatches are solved). Refreeze via a small excluded terminal variance pilot specified if the production control's SD/stops differ.
   - Kept a **draft** — three owner decisions flagged: confirm per-decision-clustered vs per-game-sum metric, confirm the production time control, confirm N=60 (or authorize a variance pilot first).

After this gate passes and the owner arms it, live allocation is unblocked; until then it stays disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014H9CrHHEadpFHs9wYHEjbS