### PR TITLE
autoplay: respect per-player move_sort_type during static play

### DIFF
--- a/src/impl/autoplay.c
+++ b/src/impl/autoplay.c
@@ -741,7 +741,7 @@ const Move *game_runner_get_best_move(AutoplayWorker *autoplay_worker,
                                 ? &autoplay_worker->args.p1_sim_args
                                 : &autoplay_worker->args.p2_sim_args;
   if (sim_args->num_plies == 0) {
-    return get_top_equity_move(
+    return get_top_move_for_player_on_turn(
         game_runner->game, autoplay_worker->move_lists[player_on_turn_index]);
   }
   return game_runner_get_top_simming_move(autoplay_worker, game_runner);

--- a/src/impl/gameplay.c
+++ b/src/impl/gameplay.c
@@ -894,6 +894,21 @@ const Move *get_top_equity_move(Game *game, MoveList *move_list) {
   return move_list_get_move(move_list, 0);
 }
 
+// Like get_top_equity_move, but sorts by the move_sort_type configured for
+// the player on turn instead of always using MOVE_SORT_EQUITY. This is what
+// static (non-simming) play should use so that per-player sort type settings
+// (e.g. the "s1"/"s2" args) actually affect play.
+const Move *get_top_move_for_player_on_turn(Game *game, MoveList *move_list) {
+  const MoveGenArgs args = {.game = game,
+                            .move_list = move_list,
+                            .eq_margin_movegen = 0,
+                            .target_equity = EQUITY_MAX_VALUE,
+                            .target_leave_size_for_exchange_cutoff =
+                                UNSET_LEAVE_SIZE};
+  generate_moves_for_game_override_record_type(&args, MOVE_RECORD_BEST);
+  return move_list_get_move(move_list, 0);
+}
+
 Move *get_top_equity_move_for_inferences(
     Game *game, MoveList *move_list, Equity target_equity,
     int target_leave_size_for_exchange_cutoff, Equity equity_margin) {

--- a/src/impl/gameplay.h
+++ b/src/impl/gameplay.h
@@ -21,6 +21,7 @@ void play_move_no_cross_set_update(const Move *move, Game *game, Rack *leave);
 void play_move_without_drawing_tiles(const Move *move, Game *game);
 void set_random_rack(Game *game, int player_index, const Rack *known_rack);
 const Move *get_top_equity_move(Game *game, MoveList *move_list);
+const Move *get_top_move_for_player_on_turn(Game *game, MoveList *move_list);
 Move *get_top_equity_move_for_inferences(
     Game *game, MoveList *move_list, Equity target_equity,
     int target_leave_size_for_exchange_cutoff, Equity equity_margin);

--- a/test/autoplay_test.c
+++ b/test/autoplay_test.c
@@ -218,6 +218,44 @@ void test_autoplay_divergent_games(void) {
   config_destroy(csw_config);
 }
 
+// Regression test: static (non-simming) autoplay must respect each player's
+// configured move_sort_type ("s1"/"s2"). Before this was fixed, static play
+// always used get_top_equity_move regardless of the configured sort type, so
+// the "s1"/"s2" args had no effect on play and game pairs never diverged.
+void test_autoplay_sort_type_divergence(void) {
+  Config *csw_config = config_create_or_die("set -lex CSW21");
+
+  // With one player sorting moves by score and the other by equity, the two
+  // players in a game pair should almost always choose different moves, so
+  // essentially every game pair should be recorded as divergent.
+  load_and_exec_config_or_die(
+      csw_config, "autoplay games 50 -seed 50 -s1 equity -s2 score -gp true");
+
+  char *ar_diff_sort_str = autoplay_results_to_string(
+      config_get_autoplay_results(csw_config), false, true);
+  assert_autoplay_output(
+      ar_diff_sort_str, 2,
+      (const char *[]){"autoplay games 100", "autoplay games 100"});
+
+  free(ar_diff_sort_str);
+
+  // Sanity check: with both players using the same sort type, the games
+  // should not diverge (mirrors the same-lexicon case in
+  // test_autoplay_divergent_games).
+  load_and_exec_config_or_die(
+      csw_config, "autoplay games 50 -seed 50 -s1 equity -s2 equity -gp true");
+
+  char *ar_same_sort_str = autoplay_results_to_string(
+      config_get_autoplay_results(csw_config), false, true);
+  assert_autoplay_output(
+      ar_same_sort_str, 2,
+      (const char *[]){"autoplay games 100", "autoplay games 0"});
+
+  free(ar_same_sort_str);
+
+  config_destroy(csw_config);
+}
+
 void test_autoplay_win_pct_record(void) {
   Config *csw_config =
       config_create_or_die("set -lex CSW21 -s1 equity -s2 equity -r1 all -r2 "
@@ -560,6 +598,7 @@ void test_autoplay_remaining(void) {
   test_odds_that_player_is_better();
   test_autoplay_leavegen();
   test_autoplay_divergent_games();
+  test_autoplay_sort_type_divergence();
   test_autoplay_win_pct_record();
   test_autoplay_leaves_record();
   test_autoplay_leavegen_force_racks();

--- a/test/gameplay_test.c
+++ b/test/gameplay_test.c
@@ -912,6 +912,46 @@ void test_incremental_cross_set_undo(void) {
   config_destroy(dual_config);
 }
 
+// Regression test: get_top_move_for_player_on_turn (used by autoplay's
+// static, non-simming play) must sort/select moves using the move_sort_type
+// configured on the player on turn, instead of always using MOVE_SORT_EQUITY
+// like get_top_equity_move does. With rack "DEKNRTY" on an empty board, the
+// top-scoring play and the top-equity play both score 36 but leave different
+// racks behind, so this rack distinguishes the two sort types: a move
+// selected by MOVE_SORT_SCORE has no leave value applied (its equity equals
+// its raw score), while the move selected by MOVE_SORT_EQUITY has a higher
+// equity than its score because it also accounts for leave value.
+void test_get_top_move_for_player_on_turn_respects_sort_type(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -s1 equity -s2 equity -r1 all -r2 all -numplays 1");
+  Game *game = config_game_create(config);
+  Player *player0 = game_get_player(game, 0);
+  MoveList *move_list = move_list_create(1000);
+
+  draw_rack_string_from_bag(game, 0, "DEKNRTY");
+
+  player_set_move_sort_type(player0, MOVE_SORT_SCORE);
+  const Move *score_move = get_top_move_for_player_on_turn(game, move_list);
+  assert(equity_to_int(move_get_score(score_move)) == 36);
+  // The move chosen by score has no leave value applied, so its equity
+  // exactly equals its score.
+  assert(move_get_score(score_move) == move_get_equity(score_move));
+
+  player_set_move_sort_type(player0, MOVE_SORT_EQUITY);
+  const Move *equity_move = get_top_move_for_player_on_turn(game, move_list);
+  assert(equity_to_int(move_get_score(equity_move)) == 36);
+  // The move chosen by equity leaves a better rack behind, so its equity is
+  // strictly higher than its raw score.
+  assert(move_get_equity(equity_move) > move_get_score(equity_move));
+
+  // The two sort types must choose different moves.
+  assert(compare_moves_without_equity(score_move, equity_move, true) != 0);
+
+  move_list_destroy(move_list);
+  game_destroy(game);
+  config_destroy(config);
+}
+
 void test_gameplay(void) {
   test_draw_to_full_rack();
   test_rack_is_drawable();
@@ -924,4 +964,5 @@ void test_gameplay(void) {
   test_leave_record();
   test_moves_are_similar();
   test_incremental_cross_set_undo();
+  test_get_top_move_for_player_on_turn_respects_sort_type();
 }


### PR DESCRIPTION
## Problem

`game_runner_get_best_move()` (autoplay's static, non-simming move-selection path) always called `get_top_equity_move()`, which hardcodes `MOVE_SORT_EQUITY`/`MOVE_RECORD_BEST` regardless of the player's configured `move_sort_type`.

Concretely, this meant the `-s1`/`-s2` autoplay args had no effect on static play: `autoplay games 20 -s1 equity -s2 score -gp true` played both players identically (top-equity move every turn), so game pairs never diverged even though the two players were supposedly using different strategies.

## Fix

Add `get_top_move_for_player_on_turn()` in `gameplay.c`, which reuses the existing `generate_moves_for_game_override_record_type()` helper to keep `MOVE_RECORD_BEST` (matching autoplay's prior behavior/speed) while sorting by whatever `move_sort_type` is configured on the player on turn. `game_runner_get_best_move()` in `autoplay.c` now calls this instead of `get_top_equity_move()`.

`get_top_equity_move()` itself is left untouched, since its other callers (`play_chooser.c`, `random_variable.c`) intentionally want the top-equity move regardless of player config.

## Verification

Before the fix:
```
autoplay games 20 -lex CSW24 -s1 equity -s2 score -gp true
...
Divergent Games
Games Played: 0
```

After the fix, the same command shows all games diverging, and the equity-sort player wins with high confidence over the score-sort player, as expected:
```
Divergent Games
Games Played: 40
...
Player 1 is better with confidence: 86.58%
```

## Tests

- `test/gameplay_test.c`: new `test_get_top_move_for_player_on_turn_respects_sort_type()` — a direct unit test asserting that, on the same rack/board, `get_top_move_for_player_on_turn()` selects a different move (and a differently-computed equity) depending on whether the player's sort type is `MOVE_SORT_SCORE` or `MOVE_SORT_EQUITY`.
- `test/autoplay_test.c`: new `test_autoplay_sort_type_divergence()` — asserts that `-s1 equity -s2 score` game pairs come back fully divergent, and that `-s1 equity -s2 equity` game pairs do not (sanity check).

Ran `movegen`, `sim`, `gameplay`, and `autoplay` test suites locally — all pass. `format.py --write`, `cppcheck.sh`, and `find_circ_deps.py` are clean. `tidy.sh` reports 92 pre-existing warnings on this branch, all outside the files touched by this PR (confirmed identical against `main`) — none introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)