### PR TITLE
make release: find versioned clang, fail fast without it, else build plain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,9 +26,11 @@ make libmagpie                 # shared library; API is src/impl/cmd_api.h
 make clean                     # remove build artifacts
 ```
 
-The local PGO build uses Clang and `llvm-profdata`, reuses an existing production
-CSW24 RIT (or creates it when missing), discards old profile data, and trains
-the current source on static autoplay. Experimental `pgo`, `pgo_sim`,
+The local PGO build uses Clang and `llvm-profdata`, found under their plain or
+distro-versioned names (`clang-18`, `llvm-profdata-18`); with no clang on PATH,
+`make release` builds the plain optimized release and says so. It reuses an
+existing production CSW24 RIT (or creates it when missing), discards old
+profile data, and trains the current source on static autoplay. Experimental `pgo`, `pgo_sim`,
 `pgo_peg`, and `pgo_eg` targets are also available. Each produces a
 `-march=native` binary for the build machine. Rerun the selected target after
 source changes and on each target architecture. Override `PGO_CC`,

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,12 @@ OBJ_DIR := $(OBJ_ROOT)/$(BUILD)-b$(BOARD_DIM)-r$(RACK_SIZE)
 PGO_DIR ?= $(OBJ_ROOT)/pgo-data
 PGO_RAW_DIR ?= $(PGO_DIR)/raw
 PGO_PROFILE ?= $(abspath $(PGO_DIR)/magpie.profdata)
-PGO_CC ?= clang
+# PGO needs clang's instrumentation and llvm-profdata. Distros often install
+# only versioned names (clang-18, llvm-profdata-18), so look for those too. An
+# explicit PGO_CC or LLVM_PROFDATA on the command line wins. With no clang at
+# all, `make release` builds the plain optimized release and says so.
+PGO_TOOL_VERSIONS := 20 19 18 17 16 15
+PGO_CC ?= $(firstword $(foreach c,clang $(addprefix clang-,$(PGO_TOOL_VERSIONS)),$(if $(shell command -v $(c) 2>/dev/null),$(c),)))
 PGO_LDFLAGS ?=
 PGO_TRAIN_GAMES ?= 16
 PGO_TRAIN_TIME_MS ?= 1000
@@ -48,9 +53,15 @@ PGO_TRAIN_SECONDS ?= 0.05
 PGO_TRAIN_THREADS ?= $(NPROCS)
 PGO_LEAVEGEN_TARGET ?= 100
 PGO_LEAVEGEN_DATA_DIR ?= $(abspath $(PGO_DIR)/leavegen-data)
-LLVM_PROFDATA ?= $(shell command -v llvm-profdata 2>/dev/null)
+# Prefer the llvm-profdata matching a versioned clang (clang-18 pairs with
+# llvm-profdata-18), then the unversioned one, then any versioned one; on macOS
+# Xcode provides it through xcrun.
+PGO_CC_VERSION_SUFFIX := $(patsubst clang%,%,$(notdir $(PGO_CC)))
+LLVM_PROFDATA ?= $(firstword $(foreach p,llvm-profdata$(PGO_CC_VERSION_SUFFIX) llvm-profdata $(addprefix llvm-profdata-,$(PGO_TOOL_VERSIONS)),$(if $(shell command -v $(p) 2>/dev/null),$(p),)))
 ifeq ($(LLVM_PROFDATA),)
+ifneq ($(shell command -v xcrun 2>/dev/null),)
 LLVM_PROFDATA := xcrun llvm-profdata
+endif
 endif
 
 SRC  := $(wildcard $(SRC_DIR)/**/*.c)
@@ -127,6 +138,7 @@ LDFLAGS  := ${ldflags.${BUILD}}
 LDLIBS   := -lm
 
 .PHONY: all clean iwyu release leavegen_pgo_release pgo pgo_sim pgo_peg \
+	pgo_toolchain_check \
 	pgo_eg peg_eg pgo_workload libmagpie examples
 
 all: magpie magpie_test
@@ -210,9 +222,16 @@ clean:
 	@$(RM) -rv $(BIN_DIR) $(OBJ_ROOT) libmagpie_core.a
 
 # The production release is trained on static autoplay, the best general
-# profile in the measured workload matrix.
+# profile in the measured workload matrix. Without clang there is nothing to
+# train with, so build the plain optimized release rather than fail.
 release:
-	$(MAKE) pgo_workload PGO_WORKLOAD=static
+	@if test -n "$(PGO_CC)"; then \
+		$(MAKE) pgo_workload PGO_WORKLOAD=static; \
+	else \
+		echo '*** No clang on PATH for the profile-guided release; building the plain optimized release instead.'; \
+		echo '*** Install clang, or pass PGO_CC=<clang> LLVM_PROFDATA=<llvm-profdata>, to train the PGO build.'; \
+		$(MAKE) magpie BUILD=no_pgo_release; \
+	fi
 
 # Leave generation benefits from its own focused profile.
 leavegen_pgo_release:
@@ -237,11 +256,30 @@ pgo_eg:
 # Accept the originally proposed endgame spelling as an alias.
 peg_eg: pgo_eg
 
+# Refuse to start a PGO build without its toolchain, instead of failing on the
+# first object file. The instrumentation flags are clang's, so PGO_CC must be
+# some clang; LLVM_PROFDATA may carry an `xcrun` prefix.
+pgo_toolchain_check:
+	@if test -z "$(PGO_CC)"; then \
+		echo '*** PGO needs clang and none was found on PATH (clang, clang-20 .. clang-15).'; \
+		echo '*** Install clang, or pass PGO_CC=<clang> LLVM_PROFDATA=<llvm-profdata>.'; \
+		exit 1; \
+	fi
+	@if ! command -v "$(PGO_CC)" >/dev/null 2>&1; then \
+		echo '*** PGO_CC=$(PGO_CC) was not found on PATH.'; exit 1; \
+	fi
+	@if ! "$(PGO_CC)" --version 2>/dev/null | grep -qi clang; then \
+		echo '*** PGO_CC=$(PGO_CC) is not clang; the PGO instrumentation flags are clang-specific.'; exit 1; \
+	fi
+	@if test -z "$(LLVM_PROFDATA)" || ! command -v $(firstword $(LLVM_PROFDATA)) >/dev/null 2>&1; then \
+		echo '*** PGO needs llvm-profdata (llvm-profdata, llvm-profdata-20 .. -15, or xcrun on macOS); pass LLVM_PROFDATA=<path>.'; exit 1; \
+	fi
+
 # Reuse or build the production RIT, discard all previous profile data, train
 # a freshly instrumented production engine, and replace bin/magpie with the
 # profile-guided native build. The dedicated driver contains no benchmark
 # harness; it invokes real engine workloads directly.
-pgo_workload:
+pgo_workload: pgo_toolchain_check
 	@set -e; if test -f data/lexica/CSW24.rit; then \
 		echo 'Using existing data/lexica/CSW24.rit'; \
 	else \

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ This will start MAGPIE in async interactive mode by default. For more details on
 
 ### Release builds
 
-The production release is a native profile-guided build. Install Clang and
-`llvm-profdata`, then run:
+The production release is a native profile-guided build. It needs Clang and
+`llvm-profdata`; with no clang on PATH it builds the plain optimized release
+instead and says so. Run:
 
 ```
 make release
@@ -83,8 +84,9 @@ The result is tailored to the machine that ran the build, making it suitable
 for long-running jobs and release builds on that target.
 
 Run the selected release target again after changing source, and run it
-separately on each target architecture. Override the tool names when a system
-installs versioned LLVM binaries:
+separately on each target architecture. Versioned LLVM binaries (`clang-18`,
+`llvm-profdata-18`) are found automatically; override the tool names only when
+they live outside `PATH` or you want a particular version:
 
 ```
 make release \

--- a/run
+++ b/run
@@ -65,8 +65,7 @@ xdg-open covhtml/index.html
 
 # Build the production release version of magpie
 elif [ "$1" == "r" ]; then
-make release
-./bin/magpie
+make release && ./bin/magpie
 
 # Run an autoplay perf test
 


### PR DESCRIPTION
## Problem

`PGO_CC ?= clang` was handed to three sub-makes unchecked. On a machine without that exact name — gcc-only, or a distro that installs only `clang-18` — `make release` compiled half the tree and then died on the first object:

```
make[2]: clang: Command not found
make[2]: *** [Makefile:182: obj/no_pgo_release-b15-r7/src/str/move_string.o] Error 127
./run: line 69: ./bin/magpie: No such file or directory
```

## What this does

- **Finds the toolchain.** `PGO_CC` tries `clang`, then `clang-20` … `clang-15`; `LLVM_PROFDATA` tries the one matching a versioned clang first (`clang-18` → `llvm-profdata-18`), then the plain and versioned names, then `xcrun` on macOS. An explicit `PGO_CC=` / `LLVM_PROFDATA=` still wins.
- **Fails before compiling anything.** A `pgo_toolchain_check` prerequisite of `pgo_workload` refuses to start with no compiler, with a `PGO_CC` that is not clang (the instrumentation flags are clang's), or with no `llvm-profdata`, and names the variable to set.
- **`make release` without clang builds the plain optimized release** and says so, so the documented entry point — and `./run r` — still produce a fast binary on a gcc-only box.
- `run r` no longer launches `bin/magpie` after a failed build (`&&`).
- README / AGENTS.md describe the detection and the fallback.

## Validation (M4, macOS)

| path | result |
|---|---|
| `make release` (clang + `xcrun llvm-profdata` detected) | PGO build end to end, exit 0; `pgo_generate` / `pgo_use` / `pgo-data` present; binary loads CSW24 |
| `make release PGO_CC= LLVM_PROFDATA=` (no toolchain) | notice, then `make magpie BUILD=no_pgo_release`; `bin/magpie` built |
| `make release PGO_CC=clang-99` | `*** PGO_CC=clang-99 was not found on PATH.` — nothing compiled |
| `make release PGO_CC=<fake gcc>` | `*** PGO_CC=… is not clang; the PGO instrumentation flags are clang-specific.` |
| `make release LLVM_PROFDATA=` | `*** PGO needs llvm-profdata (…); pass LLVM_PROFDATA=<path>.` |

Not testable here: an Ubuntu box with only `clang-18` on PATH — that is the detection path this is for, and worth one run there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEZJov4z3ZkZpTsTrLQMd1
