### PR TITLE
Fix six pass game end when the bag is empty

### DIFF
--- a/src/impl/config.c
+++ b/src/impl/config.c
@@ -4740,77 +4740,80 @@ void config_game_play_events_internal(Config *config, ErrorStack *error_stack) {
     return;
   }
 
-  // Add the consecutive pass rack end penalties for both players
-  int player_index = game_get_player_on_turn_index(game);
+  // Add the consecutive pass rack end penalties for both players.
+  //
+  // The racks for both players are resolved before either is drawn. When the
+  // game ends on consecutive passes with an empty (or nearly empty) bag, the
+  // tiles one player must draw are sitting on the other player's rack, so
+  // drawing them one player at a time would fail.
+  const int first_player_index = game_get_player_on_turn_index(game);
   const LetterDistribution *ld = game_get_ld(game);
+  const Rack *racks_to_draw[2] = {NULL, NULL};
   for (int i = 0; i < 2; i++) {
-    if (i == 1) {
-      player_index = 1 - player_index;
-    }
-    const Player *player = game_get_player(game, player_index);
-    const Rack *player_rack = player_get_rack(player);
+    const int player_index =
+        i == 0 ? first_player_index : 1 - first_player_index;
     const Rack *rack_to_draw_before_pass_out_game_end =
         game_history_player_get_rack_to_draw_before_pass_out_game_end(
             game_history, player_index);
     if (rack_get_dist_size(rack_to_draw_before_pass_out_game_end) != 0) {
-      if (!rack_is_drawable(game, player_index,
-                            rack_to_draw_before_pass_out_game_end)) {
-        StringBuilder *sb = string_builder_create();
-        string_builder_add_rack(sb, rack_to_draw_before_pass_out_game_end, ld,
-                                false);
-        error_stack_push(
-            error_stack, ERROR_STATUS_COMMIT_PASS_OUT_RACK_NOT_IN_BAG,
-            get_formatted_string(
-                "rack to draw before game end pass out '%s' for player '%s'"
-                "is not available in the bag",
-                string_builder_peek(sb),
-                game_history_player_get_name(game_history, player_index)));
-        string_builder_destroy(sb);
-        return;
-      }
-      return_rack_to_bag(game, player_index);
-      draw_rack_from_bag(game, player_index,
-                         rack_to_draw_before_pass_out_game_end);
-    } else {
-      // Get the rack from the previous pass
-      bool found_pass = false;
-      for (int j = num_events - 1; j >= 0; j--) {
-        GameEvent *game_event = game_history_get_event(game_history, j);
-        if (game_event_get_type(game_event) == GAME_EVENT_PASS &&
-            game_event_get_player_index(game_event) == player_index) {
-          const Rack *prev_pass_rack = game_event_get_rack(game_event);
-          if (!rack_is_drawable(game, player_index, prev_pass_rack)) {
-            StringBuilder *sb = string_builder_create();
-            string_builder_add_rack(sb, prev_pass_rack, ld, false);
-            error_stack_push(
-                error_stack, ERROR_STATUS_COMMIT_PASS_OUT_RACK_NOT_IN_BAG,
-                get_formatted_string(
-                    "rack to draw before game end pass out "
-                    "'%s' for player '%s'"
-                    "is not available in the bag",
-                    string_builder_peek(sb),
-                    game_history_player_get_name(game_history, player_index)));
-            string_builder_destroy(sb);
-            return;
-          }
-          return_rack_to_bag(game, player_index);
-          draw_rack_from_bag(game, player_index, prev_pass_rack);
-          found_pass = true;
-          break;
-        }
-      }
-      if (!found_pass) {
-        error_stack_push(
-            error_stack, ERROR_STATUS_COMMIT_PREVIOUS_PASS_NOT_FOUND,
-            get_formatted_string(
-                "did not find expected previous pass for player '%s' when "
-                "processing consecutive pass game end penalty",
-                game_history_player_get_name(game_history, player_index)));
+      racks_to_draw[i] = rack_to_draw_before_pass_out_game_end;
+      continue;
+    }
+    // Get the rack from the previous pass
+    for (int j = num_events - 1; j >= 0; j--) {
+      const GameEvent *game_event = game_history_get_event(game_history, j);
+      if (game_event_get_type(game_event) == GAME_EVENT_PASS &&
+          game_event_get_player_index(game_event) == player_index) {
+        racks_to_draw[i] = game_event_get_const_rack(game_event);
+        break;
       }
     }
+    if (!racks_to_draw[i]) {
+      error_stack_push(
+          error_stack, ERROR_STATUS_COMMIT_PREVIOUS_PASS_NOT_FOUND,
+          get_formatted_string(
+              "did not find expected previous pass for player '%s' when "
+              "processing consecutive pass game end penalty",
+              game_history_player_get_name(game_history, player_index)));
+      return;
+    }
+  }
 
+  // Both racks go back to the bag before either player draws so that the
+  // tiles held by one player are available to the other.
+  return_rack_to_bag(game, 0);
+  return_rack_to_bag(game, 1);
+
+  for (int i = 0; i < 2; i++) {
+    const int player_index =
+        i == 0 ? first_player_index : 1 - first_player_index;
+    if (!rack_is_drawable(game, player_index, racks_to_draw[i])) {
+      StringBuilder *sb = string_builder_create();
+      string_builder_add_rack(sb, racks_to_draw[i], ld, false);
+      error_stack_push(
+          error_stack, ERROR_STATUS_COMMIT_PASS_OUT_RACK_NOT_IN_BAG,
+          get_formatted_string(
+              "rack to draw before game end pass out '%s' for player '%s'"
+              "is not available in the bag",
+              string_builder_peek(sb),
+              game_history_player_get_name(game_history, player_index)));
+      string_builder_destroy(sb);
+      return;
+    }
+    draw_rack_from_bag(game, player_index, racks_to_draw[i]);
+  }
+
+  for (int i = 0; i < 2; i++) {
+    const int player_index =
+        i == 0 ? first_player_index : 1 - first_player_index;
     draw_to_full_rack(game, player_index);
+  }
 
+  for (int i = 0; i < 2; i++) {
+    const int player_index =
+        i == 0 ? first_player_index : 1 - first_player_index;
+    const Player *player = game_get_player(game, player_index);
+    const Rack *player_rack = player_get_rack(player);
     const Equity end_rack_penalty = calculate_end_rack_penalty(player_rack, ld);
     GameEvent *rack_penalty_event =
         game_history_add_game_event(game_history, error_stack);

--- a/test/config_test.c
+++ b/test/config_test.c
@@ -2227,6 +2227,77 @@ void test_config_load_incomplete(void) {
   config_destroy(config);
 }
 
+// The game ends on six passes with an empty bag. The tiles each player has to
+// draw back for the end rack penalties are sitting on the other player's rack,
+// so both racks must be returned to the bag before either player draws.
+void test_config_six_pass_empty_bag(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -s1 equity -s2 equity -r1 all -r2 all -numplays 1");
+
+  load_and_exec_config_or_die(config, "load testdata/gcgs/success_standard");
+  // Rewind to the position just before the final outplay, where the bag is
+  // empty, HastyBot holds I and RightBehindYou holds OST.
+  load_and_exec_config_or_die(config, "goto 26");
+  const Game *game = config_get_game(config);
+  assert(bag_get_letters(game_get_bag(game)) == 0);
+  assert_rack_equals_string(game_get_ld(game),
+                            player_get_rack(game_get_player(game, 0)), "I");
+  assert_rack_equals_string(game_get_ld(game),
+                            player_get_rack(game_get_player(game, 1)), "OST");
+  assert(equity_to_int(player_get_score(game_get_player(game, 0))) == 516);
+  assert(equity_to_int(player_get_score(game_get_player(game, 1))) == 362);
+
+  for (int pass_index = 0; pass_index < 6; pass_index++) {
+    assert_config_exec_status(config, "com pass", ERROR_STATUS_SUCCESS);
+  }
+
+  game = config_get_game(config);
+  assert(game_get_game_end_reason(game) == GAME_END_REASON_CONSECUTIVE_ZEROS);
+  // Both players keep the rack they passed with and are penalized for it.
+  assert_rack_equals_string(game_get_ld(game),
+                            player_get_rack(game_get_player(game, 0)), "I");
+  assert_rack_equals_string(game_get_ld(game),
+                            player_get_rack(game_get_player(game, 1)), "OST");
+  assert(equity_to_int(player_get_score(game_get_player(game, 0))) == 515);
+  assert(equity_to_int(player_get_score(game_get_player(game, 1))) == 359);
+  // Six passes plus the two end rack penalty events.
+  assert(game_history_get_num_events(config_get_game_history(config)) == 34);
+
+  config_destroy(config);
+}
+
+// The game ends on six passes with fewer than RACK_SIZE tiles left in the bag,
+// so the two racks do not account for every unseen tile.
+void test_config_six_pass_partial_bag(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -s1 equity -s2 equity -r1 all -r2 all -numplays 1");
+
+  load_and_exec_config_or_die(config, "load testdata/gcgs/success_standard");
+  // Rewind to a position with 5 tiles left in the bag.
+  load_and_exec_config_or_die(config, "goto 22");
+  // RightBehindYou is on turn holding ILOOPQR. The other twelve unseen tiles
+  // are still in the bag object, seven of which are HastyBot's unknown rack,
+  // leaving five tiles that neither player will hold.
+  const Game *game = config_get_game(config);
+  assert(bag_get_letters(game_get_bag(game)) == 12);
+
+  for (int pass_index = 0; pass_index < 6; pass_index++) {
+    if (pass_index % 2 == 0) {
+      assert_config_exec_status(config, "rack ILOOPQR", ERROR_STATUS_SUCCESS);
+    } else {
+      assert_config_exec_status(config, "rack EEIIPRU", ERROR_STATUS_SUCCESS);
+    }
+    assert_config_exec_status(config, "com pass", ERROR_STATUS_SUCCESS);
+  }
+
+  game = config_get_game(config);
+  assert(game_get_game_end_reason(game) == GAME_END_REASON_CONSECUTIVE_ZEROS);
+  assert(equity_to_int(player_get_score(game_get_player(game, 0))) == 472);
+  assert(equity_to_int(player_get_score(game_get_player(game, 1))) == 271);
+
+  config_destroy(config);
+}
+
 void test_config_export(void) {
   Config *config = config_create_default_test();
   assert_config_exec_status(config, "ex",
@@ -3013,6 +3084,8 @@ void test_config(void) {
   test_config_anno_challenge();
   test_config_anno_endgame_rack();
   test_config_load_incomplete();
+  test_config_six_pass_empty_bag();
+  test_config_six_pass_partial_bag();
   test_config_challenge_rack();
   test_config_export();
   test_config_load_error_cases();


### PR DESCRIPTION
When a game ends on six consecutive passes, each player's final rack is restored from their last pass event so the end rack penalties can be computed. This was done one player at a time: the first player's rack was returned to the bag and redrawn before the second player's rack was even checked for drawability.

rack_is_drawable only counts the bag plus that player's own rack, so with an empty bag the check failed. Every remaining tile is on the two racks at that point, and the rack inference in set_after_game_event_racks hands all the unaccounted tiles to a single player, leaving the other player's pass rack neither in the bag nor on their rack:

  (error 194) rack to draw before game end pass out 'LR' for player
  'Terry' is not available in the bag

With a full bag the tiles really are in the bag, which is why only the empty bag case broke.

Resolve both players' pass racks first, return both racks to the bag, and only then check drawability and draw. Exact multiset removal makes feasibility order independent, so both players are now checked against the whole unseen pool. Drawing to a full rack is deferred until both exact draws are done so neither player can steal the other's tiles.

Adds two regression tests: a six pass with an empty bag (which reproduces the error without this fix) and a six pass with fewer than RACK_SIZE tiles left in the bag.