### PR TITLE
Do not add leaves to the WMP subrack bound under score sort

### DIFF
--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -1002,7 +1002,12 @@ static inline __attribute__((always_inline)) bool
 wordmap_gen_record_subrack(MoveGen *gen, const Anchor *anchor, int subrack_idx,
                            bool lazy) {
   WMPMoveGen *wgen = &gen->wmp_move_gen;
-  if (gen->number_of_tiles_in_bag > 0) {
+  // The anchor's score bound plus this subrack's leave bounds the equity of
+  // every play the subrack can make, so under equity sort a subrack whose
+  // bound cannot reach the cutoff is skipped. Under score sort the cutoff is
+  // a score, which the anchor-level check already bounded; adding a leave
+  // there would skip subracks that still hold plays above the cutoff.
+  if (gen->wmp_prune_subracks_by_leave) {
     const Equity leave_value = wmp_move_gen_get_leave_value(wgen, subrack_idx);
     if (better_play_has_been_found(gen, leave_value +
                                             anchor->highest_possible_score)) {
@@ -3148,6 +3153,8 @@ void gen_load_position(MoveGen *gen, const MoveGenArgs *args) {
 
   gen->bingo_bonus = game_get_bingo_bonus(game);
   gen->number_of_tiles_in_bag = bag_get_letters(game_get_bag(game));
+  gen->wmp_prune_subracks_by_leave = (gen->number_of_tiles_in_bag > 0) &&
+                                     (gen->move_sort_type == MOVE_SORT_EQUITY);
   gen->kwgs_are_shared = game_get_data_is_shared(game, PLAYERS_DATA_TYPE_KWG);
   gen->move_list = move_list;
   gen->cross_index =

--- a/src/impl/move_gen.h
+++ b/src/impl/move_gen.h
@@ -90,6 +90,10 @@ typedef struct MoveGen {
   int move_sort_type;
   move_record_t move_record_type;
   int number_of_tiles_in_bag;
+  // Whether a subrack's leave may take part in the bound that decides if the
+  // subrack can still beat the cutoff: only when the bag is not empty and
+  // the sort is by equity.
+  bool wmp_prune_subracks_by_leave;
   int player_index;
   Equity bingo_bonus;
   bool kwgs_are_shared;

--- a/test/wmp_move_gen_test.c
+++ b/test/wmp_move_gen_test.c
@@ -735,6 +735,161 @@ static void test_playthrough_moves_against_recursive(void) {
   config_destroy(reference);
 }
 
+// Under score sort the cutoff is a score, so a subrack's leave value must take
+// no part in the bound that decides whether the subrack can still beat the
+// cutoff (#673). This drives the WMP generator through the cutoff-based record
+// modes on a set of positions in both sort types and checks each result
+// against the full list: the best move carries the head's equity, and a
+// within-x list holds every play strictly inside the margin. Equal-equity
+// ties are compared by membership rather than position, since shadow lets the
+// bounded modes skip anchors that cannot beat the running cutoff and that
+// decides ties by anchor order.
+enum { CUTOFF_MODES_FULL_CAPACITY = 100000 };
+
+// A SortedMoveList borrows its Move objects from the MoveList it was built
+// from, so the two live and die together.
+typedef struct CutoffModesGeneration {
+  MoveList *move_list;
+  SortedMoveList *sorted;
+} CutoffModesGeneration;
+
+static CutoffModesGeneration
+cutoff_modes_generate(Game *game, move_record_t record_type,
+                      move_sort_t sort_type, Equity eq_margin, int capacity) {
+  CutoffModesGeneration generation;
+  generation.move_list = move_list_create(capacity);
+  const MoveGenArgs args = {
+      .game = game,
+      .move_list = generation.move_list,
+      .move_record_type = record_type,
+      .move_sort_type = sort_type,
+      .eq_margin_movegen = eq_margin,
+      .target_equity = EQUITY_MAX_VALUE,
+      .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+  };
+  // Not generate_moves_for_game(): that replaces the record type with the
+  // on-turn player's configured one.
+  generate_moves(&args);
+  generation.sorted = sorted_move_list_create(generation.move_list);
+  return generation;
+}
+
+static void cutoff_modes_generation_destroy(CutoffModesGeneration *generation) {
+  sorted_move_list_destroy(generation->sorted);
+  move_list_destroy(generation->move_list);
+}
+
+static bool cutoff_modes_moves_match(const Move *move_1, const Move *move_2) {
+  if (move_get_type(move_1) != move_get_type(move_2) ||
+      move_get_row_start(move_1) != move_get_row_start(move_2) ||
+      move_get_col_start(move_1) != move_get_col_start(move_2) ||
+      move_get_dir(move_1) != move_get_dir(move_2) ||
+      move_get_tiles_played(move_1) != move_get_tiles_played(move_2) ||
+      move_get_tiles_length(move_1) != move_get_tiles_length(move_2) ||
+      move_get_score(move_1) != move_get_score(move_2) ||
+      move_get_equity(move_1) != move_get_equity(move_2)) {
+    return false;
+  }
+  for (int tile_idx = 0; tile_idx < move_get_tiles_length(move_1); tile_idx++) {
+    if (move_get_tile(move_1, tile_idx) != move_get_tile(move_2, tile_idx)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static void cutoff_modes_assert_in_list(const SortedMoveList *full,
+                                        const Move *move) {
+  for (int move_idx = 0; move_idx < full->count; move_idx++) {
+    if (cutoff_modes_moves_match(full->moves[move_idx], move)) {
+      return;
+    }
+  }
+  assert(false);
+}
+
+static int cutoff_modes_count_above(const SortedMoveList *sorted,
+                                    Equity cutoff) {
+  int count = 0;
+  while (count < sorted->count &&
+         move_get_equity(sorted->moves[count]) > cutoff) {
+    count++;
+  }
+  return count;
+}
+
+static void assert_cutoff_modes_are_complete(Game *game,
+                                             move_sort_t sort_type) {
+  CutoffModesGeneration full_generation = cutoff_modes_generate(
+      game, MOVE_RECORD_ALL, sort_type, 0, CUTOFF_MODES_FULL_CAPACITY);
+  const SortedMoveList *full = full_generation.sorted;
+  assert(full->count > 10);
+
+  CutoffModesGeneration best_generation =
+      cutoff_modes_generate(game, MOVE_RECORD_BEST, sort_type, 0, 1);
+  const SortedMoveList *best = best_generation.sorted;
+  assert(best->count == 1);
+  assert(move_get_equity(best->moves[0]) == move_get_equity(full->moves[0]));
+  cutoff_modes_assert_in_list(full, best->moves[0]);
+  cutoff_modes_generation_destroy(&best_generation);
+
+  const int margins[] = {0, 5, 20, 40};
+  const int num_margins = 4;
+  for (int margin_idx = 0; margin_idx < num_margins; margin_idx++) {
+    const Equity margin = int_to_equity(margins[margin_idx]);
+    CutoffModesGeneration within_generation =
+        cutoff_modes_generate(game, MOVE_RECORD_WITHIN_X_EQUITY_OF_BEST,
+                              sort_type, margin, CUTOFF_MODES_FULL_CAPACITY);
+    const SortedMoveList *within = within_generation.sorted;
+    const Equity cutoff = move_get_equity(full->moves[0]) - margin;
+    assert(within->count > 0);
+    assert(move_get_equity(within->moves[0]) ==
+           move_get_equity(full->moves[0]));
+    assert(cutoff_modes_count_above(within, cutoff) ==
+           cutoff_modes_count_above(full, cutoff));
+    for (int move_idx = 0; move_idx < within->count; move_idx++) {
+      assert(move_get_equity(within->moves[move_idx]) >= cutoff);
+      cutoff_modes_assert_in_list(full, within->moves[move_idx]);
+    }
+    cutoff_modes_generation_destroy(&within_generation);
+  }
+  cutoff_modes_generation_destroy(&full_generation);
+}
+
+void test_wmp_cutoff_modes_are_complete(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW21 -wmp true -s1 equity -s2 equity -r1 all -r2 all "
+      "-numplays 1 -threads 1");
+  // Midgame boards with a full bag, racks holding blanks and fewer than seven
+  // tiles, late boards with a short bag, the same endgame board with the bag
+  // empty and with two tiles left, and an opening rack on an empty board.
+  const char *cgps[] = {
+      "cgp " DOUG_V_EMELY_CGP,
+      "cgp " GUY_VS_BOT_CGP,
+      "cgp " NOAH_VS_MISHU_CGP,
+      "cgp " JOSH2_CGP,
+      "cgp " SOME_ISC_GAME_CGP,
+      "cgp " UTF8_DOS_CGP,
+      "cgp " VS_FRENTZ_CGP,
+      "cgp " NOAH_VS_PETER_CGP,
+      "cgp " DOUG_V_EMELY_DOUBLE_CHALLENGE_CGP,
+      "cgp 5U4OHMIC/5N3WREATH/5T4FAX2/5i3B1VIA1/5N3L1E3/5G2VELDT2/5E3S5/"
+      "5DREKS1F3/8YELL3/4ABASER1U3/4GYM3ZO3/WAITE5OR2J/10OI2A/3QUOIT1PINNER/"
+      "4RENEGADE2P CDIOST?/AIINOOU 450/392 0 -lex CSW21;",
+      "cgp 5U4OHMIC/5N3WREATH/5T4FAX2/5i3B1VIA1/5N3L1E3/5G2VELDT2/5E3S5/"
+      "5DREKS1F3/8YELL3/4ABASER1U3/4GYM3ZO3/WAITE5OR2J/10OI2A/3QUOIT1PINNER/"
+      "4RENEGADE2P AIINOOU/CDIOS 392/450 0 -lex CSW21;",
+  };
+  const int num_cgps = 11;
+  for (int cgp_idx = 0; cgp_idx < num_cgps; cgp_idx++) {
+    load_and_exec_config_or_die(config, cgps[cgp_idx]);
+    Game *game = config_get_game(config);
+    assert_cutoff_modes_are_complete(game, MOVE_SORT_EQUITY);
+    assert_cutoff_modes_are_complete(game, MOVE_SORT_SCORE);
+  }
+  config_destroy(config);
+}
+
 void test_wmp_move_gen(void) {
   test_wmp_move_gen_inactive();
   test_shadow_playthrough_restoration();
@@ -745,6 +900,7 @@ void test_wmp_move_gen(void) {
   test_nonplaythrough_existence();
   test_playthrough_bingo_existence();
   test_wmp_bounded_record_modes();
+  test_wmp_cutoff_modes_are_complete();
 }
 
 // The RIT-backed path resolves nonplaythrough WMP entries lazily at record


### PR DESCRIPTION
Fixes #673.

## What this does

In the WMP path, `wordmap_gen_record_subrack` skips a subrack when the anchor's highest possible score plus the subrack's leave value cannot beat the record cutoff. That sum bounds **equity**, which is what the cutoff measures under equity sort. Under score sort the cutoff is a **score**, and a negative leave pulls the bound below plays the subrack can still make, so the subrack is skipped and its plays are never generated. It bites in whichever direction is generated second, once the cutoff has risen.

The leave now takes part in the bound only when the bag is not empty and the sort is by equity. The decision is made once per generation in `gen_load_position` (`wmp_prune_subracks_by_leave`), so the per-subrack test stays a single flag check, as it was. Under score sort nothing replaces it: the anchor-level check in `gen_record_scoring_plays` already bounded the score.

```c
  // move_gen.c, wordmap_gen_record_subrack
  if (gen->wmp_prune_subracks_by_leave) {
    const Equity leave_value = wmp_move_gen_get_leave_value(wgen, subrack_idx);
    if (better_play_has_been_found(gen, leave_value +
                                            anchor->highest_possible_score)) {
      return false;
    }
  }

  // gen_load_position
  gen->wmp_prune_subracks_by_leave =
      (gen->number_of_tiles_in_bag > 0) &&
      (gen->move_sort_type == MOVE_SORT_EQUITY);
```

## Where it came from

The original WMP move generator. The subrack prune was written in `b6a84ef6` (2025-09-11, "functions for wmp movegen in move_gen.c (not called)") with only the `bag > 0` guard, and went live the next day in `d8064509`. The non-WMP path had guarded its own leave-based prune (`record_exchange`) with `move_sort_type == MOVE_SORT_EQUITY` since early 2024; the WMP port omitted that guard. Later refactors of this loop (the masked-scan split in September 2026) moved the lines and kept the logic. So it is not a regression from an equity-sort optimization; it has been there for every score-sorted WMP generation since the WMP path shipped.

## What it affected

- `MOVE_RECORD_WITHIN_X_EQUITY_OF_BEST` under score sort: lists missing plays above the cutoff, including ties for the best (E7 LID for 4 on the WINDY position; a 24-point tie on another).
- `MOVE_RECORD_BEST` under score sort is exposed to the same skip whenever a better play scores less than |leave| above the running best and its anchor's bound is not slack enough to absorb it. And it did: over 400 score-sorted autoplay games `main`'s WMP generator diverges from the non-WMP generator's play, and the fixed one matches it move for move (differential below).
- Equity sort is unaffected: the bound is correct there, and the test below holds on `main` for it.

## Correctness

- **New test** `test_wmp_cutoff_modes_are_complete` (`wmg` suite): drives `MOVE_RECORD_BEST` and within-x lists (margins 0/5/20/40) through eleven CSW21 positions in both sort types and checks each against the full list — the best move carries the head's equity, and a within-x list holds every play strictly inside the margin, with equal-equity ties compared by membership. It fails on `main` under score sort (`cutoff_modes_count_above(within, cutoff) == cutoff_modes_count_above(full, cutoff)` on the first position) and passes with the fix.
- **Autoplay differential** against `main` (200 game pairs, CSW24 with WMP, WIT, RIT, seed 4242): with the WMP, WIT and RIT on, seed 4242. Score sort, `best`: the fixed generator's games are **identical to the generator without a WMP** (`-wmp false`, the reference path), while `main`'s WMP games diverge from it (9,230 vs 9,498 turns over the 400 games). Equity sort, `best`: WMP and non-WMP games identical on both, so equity sort is untouched. Score sort with `all -numplays 5` and with within-x: fixed vs `main` differ, as expected.
- ASan `wmg movegen shadow`; release `wmg movegen shadow sim witsweep witdiff`; cppcheck, circular-dependency check and `format.py` clean.

## Performance

No difference. In the benchmark workload (equity sort, bag not empty) the flag is true exactly when the old `bag > 0` test was true, so the pruning decisions are the same as on `main`; the only question was codegen, and it comes out even. M4 Mac mini, 8 workers, `no_pgo_release`, `simbench` 0.5 s/turn, WIT on, seeds 42/24301/1552 × 6 interleaved rounds, paired within-round geometric means, stratified-bootstrap 95% CIs, 18 pairs per row:

| configuration | fix vs `main` | 95% CI |
|---|---:|---:|
| RIT on | +0.03% | [-0.22%, +0.35%] |
| RIT off | +0.01% | [-0.09%, +0.11%] |

The flag exists because the alternative costs: writing the fix as `bag > 0 && sort == equity` per subrack, with no new field, measured **-1.44%** [-1.79%, -1.05%] against `main` in the same campaign. Where the flag sits in `MoveGen` makes no difference (a variant with it at the end of the struct is within 0.2% either way). The full codegen, layout and profile comparison is in a comment below.

## Related

- #612's `test_wmp_bounded_record_modes` limits its within-x check to equity sort because of this bug; once this merges that guard can go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEZJov4z3ZkZpTsTrLQMd1
