### PR TITLE
Fix WMP anchor overflow at maximum playthrough blocks

### DIFF
--- a/src/impl/wmp_move_gen.h
+++ b/src/impl/wmp_move_gen.h
@@ -19,8 +19,9 @@
 
 enum {
   MAX_POSSIBLE_PLAYTHROUGH_BLOCKS = ((BOARD_DIM / 2) + 1),
+  // Block count zero also occupies a row in the anchor table.
   MAX_WMP_MOVE_GEN_ANCHORS =
-      ((RACK_SIZE + 1) * MAX_POSSIBLE_PLAYTHROUGH_BLOCKS),
+      ((RACK_SIZE + 1) * (MAX_POSSIBLE_PLAYTHROUGH_BLOCKS + 1)),
 };
 
 typedef struct SubrackInfo {

--- a/test/wmp_move_gen_test.c
+++ b/test/wmp_move_gen_test.c
@@ -890,7 +890,24 @@ void test_wmp_cutoff_modes_are_complete(void) {
   config_destroy(config);
 }
 
+void test_wmp_maximum_playthrough_blocks(void) {
+  WMPMoveGen wmg = {0};
+  for (int block = 0; block < MAX_POSSIBLE_PLAYTHROUGH_BLOCKS; block++) {
+    wmp_move_gen_increment_playthrough_blocks(&wmg);
+  }
+  wmp_move_gen_maybe_update_anchor(&wmg, RACK_SIZE,
+                                   MAX_POSSIBLE_PLAYTHROUGH_BLOCKS + RACK_SIZE,
+                                   0, int_to_equity(50), int_to_equity(50));
+  const Anchor *anchor =
+      wmp_move_gen_get_anchor(&wmg, MAX_POSSIBLE_PLAYTHROUGH_BLOCKS, RACK_SIZE);
+  assert(anchor->tiles_to_play == RACK_SIZE);
+  assert(anchor->playthrough_blocks == MAX_POSSIBLE_PLAYTHROUGH_BLOCKS);
+  wmp_move_gen_reset_anchors(&wmg);
+  assert(anchor->tiles_to_play == 0);
+}
+
 void test_wmp_move_gen(void) {
+  test_wmp_maximum_playthrough_blocks();
   test_wmp_move_gen_inactive();
   test_shadow_playthrough_restoration();
   test_playthrough_positions_reset();


### PR DESCRIPTION
Fixes #676.

A 15-square extent can contain eight existing-tile blocks separated by seven new tiles. The anchor index is then 71, but the old table has only 64 slots because it omits the zero-block row when sizing the array. Include block counts zero through the maximum, increasing the standard-board capacity to 72.

Add an asset-independent regression to `wmg` that records the maximum-block/rack-size anchor, verifies its fields, and resets it. With the old allocation, this test fails under UBSan at index 71; with the fix it passes.

Validation:
- Confirmed the regression fails before the fix and passes afterward with `UBSAN_OPTIONS=halt_on_error=1`.
- ASan/UBSan `wmg`, `shadow`, and `movegen` suites pass.
- The captured FRA24 rollout position generates safely and produces identical output with WMP on/off after the fix.
- The original five-ply FRA24 simulation passes under ASan/UBSan.
- Project formatter and `git diff --check` pass.

The reproducer and diagnostic are in #676. Sparse-anchor implementations such as #667 must size their masks from the updated capacity (72 slots require two 64-bit words).
