### PR TITLE
Skip playthrough rack preparation for rejected anchors

### DIFF
--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -1127,7 +1127,7 @@ wordmap_gen(MoveGen *gen, const Anchor *anchor, bool lazy) {
       wgen, anchor, gen->row_squares,
       gen->word_info_table != NULL ? gen->wit_row_lane : NULL,
       gen->wit_len_lane, gen->word_info_table);
-  wmp_move_gen_playthrough_subracks_init(wgen, anchor);
+  wmp_move_gen_playthrough_metadata_init(wgen, anchor);
 
   assert(anchor->leftmost_start_col <= anchor->rightmost_start_col);
   assert(anchor->leftmost_start_col <= anchor->col);
@@ -1173,6 +1173,10 @@ wordmap_gen(MoveGen *gen, const Anchor *anchor, bool lazy) {
       return;
     }
   }
+
+  // Neither whole-anchor rejection above needs combined subracks. Build
+  // them sequentially once for either surviving subrack scan below.
+  wmp_move_gen_build_playthrough_subracks(wgen);
 
   // The forbidden set is the same for every subrack, so decide once per
   // anchor. The masked scan lives out of line; this loop stays the one the

--- a/src/impl/wmp_move_gen.h
+++ b/src/impl/wmp_move_gen.h
@@ -212,12 +212,19 @@ wmp_move_gen_enumerate_nonplaythrough_subracks(WMPMoveGen *wmp_move_gen,
 }
 
 static inline void
-wmp_move_gen_playthrough_subracks_init(WMPMoveGen *wmp_move_gen,
+wmp_move_gen_playthrough_metadata_init(WMPMoveGen *wmp_move_gen,
                                        const Anchor *anchor) {
-  const int subrack_size = anchor->tiles_to_play;
   wmp_move_gen->word_length = anchor->word_length;
-  wmp_move_gen->num_tiles_played_through = anchor->word_length - subrack_size;
-  wmp_move_gen->tiles_to_play = subrack_size;
+  wmp_move_gen->num_tiles_played_through =
+      anchor->word_length - anchor->tiles_to_play;
+  wmp_move_gen->tiles_to_play = anchor->tiles_to_play;
+}
+
+// Preserve the sequential preparation loop for anchors that survive the
+// whole-anchor mask and rack-capacity checks.
+static inline void
+wmp_move_gen_build_playthrough_subracks(WMPMoveGen *wmp_move_gen) {
+  const int subrack_size = wmp_move_gen->tiles_to_play;
   if (wmp_move_gen->num_tiles_played_through == 0) {
     // We can use nonplaythrough subracks
     return;
@@ -233,6 +240,13 @@ wmp_move_gen_playthrough_subracks_init(WMPMoveGen *wmp_move_gen,
     bit_rack_add_bit_rack(&playthrough_subrack_info->subrack,
                           &wmp_move_gen->playthrough_bit_rack);
   }
+}
+
+static inline void
+wmp_move_gen_playthrough_subracks_init(WMPMoveGen *wmp_move_gen,
+                                       const Anchor *anchor) {
+  wmp_move_gen_playthrough_metadata_init(wmp_move_gen, anchor);
+  wmp_move_gen_build_playthrough_subracks(wmp_move_gen);
 }
 
 // Necessary-only prune for a multi-playthrough case. Tests each

--- a/test/wmp_move_gen_test.c
+++ b/test/wmp_move_gen_test.c
@@ -25,6 +25,7 @@
 #include "../src/impl/move_gen.h"
 #include "../src/impl/wmp_move_gen.h"
 #include "../src/impl/word_info_table_maker.h"
+#include "../src/util/io_util.h"
 #include "test_constants.h"
 #include "test_util.h"
 #include <assert.h>
@@ -1056,7 +1057,104 @@ void test_wmp_maximum_playthrough_blocks(void) {
   assert(anchor->tiles_to_play == 0);
 }
 
+// Metadata remains current even when an anchor is rejected before any
+// combined row is built. Model each rejection boundary, then reuse rows for
+// a different block/size and compare the words with the direct WMP API.
+static void test_playthrough_preparation_after_rejection(void) {
+  Config *config = config_create_or_die("set -lex CSW21 -wmp true");
+  Game *game = config_game_create(config);
+  const LetterDistribution *ld = game_get_ld(game);
+  const WMP *wmp = player_get_wmp(game_get_player(game, 0));
+  Rack *rack = rack_create(ld_get_size(ld));
+  rack_set_to_string(ld, rack, "C??");
+  WMPMoveGen wmg = {0};
+  wmp_move_gen_init(&wmg, ld, rack, wmp);
+  MachineLetter *expected_words = malloc_or_die(wmp->max_word_lookup_bytes);
+  const struct {
+    const char *block;
+    const char *subracks[2];
+  } cases[] = {
+      {"AT", {"C", "?"}},    {"A", {"C?", "??"}}, {"IT", {"?", "C"}},
+      {"ZZ", {"C?", "??"}},  {"AA", {"C", "?"}},  {"AT", {"??", "C?"}},
+      {"AT", {"C??", NULL}},
+  };
+  for (size_t case_idx = 0; case_idx < sizeof(cases) / sizeof(cases[0]);
+       case_idx++) {
+    // Shadow can populate a scratch row independently of generation.
+    wmg.playthrough_bit_rack = string_to_bit_rack(ld, "QI");
+    wmg.num_tiles_played_through = 2;
+    (void)wmp_move_gen_check_playthrough_full_rack_existence(&wmg);
+    for (int rejection = 0; rejection < 2; rejection++) {
+      const Anchor skipped = {.tiles_to_play = 3, .word_length = 5};
+      wmg.playthrough_bit_rack = string_to_bit_rack(ld, "QI");
+      wmg.playthrough_addable = rejection == 0 ? 0 : (1U << 1);
+      wmp_move_gen_playthrough_metadata_init(&wmg, &skipped);
+      assert(wmg.word_length == 5 && wmg.tiles_to_play == 3 &&
+             wmg.num_tiles_played_through == 2);
+      if (rejection == 0) {
+        assert(wmg.playthrough_addable == 0);
+      } else {
+        // Only the two rack blanks are usable when A is the sole addable
+        // letter, but this rejected anchor needs three tiles.
+        assert(bit_rack_get_letter(&wmg.player_bit_rack, 1) == 0);
+        assert(bit_rack_get_letter(&wmg.player_bit_rack, BLANK_MACHINE_LETTER) <
+               skipped.tiles_to_play);
+      }
+      // The rejected path omits the builder. A later surviving anchor must
+      // not trust any scratch row left by a different length or shadow.
+      const int size = (int)strlen(cases[case_idx].subracks[0]);
+      const int offset = subracks_get_combination_offset(size);
+      const int count = cases[case_idx].subracks[1] != NULL ? 2 : 1;
+      wmg.count_by_size[size] = (uint8_t)count;
+      for (int idx = 0; idx < count; idx++) {
+        wmg.nonplaythrough_infos[offset + idx].subrack =
+            string_to_bit_rack(ld, cases[case_idx].subracks[idx]);
+      }
+      const Anchor anchor = {
+          .tiles_to_play = (unsigned int)size,
+          .word_length = (unsigned int)(size + strlen(cases[case_idx].block))};
+      wmg.playthrough_bit_rack = string_to_bit_rack(ld, cases[case_idx].block);
+      wmp_move_gen_playthrough_metadata_init(&wmg, &anchor);
+      assert(wmp_move_gen_get_num_subrack_combinations(&wmg) == count);
+      wmp_move_gen_build_playthrough_subracks(&wmg);
+      for (int idx = count - 1; idx >= 0; idx--) {
+        BitRack expected =
+            string_to_bit_rack(ld, cases[case_idx].subracks[idx]);
+        const BitRack canonical = expected;
+        bit_rack_add_bit_rack(&expected, &wmg.playthrough_bit_rack);
+        const int expected_bytes = wmp_write_words_to_buffer(
+            wmp, &expected, (int)anchor.word_length, expected_words);
+        const bool found = wmp_move_gen_get_subrack_words(&wmg, idx, true);
+        assert(found == (expected_bytes > 0));
+        if (found) {
+          assert(wmg.num_words * wmg.word_length == expected_bytes);
+          assert(wmg.words != NULL);
+          assert(memcmp(wmg.words, expected_words, (size_t)expected_bytes) ==
+                 0);
+        }
+        assert(bit_rack_equals(
+            &canonical, &wmg.nonplaythrough_infos[offset + idx].subrack));
+      }
+      // The original one-call initializer keeps its complete semantics for
+      // callers that do not need to put an anchor-level check in between.
+      wmp_move_gen_playthrough_subracks_init(&wmg, &anchor);
+      for (int idx = 0; idx < count; idx++) {
+        BitRack expected =
+            string_to_bit_rack(ld, cases[case_idx].subracks[idx]);
+        bit_rack_add_bit_rack(&expected, &wmg.playthrough_bit_rack);
+        assert(bit_rack_equals(&expected,
+                               &wmg.playthrough_infos[offset + idx].subrack));
+      }
+    }
+  }
+  free(expected_words);
+  rack_destroy(rack);
+  game_destroy(game);
+  config_destroy(config);
+}
+
 void test_wmp_move_gen(void) {
+  test_playthrough_preparation_after_rejection();
   test_wmp_maximum_playthrough_blocks();
   test_word_plus_floater_positional_intersection();
   test_word_plus_floater_dense_coverage();


### PR DESCRIPTION
## What this does

Stacked on #678. Combined playthrough racks are prepared only after the existing whole-anchor WIT and rack-capacity checks succeed. Previously, those checks could reject an anchor after every canonical subrack had already been combined with its fixed board letters.

Anchor metadata is still initialized before filtering. Surviving anchors use the same sequential preparation loop and word-lookup path. The existing initializer remains available as a wrapper for callers that need both steps together. No pruning rule, table, cached state or recording order changes.

## Performance

**Whole-stack comparison:** native stack #681 (#678 → #679 → #680), at `cf0fbb37` versus main `89f54e0c`, gives **+6.04% geometric throughput, +4.30% paired median** across 16 retained pairs. [#680 contains the complete measurement, variability and profile results](https://github.com/jvc56/MAGPIE/pull/680). This measures all three PRs together and does not isolate this PR’s gain.

Measured `1b4877b5` against the combined-WIT #678 head `70d594b9` on an Apple M4 Mac mini: CSW24, four workers, WMP/WIT and RIT mmap enabled, two plies, 0.5 seconds per simulated turn. Each source received its own fresh production PGO profile from 16 static games using Apple Clang 17, `make release`, and four configured training workers.

**16 fresh seed pairs**, eight in each run order, with all 32 timed runs retained. Games play the top static-equity move to hold the board trajectory fixed while measuring simulation iterations per second. The simulation benchmark runs in each PGO-use test binary with the same temporary seedable harness; the submitted harness is unchanged. Table loading is outside the timed region, and both variants load byte-identical full WIT4 data.

| Configuration | Geometric mean gain over #678 | Nominal paired 95% CI | Paired median |
|---|---:|---:|---:|
| Production PGO, RIT on | **+0.97%** | **[+0.40%, +1.54%]** | **+1.10%** |

**14/16 pairs favor this change.** Base-first pairs give +0.78% and candidate-first pairs +1.16%. An independent recomputation from every raw run's iterations and elapsed time agrees with these results.

The interval is Student-t over paired log throughput ratios, conditional on this host, workload and pair of trained binaries. It does not establish gains on other hardware or across repeated PGO training. Process/thermal boundary snapshots and all raw logs are retained; continuous clock/thermal telemetry was not collected. This is the incremental gain over #678.

### Profiling: affected functions

`wmp_move_gen_playthrough_metadata_init` keeps the current word length and tile counts available before the existing checks. `wordmap_gen` now calls `wmp_move_gen_build_playthrough_subracks` after both whole-anchor rejection paths, before either surviving subrack scan. The loop and `wmp_move_gen_get_subrack_words` retain their original bodies.

An earlier untimed observer of the same pruning decisions counted 12,955,864 eager playthrough-rack combinations over 1,000 fixed static games. Of those, 2,313,600 belonged to anchors rejected by these whole-anchor checks: **17.86%** of preparation work that can be skipped at this boundary. These are source-level operation counts from that static corpus, not a function speedup or a new measurement of this candidate.

Six macOS captures use three separate profile seeds, with six seconds of sampling after one second of startup. An independent audit reproduces all exclusive counts and finds no unresolved nonwaiting samples. Pooled exclusive nonwaiting **simulation-worker** shares are:

| Function/path | #678 | This PR |
|---|---:|---:|
| `generate_moves` self, including inlined work | 40.47% | 38.38% |
| Named shadow functions | 29.36% | 28.38% |
| Named wordmap subrack scan/lookup helpers | 1.89% | 1.85% |
| `wmp_get_word_entry` | 0.84% | 0.85% |
| Named WMP word materialization | 3.04% | 2.88% |
| Named move recording | 2.22% | 2.35% |

The actual candidate PGO assembly retains a board-rack load before the original sequential copy/add/store loop. Both whole-anchor rejection branches skip that loop, as intended. Preparation is inlined into its callers, so sampling does not time that loop separately. These shares also reflect game-phase differences and are not per-function speedups; the paired throughput result measures the net improvement.

## Correctness

- Optimized, ASan/UBSan and final production-PGO builds pass complete WIT-on/off comparisons across the same **32 seeded CSW24 games / 723 positions**, checking move identities, scores and equities before and after copy/undo.
- A reuse regression covers both rejected-anchor cutpoints followed by different fixed blocks and rack sizes, one/two blanks, misses, canonical-rack restoration and the exact full-rack row previously written by shadow. It compares complete words against direct WMP lookup and checks the original initializer wrapper.
- A standalone ASan/UBSan driver at `BOARD_DIM=21` checks the actual metadata, preparation and wrapper helpers across **254 combined rows**, including final length 21 and the nonplaythrough return. This is helper coverage, not a full 21-board move corpus.
- Independent review confirms that both surviving scan paths rebuild their current rows before lookup and that shadow overwrites its own scratch before use. Existing recursive move fixtures and the complete differential provide integration coverage beyond the direct reuse fixture.
- Formatting, circular dependencies and targeted cppcheck pass; native clang-tidy reports no new diagnostics relative to the parent. All remote CI checks pass on the published head `1b4877b5`.

Static benchmark score agreement is a workload check, separate from the complete-move correctness comparisons.

## What can build on this

Stronger necessary conditions can reject more anchors before preparation. Compatible base-position masks could provide additional necessary conditions; this change does not depend on an additional table or a new filter.
