### PR TITLE
Prune shadow using positional word-length masks

### DIFF
--- a/src/ent/word_info_table.c
+++ b/src/ent/word_info_table.c
@@ -31,6 +31,7 @@ static void wit_clear(WordInfoTable *wit) {
     free(trie->node_value);
     free(trie->values);
     free(wit->word_plus_floater[length]);
+    free(wit->position_lengths[length]);
   }
   free(wit->name);
   memset(wit, 0, sizeof(*wit));
@@ -94,6 +95,99 @@ static bool wit_validate_trie(const WitTrie *trie, int length) {
   free(seen_values);
   free(seen_nodes);
   return valid;
+}
+
+// Sorted sibling lists let a failed native construction lookup stop as
+// soon as it passes the desired tile. The trie has already been validated.
+static int32_t wit_position_value(const WitTrie *trie,
+                                  const MachineLetter *letters, int length) {
+  uint32_t node = trie->root;
+  for (int position = 0; position < length; position++) {
+    if (node == 0) {
+      return -1;
+    }
+    while (trie->node_tile[node] < letters[position] &&
+           !trie->node_last[node]) {
+      node++;
+    }
+    if (trie->node_tile[node] != letters[position]) {
+      return -1;
+    }
+    if (position + 1 == length) {
+      return trie->node_value[node];
+    }
+    node = trie->node_child[node];
+  }
+  return -1;
+}
+
+static void wit_position_add_word(WordInfoTable *wit,
+                                  const MachineLetter *letters,
+                                  int final_length) {
+  const uint32_t length_bit = UINT32_C(1) << final_length;
+  for (int base_length = WIT_POSITION_MIN_BASE_LENGTH;
+       base_length <= final_length &&
+       base_length <= WIT_POSITION_MAX_BASE_LENGTH;
+       base_length++) {
+    const WitTrie *trie = &wit->tries[base_length];
+    if (trie->num_values == 0) {
+      continue;
+    }
+    const size_t stride = (size_t)wit_stride_for_len(base_length);
+    for (int position = 0; position + base_length <= final_length; position++) {
+      const int32_t value =
+          wit_position_value(trie, letters + position, base_length);
+      if (value >= 0) {
+        wit->position_lengths[base_length][((size_t)value * stride) +
+                                           position] |= length_bit;
+      }
+    }
+  }
+}
+
+static void wit_position_visit_words(WordInfoTable *wit, const WitTrie *trie,
+                                     uint32_t first_node, int depth, int length,
+                                     MachineLetter *letters) {
+  for (uint32_t node = first_node; node != 0; node++) {
+    letters[depth - 1] = trie->node_tile[node];
+    if (depth == length) {
+      if (trie->node_value[node] >= 0) {
+        wit_position_add_word(wit, letters, length);
+      }
+    } else if (trie->node_child[node] != 0) {
+      wit_position_visit_words(wit, trie, trie->node_child[node], depth + 1,
+                               length, letters);
+    }
+    if (trie->node_last[node]) {
+      break;
+    }
+  }
+}
+
+void word_info_table_build_position_lengths(WordInfoTable *wit) {
+  word_info_table_clear_position_lengths(wit);
+  if (wit->kwg_hash == 0) {
+    return;
+  }
+  for (int length = WIT_POSITION_MIN_BASE_LENGTH;
+       length <= WIT_POSITION_MAX_BASE_LENGTH; length++) {
+    const size_t rows = wit->tries[length].num_values;
+    const size_t stride = (size_t)wit_stride_for_len(length);
+    if (rows > SIZE_MAX / stride / sizeof(uint32_t)) {
+      word_info_table_clear_position_lengths(wit);
+      return;
+    }
+    if (rows != 0) {
+      wit->position_lengths[length] =
+          calloc_or_die(rows * stride, sizeof(uint32_t));
+    }
+  }
+  MachineLetter letters[BOARD_DIM];
+  for (int length = WIT_POSITION_MIN_BASE_LENGTH; length <= BOARD_DIM;
+       length++) {
+    const WitTrie *trie = &wit->tries[length];
+    wit_position_visit_words(wit, trie, trie->root, 1, length, letters);
+  }
 }
 
 static bool wit_positional_alphabet_supported(const WordInfoTable *wit) {
@@ -344,6 +438,7 @@ void word_info_table_load(WordInfoTable *wit, const char *name,
     return;
   }
   wit->name = string_duplicate(name);
+  word_info_table_build_position_lengths(wit);
 }
 
 WordInfoTable *word_info_table_create(const char *data_paths,

--- a/src/ent/word_info_table.h
+++ b/src/ent/word_info_table.h
@@ -4,6 +4,7 @@
 #include "../def/board_defs.h"
 #include "../def/letter_distribution_defs.h"
 #include "../util/io_util.h"
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -33,7 +34,11 @@ enum {
   WPF_MIN_BLOCK_LENGTH = 2,
   WPF_MAX_BLOCK_LENGTH = 4,
   WPF_ALPHABET_SIZE = 26,
+  WIT_POSITION_MIN_BASE_LENGTH = 2,
+  WIT_POSITION_MAX_BASE_LENGTH = BOARD_DIM,
 };
+
+static_assert(BOARD_DIM < 32, "WIT positional lengths must fit in uint32_t");
 
 typedef struct WitTrie {
   uint32_t num_nodes;
@@ -58,6 +63,10 @@ typedef struct WordInfoTable {
   WitTrie tries[BOARD_DIM + 1];
   // Optional positional table, indexed directly by this WIT's value IDs.
   uint32_t *word_plus_floater[BOARD_DIM + 1];
+  // Derived from this table's complete dictionary on construction/load.
+  // For each value ID, position p contains bits for absolute final lengths
+  // having this base at p. It does not change the serialized WIT format.
+  uint32_t *position_lengths[BOARD_DIM + 1];
 } WordInfoTable;
 
 static inline size_t word_plus_floater_cells_per_key(int block_length) {
@@ -118,6 +127,42 @@ static inline const uint32_t *word_info_table_lookup(const WordInfoTable *wit,
   return NULL;
 }
 
+// Return the derived row only when the borrowed ordinary row belongs to
+// this exact table. Shared-KWG board lanes can borrow the other player's WIT.
+static inline const uint32_t *word_info_table_get_position_lengths(
+    const WordInfoTable *wit, const uint32_t *ordinary_row, int base_length) {
+  if (wit == NULL || ordinary_row == NULL ||
+      base_length < WIT_POSITION_MIN_BASE_LENGTH ||
+      base_length > WIT_POSITION_MAX_BASE_LENGTH ||
+      wit->position_lengths[base_length] == NULL) {
+    return NULL;
+  }
+  const uintptr_t address = (uintptr_t)ordinary_row;
+  const uintptr_t values = (uintptr_t)wit->tries[base_length].values;
+  const size_t stride = (size_t)wit_stride_for_len(base_length);
+  const size_t row_bytes = stride * sizeof(uint32_t);
+  if (address < values) {
+    return NULL;
+  }
+  const uintptr_t offset = address - values;
+  if (offset >= (size_t)wit->tries[base_length].num_values * row_bytes ||
+      offset % row_bytes != 0) {
+    return NULL;
+  }
+  return wit->position_lengths[base_length] + ((offset / row_bytes) * stride);
+}
+
+static inline void word_info_table_clear_position_lengths(WordInfoTable *wit) {
+  for (int length = 0; length <= BOARD_DIM; length++) {
+    free(wit->position_lengths[length]);
+    wit->position_lengths[length] = NULL;
+  }
+}
+
+// Requires a complete validated WIT dictionary, as produced by the native
+// maker or loader. A zero source fingerprint leaves this optional cache absent.
+void word_info_table_build_position_lengths(WordInfoTable *wit);
+
 static inline void word_info_table_destroy(WordInfoTable *wit) {
   if (wit == NULL) {
     return;
@@ -130,6 +175,7 @@ static inline void word_info_table_destroy(WordInfoTable *wit) {
     free(trie->node_value);
     free(trie->values);
     free(wit->word_plus_floater[len]);
+    free(wit->position_lengths[len]);
   }
   free(wit->name);
   free(wit);

--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -32,6 +32,7 @@
 #include "../ent/rack_info_table.h"
 #include "../ent/static_eval.h"
 #include "../ent/wmp.h"
+#include "../ent/word_info_table.h"
 #include "../util/io_util.h"
 #include "wmp_move_gen.h"
 #include <assert.h>
@@ -1737,9 +1738,14 @@ void go_on_alpha(MoveGen *gen, int current_col, MachineLetter L, int leftstrip,
 }
 
 static inline __attribute__((always_inline)) void
-shadow_record_impl(MoveGen *gen, bool wmp_active) {
+shadow_record_impl(MoveGen *gen, bool wmp_active, uint32_t allowed_lengths) {
   const Equity *best_leaves = gen->best_leaves;
   if (wmp_active) {
+    const int final_length =
+        gen->tiles_played + gen->wmp_move_gen.num_tiles_played_through;
+    if ((allowed_lengths & (UINT32_C(1) << final_length)) == 0) {
+      return;
+    }
     if (wmp_move_gen_has_playthrough(&gen->wmp_move_gen)) {
       // RIT fast path for single-playthrough anchors: the RIT's
       // playthrough_union[leave_size] holds a uint32 bitmask of letters L
@@ -1896,17 +1902,18 @@ shadow_record_impl(MoveGen *gen, bool wmp_active) {
   }
 }
 
-static __attribute__((noinline)) void shadow_record_wmp(MoveGen *gen) {
-  shadow_record_impl(gen, true);
+static __attribute__((noinline)) void
+shadow_record_wmp(MoveGen *gen, uint32_t allowed_lengths) {
+  shadow_record_impl(gen, true, allowed_lengths);
 }
 
 static __attribute__((noinline)) void shadow_record_recursive(MoveGen *gen) {
-  shadow_record_impl(gen, false);
+  shadow_record_impl(gen, false, UINT32_MAX);
 }
 
-static inline void shadow_record(MoveGen *gen) {
+static inline void shadow_record(MoveGen *gen, uint32_t allowed_lengths) {
   if (wmp_move_gen_is_active(&gen->wmp_move_gen)) {
-    shadow_record_wmp(gen);
+    shadow_record_wmp(gen, allowed_lengths);
   } else {
     shadow_record_recursive(gen);
   }
@@ -2133,7 +2140,46 @@ static inline bool wit_shadow_right_block_dead(const MoveGen *gen,
   return true;
 }
 
-static inline void shadow_play_right(MoveGen *gen, bool is_unique) {
+// Only a complete, owned block contained in this shadow span can constrain
+// word positions. Missing, foreign, and partial cached rows remain permissive.
+static inline const uint32_t *shadow_position_row_for_block(const MoveGen *gen,
+                                                            int block_col) {
+  if (!wmp_move_gen_is_active(&gen->wmp_move_gen) || gen->is_wordsmog ||
+      gen->word_info_table == NULL || gen->wit_row_lane == NULL ||
+      gen->wit_len_lane == NULL || block_col < gen->current_left_col ||
+      block_col < 0 || block_col >= BOARD_DIM) {
+    return NULL;
+  }
+  const int block_length = gen->wit_len_lane[block_col];
+  if (block_length < WIT_POSITION_MIN_BASE_LENGTH ||
+      block_length > WIT_POSITION_MAX_BASE_LENGTH ||
+      block_col + block_length - 1 > gen->current_right_col ||
+      (block_col > 0 && gen_cache_get_letter(gen, block_col - 1) !=
+                            ALPHABET_EMPTY_SQUARE_MARKER) ||
+      (block_col + block_length < BOARD_DIM &&
+       gen_cache_get_letter(gen, block_col + block_length) !=
+           ALPHABET_EMPTY_SQUARE_MARKER)) {
+    return NULL;
+  }
+  return word_info_table_get_position_lengths(
+      gen->word_info_table, gen->wit_row_lane[block_col], block_length);
+}
+
+static inline uint32_t shadow_initial_position_lengths(const MoveGen *gen) {
+  if (gen->shadow_position_row == NULL) {
+    return UINT32_MAX;
+  }
+  const int position = gen->shadow_position_col - gen->current_left_col;
+  if (position < 0 || position > BOARD_DIM - gen->shadow_position_length) {
+    return UINT32_MAX;
+  }
+  return gen->shadow_position_row[position];
+}
+
+static inline void shadow_play_right(MoveGen *gen, bool is_unique,
+                                     uint32_t allowed_lengths) {
+  int position_base_length = gen->shadow_position_length;
+
   // Save the score totals to be reset after shadowing right.
   const Equity orig_main_restricted_score =
       gen->shadow_mainword_restricted_score;
@@ -2169,6 +2215,15 @@ static inline void shadow_play_right(MoveGen *gen, bool is_unique) {
 
   while (gen->current_right_col < (BOARD_DIM - 1) &&
          gen->tiles_played < gen->number_of_letters_on_rack) {
+    // The next empty square makes the word at least one letter longer.
+    // Keep this stop local to the rightward branch: extending left changes
+    // the base's position and may revive lengths excluded at this start.
+    const int next_min_length =
+        gen->current_right_col - gen->current_left_col + 2;
+    if (position_base_length != 0 &&
+        (allowed_lengths >> next_min_length) == 0) {
+      break;
+    }
     gen->current_right_col++;
     gen->tiles_played++;
 
@@ -2272,6 +2327,15 @@ static inline void shadow_play_right(MoveGen *gen, bool is_unique) {
       wmp_move_gen_increment_playthrough_blocks(&gen->wmp_move_gen);
     }
 
+    if (found_playthrough_tile && position_base_length == 0) {
+      const uint32_t *position_row =
+          shadow_position_row_for_block(gen, right_block_col);
+      if (position_row != NULL) {
+        position_base_length = gen->wit_len_lane[right_block_col];
+        allowed_lengths = position_row[right_block_col - gen->current_left_col];
+      }
+    }
+
     // WordInfoTable shadow early-stop: if the tile just placed can never be an
     // addable letter of the right playthrough block at any reachable word
     // length, no rightward continuation forms a word, so stop shadowing right.
@@ -2290,7 +2354,7 @@ static inline void shadow_play_right(MoveGen *gen, bool is_unique) {
       // squares, in which case the restricted multiplier squares would
       // be invalidated.
       maybe_recalculate_effective_multipliers(gen);
-      shadow_record(gen);
+      shadow_record(gen, allowed_lengths);
     }
   }
 
@@ -2464,7 +2528,7 @@ static inline void nonplaythrough_shadow_play_left(MoveGen *gen,
     const uint64_t possible_tiles_for_shadow_right =
         gen->anchor_right_extension_set & gen->rack_cross_set;
     if (possible_tiles_for_shadow_right != 0) {
-      shadow_play_right(gen, is_unique);
+      shadow_play_right(gen, is_unique, UINT32_MAX);
     }
     gen->anchor_right_extension_set = TRIVIAL_CROSS_SET;
     if (gen->current_left_col == 0 ||
@@ -2492,7 +2556,7 @@ static inline void nonplaythrough_shadow_play_left(MoveGen *gen,
             this_word_multiplier, gen->current_left_col)) {
       insert_unrestricted_multipliers(gen, gen->current_left_col);
     }
-    shadow_record(gen);
+    shadow_record(gen, UINT32_MAX);
   }
 }
 
@@ -2535,11 +2599,12 @@ static inline void nonplaythrough_shadow_play_left_small(MoveGen *gen,
 }
 
 static inline void playthrough_shadow_play_left(MoveGen *gen, bool is_unique) {
+  uint32_t allowed_lengths = shadow_initial_position_lengths(gen);
   for (;;) {
     const uint64_t possible_tiles_for_shadow_right =
         gen->anchor_right_extension_set & gen->rack_cross_set;
     if (possible_tiles_for_shadow_right != 0) {
-      shadow_play_right(gen, is_unique);
+      shadow_play_right(gen, is_unique, allowed_lengths);
     }
     gen->anchor_right_extension_set = TRIVIAL_CROSS_SET;
 
@@ -2600,8 +2665,9 @@ static inline void playthrough_shadow_play_left(MoveGen *gen, bool is_unique) {
       is_unique = true;
     }
 
+    allowed_lengths = shadow_initial_position_lengths(gen);
     if (play_is_nonempty_and_nonduplicate(gen->tiles_played, is_unique)) {
-      shadow_record(gen);
+      shadow_record(gen, allowed_lengths);
     }
   }
 }
@@ -2708,7 +2774,7 @@ static inline void shadow_start_nonplaythrough(MoveGen *gen) {
   if (!board_is_dir_vertical(gen->dir)) {
     // word_multiplier is always hard-coded as 0 since we are recording a
     // single tile
-    shadow_record(gen);
+    shadow_record(gen, UINT32_MAX);
   }
   gen->shadow_word_multiplier = this_word_multiplier;
   maybe_recalculate_effective_multipliers(gen);
@@ -2782,6 +2848,12 @@ static inline void shadow_start_playthrough(MoveGen *gen,
   }
   if (wmp_move_gen_is_active(&gen->wmp_move_gen)) {
     wmp_move_gen_increment_playthrough_blocks(&gen->wmp_move_gen);
+  }
+  gen->shadow_position_row =
+      shadow_position_row_for_block(gen, gen->current_left_col);
+  if (gen->shadow_position_row != NULL) {
+    gen->shadow_position_col = gen->current_left_col;
+    gen->shadow_position_length = gen->wit_len_lane[gen->current_left_col];
   }
   playthrough_shadow_play_left(gen, !board_is_dir_vertical(gen->dir));
 }
@@ -2875,6 +2947,10 @@ void shadow_play_for_anchor(MoveGen *gen, int col) {
                                     EQUITY_MAX_VALUE, EQUITY_MAX_VALUE);
     return;
   }
+
+  gen->shadow_position_row = NULL;
+  gen->shadow_position_col = 0;
+  gen->shadow_position_length = 0;
 
   // Set cols
   gen->current_left_col = col;

--- a/src/impl/move_gen.h
+++ b/src/impl/move_gen.h
@@ -155,6 +155,11 @@ typedef struct MoveGen {
   // Shadow plays
   int current_left_col;
   int current_right_col;
+  // The initial complete board block is immutable while shadow explores
+  // left starts. Each rightward branch keeps its allowed lengths locally.
+  const uint32_t *shadow_position_row;
+  int shadow_position_col;
+  int shadow_position_length;
 
   // Used to calculate the maximum score for an anchor. We don't know which
   // tiles will go in which unrestricted squares, so effective multipliers are

--- a/src/impl/word_info_table_maker.c
+++ b/src/impl/word_info_table_maker.c
@@ -245,5 +245,6 @@ WordInfoTable *make_word_info_table_from_kwg(const KWG *kwg) {
   WordInfoTable *wit = make_word_info_table_from_words(words);
   dictionary_word_list_destroy(words);
   wit->kwg_hash = kwg_get_hash(kwg);
+  word_info_table_build_position_lengths(wit);
   return wit;
 }

--- a/test/position_lengths_test.c
+++ b/test/position_lengths_test.c
@@ -1,0 +1,595 @@
+#include "position_lengths_test.h"
+
+#include "../src/def/board_defs.h"
+#include "../src/def/equity_defs.h"
+#include "../src/def/game_defs.h"
+#include "../src/def/kwg_defs.h"
+#include "../src/def/letter_distribution_defs.h"
+#include "../src/def/move_defs.h"
+#include "../src/def/players_data_defs.h"
+#include "../src/ent/bag.h"
+#include "../src/ent/board.h"
+#include "../src/ent/data_filepaths.h"
+#include "../src/ent/dictionary_word.h"
+#include "../src/ent/game.h"
+#include "../src/ent/kwg.h"
+#include "../src/ent/move.h"
+#include "../src/ent/move_undo.h"
+#include "../src/ent/players_data.h"
+#include "../src/ent/validated_move.h"
+#include "../src/ent/wmp.h"
+#include "../src/ent/word_info_table.h"
+#include "../src/ent/xoshiro.h"
+#include "../src/impl/config.h"
+#include "../src/impl/gameplay.h"
+#include "../src/impl/kwg_maker.h"
+#include "../src/impl/move_gen.h"
+#include "../src/impl/wmp_maker.h"
+#include "../src/impl/word_info_table_maker.h"
+#include "../src/util/io_util.h"
+#include "../src/util/string_util.h"
+#include "test_util.h"
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+enum { POSITION_ORACLE_ROOT = 283000003, POSITION_QUERY_COUNT = 2000 };
+
+static void add_literal(DictionaryWordList *words, const char *literal) {
+  MachineLetter letters[BOARD_DIM] = {0};
+  const size_t length = strlen(literal);
+  assert(length > 0 && length <= BOARD_DIM);
+  for (size_t position = 0; position < length; position++) {
+    assert(literal[position] >= 'A' && literal[position] <= 'Z');
+    letters[position] = (MachineLetter)(literal[position] - 'A' + 1);
+  }
+  dictionary_word_list_add_word(words, letters, (int)length);
+}
+
+static DictionaryWordList *oracle_words(void) {
+  const char *const literals[] = {
+      "A",       "AA",      "AB",        "AT",     "BA",     "ZZ",
+      "AAA",     "ABA",     "AAAA",      "ABAB",   "CATS",   "TATA",
+      "ABABA",   "AAAAA",   "TATAT",     "ABABAB", "SCATS",  "ABCDE",
+      "XABCDEY", "ABCDEFG", "XABCDEFGY", "BE",     "BETTER", "BETTERS"};
+  DictionaryWordList *words = dictionary_word_list_create();
+  for (size_t index = 0; index < sizeof(literals) / sizeof(literals[0]);
+       index++) {
+    add_literal(words, literals[index]);
+  }
+  MachineLetter longest[BOARD_DIM];
+  for (int position = 0; position < BOARD_DIM; position++) {
+    longest[position] = (MachineLetter)(position + 1);
+  }
+  dictionary_word_list_add_word(words, longest, BOARD_DIM);
+  longest[0] = 1;
+  longest[1] = 20;
+  longest[BOARD_DIM - 2] = 1;
+  longest[BOARD_DIM - 1] = 20;
+  dictionary_word_list_add_word(words, longest, BOARD_DIM);
+  dictionary_word_list_sort(words);
+  return words;
+}
+
+// Enumerate literal occurrences directly. This oracle does not use trie
+// traversal, the derived cache, residual counts, or a transposed plane.
+static uint32_t literal_lengths(const DictionaryWordList *words,
+                                const DictionaryWord *base, int position) {
+  uint32_t expected = 0;
+  const int base_length = dictionary_word_get_length(base);
+  const MachineLetter *base_letters = dictionary_word_get_word(base);
+  for (int index = 0; index < dictionary_word_list_get_count(words); index++) {
+    const DictionaryWord *word = dictionary_word_list_get_word(words, index);
+    const int length = dictionary_word_get_length(word);
+    if (position >= 0 && position + base_length <= length &&
+        memcmp(dictionary_word_get_word(word) + position, base_letters,
+               (size_t)base_length) == 0) {
+      expected |= UINT32_C(1) << length;
+    }
+  }
+  return expected;
+}
+
+static void assert_literal_cache(const DictionaryWordList *words,
+                                 const WordInfoTable *wit) {
+  assert(wit->kwg_hash != 0);
+  assert(wit->position_lengths[0] == NULL);
+  assert(wit->position_lengths[1] == NULL);
+  for (int index = 0; index < dictionary_word_list_get_count(words); index++) {
+    const DictionaryWord *base = dictionary_word_list_get_word(words, index);
+    const int length = dictionary_word_get_length(base);
+    const uint32_t *ordinary =
+        word_info_table_lookup(wit, dictionary_word_get_word(base), length);
+    assert(ordinary != NULL);
+    const uint32_t *positions =
+        word_info_table_get_position_lengths(wit, ordinary, length);
+    if (length == 1) {
+      assert(positions == NULL);
+      continue;
+    }
+    assert(positions != NULL);
+    for (int position = 0; position <= BOARD_DIM - length; position++) {
+      assert(positions[position] == literal_lengths(words, base, position));
+    }
+    // The base itself must exist even though there are no outside letters.
+    assert((positions[0] & (UINT32_C(1) << length)) != 0);
+  }
+}
+
+static void test_literal_derivation(void) {
+  DictionaryWordList *words = oracle_words();
+  KWG *kwg = make_kwg_from_words(words, KWG_MAKER_OUTPUT_DAWG_AND_GADDAG,
+                                 KWG_MAKER_MERGE_EXACT);
+  WordInfoTable *wit = make_word_info_table_from_kwg(kwg);
+  assert_literal_cache(words, wit);
+  WordInfoTable *unidentified = make_word_info_table_from_words(words);
+  assert(unidentified->kwg_hash == 0);
+  word_info_table_build_position_lengths(unidentified);
+  for (int length = 0; length <= BOARD_DIM; length++) {
+    assert(unidentified->position_lengths[length] == NULL);
+  }
+  word_info_table_destroy(unidentified);
+  // Explicit reconstruction must be idempotent and replace stale contents.
+  wit->position_lengths[2][0] = 0;
+  word_info_table_build_position_lengths(wit);
+  assert_literal_cache(words, wit);
+  // Terminal IDs need not follow lexical order. Reversing IDs must simply
+  // permute cache rows, without changing the literal result for any base.
+  WitTrie *permuted = &wit->tries[2];
+  for (int pass = 0; pass < 2; pass++) {
+    for (uint32_t node = 0; node < permuted->num_nodes; node++) {
+      if (permuted->node_value[node] >= 0) {
+        permuted->node_value[node] =
+            (int32_t)permuted->num_values - 1 - permuted->node_value[node];
+      }
+    }
+    word_info_table_build_position_lengths(wit);
+    assert_literal_cache(words, wit);
+  }
+  const MachineLetter zz[] = {26, 26};
+  const uint32_t *empty_positions = word_info_table_get_position_lengths(
+      wit, word_info_table_lookup(wit, zz, 2), 2);
+  assert(empty_positions != NULL && empty_positions[1] == 0);
+  const MachineLetter unknown[] = {26, 24};
+  assert(word_info_table_lookup(wit, unknown, 2) == NULL);
+  const MachineLetter at[] = {1, 20};
+  const uint32_t *ordinary = word_info_table_lookup(wit, at, 2);
+  const uint32_t *positions =
+      word_info_table_get_position_lengths(wit, ordinary, 2);
+  assert(positions != NULL);
+  // CAT is absent, but CATS exists. An exact miss cannot stop extension.
+  assert((positions[1] & (UINT32_C(1) << 3)) == 0);
+  assert((positions[1] & (UINT32_C(1) << 4)) != 0);
+  assert((positions[BOARD_DIM - 2] & (UINT32_C(1) << BOARD_DIM)) != 0);
+  WordInfoTable *foreign = make_word_info_table_from_kwg(kwg);
+  const uint32_t *foreign_row = word_info_table_lookup(foreign, at, 2);
+  assert(word_info_table_get_position_lengths(wit, foreign_row, 2) == NULL);
+  assert(word_info_table_get_position_lengths(wit, ordinary + 1, 2) == NULL);
+  assert(word_info_table_get_position_lengths(wit, NULL, 2) == NULL);
+  assert(word_info_table_get_position_lengths(wit, ordinary, 1) == NULL);
+  assert(word_info_table_get_position_lengths(wit, ordinary, BOARD_DIM + 1) ==
+         NULL);
+  const WitTrie *trie = &wit->tries[2];
+  const uint32_t *past_end =
+      trie->values + ((size_t)trie->num_values * (size_t)wit_stride_for_len(2));
+  assert(word_info_table_get_position_lengths(wit, past_end, 2) == NULL);
+  word_info_table_clear_position_lengths(foreign);
+  assert(word_info_table_get_position_lengths(foreign, foreign_row, 2) == NULL);
+  foreign->kwg_hash = 0;
+  word_info_table_build_position_lengths(foreign);
+  for (int length = 0; length <= BOARD_DIM; length++) {
+    assert(foreign->position_lengths[length] == NULL);
+  }
+
+  // Probe length gaps and suffix boundaries independently at varied positions.
+  XoshiroPRNG *prng = prng_create(POSITION_ORACLE_ROOT);
+  const int word_count = dictionary_word_list_get_count(words);
+  int *eligible = malloc_or_die((size_t)word_count * sizeof(int));
+  int eligible_count = 0;
+  for (int index = 0; index < word_count; index++) {
+    if (dictionary_word_get_length(
+            dictionary_word_list_get_word(words, index)) >= 2) {
+      eligible[eligible_count++] = index;
+    }
+  }
+  assert(eligible_count > 0);
+  for (int query = 0; query < POSITION_QUERY_COUNT; query++) {
+    const int index = eligible[prng_next(prng) % (uint64_t)eligible_count];
+    const DictionaryWord *base = dictionary_word_list_get_word(words, index);
+    const int length = dictionary_word_get_length(base);
+    const int position =
+        (int)(prng_next(prng) % (uint64_t)(BOARD_DIM - length + 1));
+    const int minimum = (int)(prng_next(prng) % (BOARD_DIM + 2));
+    const uint32_t *row =
+        word_info_table_lookup(wit, dictionary_word_get_word(base), length);
+    const uint32_t *masks =
+        word_info_table_get_position_lengths(wit, row, length);
+    assert(masks != NULL);
+    bool literal_suffix = false;
+    const uint32_t expected = literal_lengths(words, base, position);
+    for (int final_length = minimum; final_length <= BOARD_DIM;
+         final_length++) {
+      literal_suffix |= (expected & (UINT32_C(1) << final_length)) != 0;
+    }
+    assert((masks[position] >> minimum != 0) == literal_suffix);
+  }
+  free(eligible);
+  prng_destroy(prng);
+  word_info_table_destroy(foreign);
+  word_info_table_destroy(wit);
+  kwg_destroy(kwg);
+  dictionary_word_list_destroy(words);
+}
+
+static void test_load_rebuild_and_cleanup(void) {
+  DictionaryWordList *words = oracle_words();
+  KWG *kwg =
+      make_kwg_from_words(words, KWG_MAKER_OUTPUT_DAWG, KWG_MAKER_MERGE_EXACT);
+  WordInfoTable *wit = make_word_info_table_from_kwg(kwg);
+  WordInfoTable *loaded = calloc_or_die(1, sizeof(WordInfoTable));
+  ErrorStack *errors = error_stack_create();
+  char *filename = data_filepaths_get_writable_filename(
+      DEFAULT_TEST_DATA_PATH, "position_lengths_roundtrip",
+      DATA_FILEPATH_TYPE_WORD_INFO_TABLE, errors);
+  assert(error_stack_is_empty(errors));
+  word_info_table_write_to_file(wit, filename, errors);
+  assert(error_stack_is_empty(errors));
+  word_info_table_load(loaded, "position_lengths_roundtrip", filename, errors);
+  assert(error_stack_is_empty(errors));
+  assert_literal_cache(words, loaded);
+  // Version3 ordinary rows remain loadable and still derive literal positions.
+  FILE *file = fopen_or_die(filename, "r+b");
+  const int written = fputc(3, file);
+  assert(written == 3);
+  fclose_or_die(file);
+  word_info_table_load(loaded, "position_lengths_v3", filename, errors);
+  assert(error_stack_is_empty(errors));
+  assert_literal_cache(words, loaded);
+  file = fopen_or_die(filename, "wb");
+  const int truncated = fputc(4, file);
+  assert(truncated == 4);
+  fclose_or_die(file);
+  word_info_table_load(loaded, "position_lengths_truncated", filename, errors);
+  assert(!error_stack_is_empty(errors));
+  for (int length = 0; length <= BOARD_DIM; length++) {
+    assert(loaded->position_lengths[length] == NULL);
+  }
+  error_stack_reset(errors);
+  word_info_table_write_to_file(wit, filename, errors);
+  word_info_table_load(loaded, "position_lengths_restored", filename, errors);
+  assert(error_stack_is_empty(errors));
+  assert_literal_cache(words, loaded);
+  remove_or_die(filename);
+  free(filename);
+  error_stack_destroy(errors);
+  word_info_table_destroy(loaded);
+  word_info_table_destroy(wit);
+  kwg_destroy(kwg);
+  dictionary_word_list_destroy(words);
+}
+
+static void replace_shared_data(PlayersData *players, players_data_t type,
+                                void *data) {
+  assert(players_data_get_is_shared(players, type));
+  void *original = players_data_get_data(players, type, 0);
+  assert(original == players_data_get_data(players, type, 1));
+  switch (type) {
+  case PLAYERS_DATA_TYPE_KWG:
+    kwg_destroy(original);
+    break;
+  case PLAYERS_DATA_TYPE_WMP:
+    wmp_destroy(original);
+    break;
+  case PLAYERS_DATA_TYPE_WIT:
+    word_info_table_destroy(original);
+    break;
+  default:
+    log_fatal("unexpected tiny fixture data type %d", type);
+    break;
+  }
+  players_data_set_data(players, type, 0, data);
+  players_data_set_data(players, type, 1, data);
+}
+
+static Config *tiny_config(bool with_wmp) {
+  // Keep two blanks on either board size; the WMP format supports at most two.
+  Config *config =
+      config_create_or_die("set -lex CSW21 -ld english -wmp false -rit false "
+                           "-wit false -s1 score -s2 score "
+                           "-r1 all -r2 all -numplays 100000");
+  const char *const literals[] = {"AT",    "CATS",    "SCATS",
+                                  "BE",    "BETTER",  "BETTERS",
+                                  "ABCDE", "XABCDEY", "CATXBEY"};
+  DictionaryWordList *words = dictionary_word_list_create();
+  for (size_t index = 0; index < sizeof(literals) / sizeof(literals[0]);
+       index++) {
+    add_literal(words, literals[index]);
+  }
+  dictionary_word_list_sort(words);
+  KWG *kwg = make_kwg_from_words(words, KWG_MAKER_OUTPUT_DAWG_AND_GADDAG,
+                                 KWG_MAKER_MERGE_EXACT);
+  PlayersData *players = config_get_players_data(config);
+  replace_shared_data(players, PLAYERS_DATA_TYPE_KWG, kwg);
+  if (with_wmp) {
+    WMP *wmp = make_wmp_from_words(words, config_get_ld(config), 1);
+    replace_shared_data(players, PLAYERS_DATA_TYPE_WMP, wmp);
+    replace_shared_data(players, PLAYERS_DATA_TYPE_WIT,
+                        make_word_info_table_from_kwg(kwg));
+  }
+  dictionary_word_list_destroy(words);
+  return config;
+}
+
+static char *position_string(const char *line, int first_col, const char *rack,
+                             bool vertical) {
+  char board[BOARD_DIM][BOARD_DIM];
+  memset(board, '.', sizeof(board));
+  for (size_t index = 0; index < strlen(line); index++) {
+    const int col = first_col + (int)index;
+    assert(col < BOARD_DIM);
+    board[vertical ? col : BOARD_DIM / 2][vertical ? BOARD_DIM / 2 : col] =
+        line[index];
+  }
+  StringBuilder *builder = string_builder_create();
+  for (int row = 0; row < BOARD_DIM; row++) {
+    int empty = 0;
+    for (int col = 0; col < BOARD_DIM; col++) {
+      if (board[row][col] == '.') {
+        empty++;
+      } else {
+        if (empty != 0) {
+          string_builder_add_int(builder, empty);
+          empty = 0;
+        }
+        string_builder_add_char(builder, board[row][col]);
+      }
+    }
+    if (empty != 0) {
+      string_builder_add_int(builder, empty);
+    }
+    string_builder_add_char(builder, row == BOARD_DIM - 1 ? ' ' : '/');
+  }
+  string_builder_add_formatted_string(builder, "%s/ 0/0 0", rack);
+  char *result = string_builder_dump(builder, NULL);
+  string_builder_destroy(builder);
+  return result;
+}
+
+static MoveList *all_moves(const Game *game) {
+  MoveList *moves = move_list_create(10000);
+  const MoveGenArgs args = {
+      .game = game,
+      .move_list = moves,
+      .target_equity = EQUITY_MAX_VALUE,
+      .target_leave_size_for_exchange_cutoff = UNSET_LEAVE_SIZE,
+  };
+  generate_moves_for_game(&args);
+  assert(move_list_get_count(moves) < 10000);
+  return moves;
+}
+
+static void assert_same_moves(const Game *game, const Game *reference) {
+  MoveList *actual = all_moves(game);
+  MoveList *expected = all_moves(reference);
+  SortedMoveList *sorted = sorted_move_list_create(actual);
+  SortedMoveList *oracle = sorted_move_list_create(expected);
+  assert(sorted->count == oracle->count);
+  for (int index = 0; index < sorted->count; index++) {
+    assert(compare_moves(sorted->moves[index], oracle->moves[index], true) ==
+           -1);
+  }
+  sorted_move_list_destroy(sorted);
+  sorted_move_list_destroy(oracle);
+  move_list_destroy(actual);
+  move_list_destroy(expected);
+}
+
+static void assert_word_move(const Game *game, const char *word, int start,
+                             bool vertical) {
+  char command[64];
+  if (vertical) {
+    (void)snprintf(command, sizeof(command), "%c%d %s", 'A' + (BOARD_DIM / 2),
+                   start + 1, word);
+  } else {
+    (void)snprintf(command, sizeof(command), "%d%c %s", (BOARD_DIM / 2) + 1,
+                   'A' + start, word);
+  }
+  ValidatedMoves *validated = validated_moves_create_and_assert_status(
+      game, game_get_player_on_turn_index(game), command, false, false,
+      ERROR_STATUS_SUCCESS);
+  MoveList *moves = all_moves(game);
+  bool found = false;
+  for (int index = 0; index < move_list_get_count(moves); index++) {
+    found |= compare_moves_without_equity(
+                 move_list_get_move(moves, index),
+                 validated_moves_get_move(validated, 0), true) == -1;
+  }
+  assert(found);
+  move_list_destroy(moves);
+  validated_moves_destroy(validated);
+}
+
+static void test_shadow_boundary_moves(void) {
+  Config *config = tiny_config(true);
+  Config *reference_config = tiny_config(false);
+  Game *game = config_game_create(config);
+  Game *reference = config_game_create(reference_config);
+  Game *reused = game_duplicate(game);
+  WordInfoTable *wit =
+      players_data_get_word_info_table(config_get_players_data(config), 0);
+  const struct {
+    const char *line;
+    const char *rack;
+    const char *required;
+    int relative_start;
+  } cases[] = {
+      // A one-tile base and a phony complete block have no indexed base row.
+      // Both must still be extendable into the legal word CATS.
+      {"A", "CTS", "CATS", -1},       {"CA", "TS", "CATS", 0},
+      {"AT", "CS", "CATS", -1},       {"AT", "CSS", "SCATS", -2},
+      {"BE", "TTER", "BETTER", 0},    {"AT", "C?", NULL, 0},
+      {"AT", "??", NULL, 0},          {"aT", "CS", NULL, 0},
+      {"ABCDE", "XY", "XABCDEY", -1}, {"AT.BE", "CXY", "CATXBEY", -1},
+      {"SCATS", "BE", NULL, 0},       {"", "CS", NULL, 0},
+  };
+  for (int vertical = BOARD_HORIZONTAL_DIRECTION;
+       vertical <= BOARD_VERTICAL_DIRECTION; vertical++) {
+    for (size_t index = 0; index < sizeof(cases) / sizeof(cases[0]); index++) {
+      const int first_col = (BOARD_DIM / 2) - 2;
+      char *cgp = position_string(cases[index].line, first_col,
+                                  cases[index].rack, vertical != 0);
+      load_cgp_or_die(game, cgp);
+      load_cgp_or_die(reference, cgp);
+      assert_same_moves(game, reference);
+      if (cases[index].required != NULL) {
+        assert_word_move(game, cases[index].required,
+                         first_col + cases[index].relative_start,
+                         vertical != 0);
+      }
+      game_copy(reused, game);
+      assert_same_moves(reused, reference);
+      // Reusing a loaded board with the derived cache missing must fall back.
+      word_info_table_clear_position_lengths(wit);
+      assert_same_moves(game, reference);
+      word_info_table_build_position_lengths(wit);
+      assert_same_moves(reused, reference);
+      free(cgp);
+    }
+    char *edge = position_string("AT", BOARD_DIM - 3, "CS", vertical != 0);
+    load_cgp_or_die(game, edge);
+    load_cgp_or_die(reference, edge);
+    assert_same_moves(game, reference);
+    assert_word_move(game, "CATS", BOARD_DIM - 4, vertical != 0);
+    free(edge);
+  }
+  game_destroy(reused);
+  game_destroy(reference);
+  game_destroy(game);
+  config_destroy(reference_config);
+  config_destroy(config);
+}
+
+static void test_shadow_foreign_rows_and_undo(void) {
+  Config *config = tiny_config(true);
+  Config *reference_config = tiny_config(false);
+  Game *game = config_game_create(config);
+  Game *reference = config_game_create(reference_config);
+  const int first_col = (BOARD_DIM / 2) - 1;
+  char *cgp = position_string("AT", first_col, "CS", false);
+  load_cgp_or_die(game, cgp);
+  load_cgp_or_die(reference, cgp);
+  const PlayersData *players = config_get_players_data(config);
+  WordInfoTable *foreign =
+      make_word_info_table_from_kwg(players_data_get_kwg(players, 0));
+  const MachineLetter at[] = {1, 20};
+  const uint32_t *foreign_row = word_info_table_lookup(foreign, at, 2);
+  assert(foreign_row != NULL);
+  for (int cross_index = 0; cross_index < 2; cross_index++) {
+    board_set_wit_block(game_get_board(game), BOARD_DIM / 2, first_col, 0,
+                        cross_index, foreign_row, 2);
+  }
+  assert_same_moves(game, reference);
+  assert_word_move(game, "CATS", first_col - 1, false);
+  // A cache with all borrowed rows absent must likewise remain permissive.
+  board_clear_wit_cache(game_get_board(game));
+  assert_same_moves(game, reference);
+  game_gen_all_cross_sets(game);
+  word_info_table_destroy(foreign);
+
+  for (int incremental = 0; incremental < 2; incremental++) {
+    load_cgp_or_die(game, cgp);
+    load_cgp_or_die(reference, cgp);
+    game_seed(game, POSITION_ORACLE_ROOT);
+    game_seed(reference, POSITION_ORACLE_ROOT);
+    if (incremental) {
+      while (bag_get_letters(game_get_bag(game)) > 0) {
+        bag_draw_random_letter(game_get_bag(game), 0);
+        bag_draw_random_letter(game_get_bag(reference), 0);
+      }
+    } else {
+      game_set_backup_mode(game, BACKUP_MODE_SIMULATION);
+      game_set_backup_mode(reference, BACKUP_MODE_SIMULATION);
+    }
+    char command[64];
+    (void)snprintf(command, sizeof(command), "%d%c CATS", (BOARD_DIM / 2) + 1,
+                   'A' + first_col - 1);
+    ValidatedMoves *validated = validated_moves_create_and_assert_status(
+        game, 0, command, false, false, ERROR_STATUS_SUCCESS);
+    const Move *move = validated_moves_get_move(validated, 0);
+    if (incremental) {
+      MoveUndo undo;
+      MoveUndo reference_undo;
+      play_move_incremental(move, game, &undo);
+      play_move_incremental(move, reference, &reference_undo);
+      update_cross_set_for_move_from_undo(&undo, game);
+      update_cross_set_for_move_from_undo(&reference_undo, reference);
+      assert_same_moves(game, reference);
+      unplay_move_incremental(game, &undo);
+      unplay_move_incremental(reference, &reference_undo);
+    } else {
+      play_move(move, game, NULL);
+      play_move(move, reference, NULL);
+      assert_same_moves(game, reference);
+      game_unplay_last_move(game);
+      game_unplay_last_move(reference);
+    }
+    assert_same_moves(game, reference);
+    assert_word_move(game, "CATS", first_col - 1, false);
+    validated_moves_destroy(validated);
+  }
+  free(cgp);
+  game_destroy(reference);
+  game_destroy(game);
+  config_destroy(reference_config);
+  config_destroy(config);
+}
+
+void test_position_lengths(void) {
+  test_literal_derivation();
+  test_load_rebuild_and_cleanup();
+  test_shadow_boundary_moves();
+  test_shadow_foreign_rows_and_undo();
+  printf("POSITION_LENGTHS_TEST_PASS board=%d root=%d queries=%d\n", BOARD_DIM,
+         POSITION_ORACLE_ROOT, POSITION_QUERY_COUNT);
+}
+
+void test_position_lengths_loaded(void) {
+  Config *config = config_create_or_die(
+      "set -lex CSW24 -wmp true -rit true -ritmmap true -wit true");
+  const WordInfoTable *wit =
+      players_data_get_word_info_table(config_get_players_data(config), 0);
+  assert(wit != NULL && wit->kwg_hash != 0);
+  assert(wit->position_lengths[1] == NULL);
+  size_t bases = 0;
+  size_t entries = 0;
+  uint64_t digest = UINT64_C(14695981039346656037);
+  for (int length = 2; length <= BOARD_DIM; length++) {
+    const WitTrie *trie = &wit->tries[length];
+    const size_t stride = (size_t)wit_stride_for_len(length);
+    assert(trie->num_values == 0 || wit->position_lengths[length] != NULL);
+    bases += trie->num_values;
+    entries += (size_t)trie->num_values * stride;
+    for (size_t base = 0; base < trie->num_values; base++) {
+      const uint32_t *row = word_info_table_get_position_lengths(
+          wit, trie->values + (base * stride), length);
+      assert(row != NULL && (row[0] & (UINT32_C(1) << length)) != 0);
+      for (size_t position = 0; position < stride; position++) {
+        digest = (digest ^ row[position]) * UINT64_C(1099511628211);
+      }
+    }
+  }
+  const MachineLetter at[] = {1, 20};
+  const uint32_t *row = word_info_table_get_position_lengths(
+      wit, word_info_table_lookup(wit, at, 2), 2);
+  assert(row != NULL && (row[1] & (UINT32_C(1) << 3)) != 0);
+  assert(bases > 0 && entries > bases);
+  printf(
+      "POSITION_LENGTHS_LOADED kwg=%llu bases=%llu entries=%llu digest=%llu\n",
+      (unsigned long long)wit->kwg_hash, (unsigned long long)bases,
+      (unsigned long long)entries, (unsigned long long)digest);
+  config_destroy(config);
+}

--- a/test/position_lengths_test.h
+++ b/test/position_lengths_test.h
@@ -1,0 +1,7 @@
+#ifndef POSITION_LENGTHS_TEST_H
+#define POSITION_LENGTHS_TEST_H
+
+void test_position_lengths(void);
+void test_position_lengths_loaded(void);
+
+#endif

--- a/test/test.c
+++ b/test/test.c
@@ -49,6 +49,7 @@
 #include "peg_test.h"
 #include "play_chooser_test.h"
 #include "players_data_test.h"
+#include "position_lengths_test.h"
 #include "rack_info_table_test.h"
 #include "rack_list_test.h"
 #include "rack_test.h"
@@ -92,6 +93,7 @@ static TestEntry test_table[] = {
     {"rit", test_rack_info_table},
     {"wit", test_word_info_table},
     {"wpfmaker", test_word_plus_floater_maker},
+    {"positionlengths", test_position_lengths},
     {"witcache", test_wit_cache},
     {"witsweep", test_wit_equivalence_sweep},
     {"kwg", test_kwg_alpha},
@@ -154,6 +156,7 @@ static TestEntry test_table[] = {
 
 // Tests that only run when explicitly requested (not included in run_all)
 static TestEntry on_demand_test_table[] = {
+    {"positionloaded", test_position_lengths_loaded},
     {"witdiff", test_wit_cache_differential},
     {"witcopy", test_wit_cache_copy},
     {"witundo", test_wit_cache_undo},
@@ -243,6 +246,7 @@ void run_test(const char *subtest) {
 }
 
 void run_all_super(void) {
+  test_position_lengths();
   test_bit_rack();
   test_board_layout_super();
 }


### PR DESCRIPTION
## What this does

Shadow can spend time checking racks and computing score bounds for word lengths that cannot contain an existing board word at its required position. This PR rejects those lengths before that work, stacked on the combined-rack preparation changes in #679 (`1b4877b5`). Native GitHub stack #681 contains #678 → #679 → #680.

A compact native cache records the possible final word lengths for every position of every dictionary base of length **2 through BOARD_DIM**. It is derived from the complete WIT dictionary during loading or native construction. CSW24 adds **7,746,156 bytes** in memory; the existing WIT file bytes, format and generation commands are unchanged. Coverage is independent of word frequency and includes longer bases; single-letter/FPF entries are not added.

Each shadow branch uses one complete board block: the initial playthrough block when usable, otherwise its first usable crossed block. An exact missing length skips recording work. If no longer length is possible at the current start, shadow stops extending right. Extending left reloads the mask for the new relative position, so a dead right branch cannot discard a valid left extension. Later blocks are not intersected in this change. Missing, foreign and partial cached rows remain permissive.

## Performance

Measured on an Apple M4 Mac mini with Apple Clang 17: CSW24, four workers, WMP/WIT and RIT mmap enabled, two plies and 0.5 seconds per simulated turn. Each comparison uses its own pair of freshly production-PGO-trained binaries (`make release`, 16 static training games, four training workers).

Each comparison retains **16 seed pairs / 32 timed runs**, eight in each run order. Games play the top static-equity move while the same temporary seedable harness measures simulation iterations per post-load work second. Loading and cache construction are outside the timer. The comparisons use separate seed sets and are not pooled.

| Comparison | Geometric throughput gain | Nominal paired 95% CI | Paired median |
|---|---:|---:|---:|
| This PR (`cf0fbb37`) vs #679 (`1b4877b5`) | **+1.40%** | **[+0.70%, +2.10%]** | **+1.18%** |
| Whole stack #678 → #679 → #680 (`cf0fbb37`) vs main (`89f54e0c`) | **+6.04%** | **[+3.37%, +8.76%]** | **+4.30%** |

The incremental comparison wins **15/16 pairs**, with +1.31% base-first and +1.49% candidate-first. The whole stack wins **16/16 pairs**, ranging from **+0.92% to +19.78%**. Its base-first group gives +3.74% and candidate-first +8.38%; these groups contain different seeds, so this does not isolate an order effect. The median and interval make the observed variability explicit.

Main uses its native WIT3 whole-word masks. The full stack uses WIT4 residual masks, complete WPF planes and the derived positional-length cache. Independent checks establish identical dictionary/trie/terminal identity and the intended mask relationship for all 1,936,539 ordinary slots; all other assets match. The incremental comparison uses byte-identical WIT4 data.

The whole-stack result uses a complete replacement campaign. An earlier attempt stopped on main after 10 pairs while temporary-file writes were failing. Its 20 completed runs and a subsequent successful diagnostic replay are preserved and excluded wholesale. The exact original PGO binaries were retained; there was no retraining between attempts. The replacement plan used fresh seeds and checked disk headroom and actual temporary-file writes before each process. No crash trace proved the original abort's cause.

Intervals use Student-t over paired log throughput ratios, conditional on each host/workload/binary pair. They do not resolve repeat-training variation, broader workload uncertainty or all shared-host noise. Process/thermal boundary snapshots and raw logs are retained. The three largest gains coincide with substantial background File Provider activity in boundary snapshots; those snapshots cannot establish its effect on either run. Continuous clock/thermal telemetry was not collected.

The new cache adds **7,746,156 bytes** for CSW24. An external driver linked against uninstrumented **O3/LTO, non-PGO production objects** measured **333.7 ms median** over five warm reconstructions, with prior-cache release and digest validation outside the interval. This is a warm native-construction cost, not a cold-load or PGO timing; every reconstruction produced the same cache.

### Profiling: affected functions

`shadow_record_wmp` rejects an impossible exact length before the existing RIT/WMP checks, leave evaluation and score-bound computation. `shadow_play_right` stops a fixed-left branch before its next empty-square step when no longer completion exists. Fewer or tighter anchor bounds then reduce work in `wordmap_gen`, `wmp_move_gen_build_playthrough_subracks` and the playthrough lookup path. `word_info_table_build_position_lengths` performs the additional work once at WIT construction/load.

An untimed, single-worker observer ran **1,000 static games** with the new pruning disabled and enabled in the same instrumented binary. Both modes retained the existing WIT/WPF/RIT checks and computed the new metadata; the switch controlled only the two new rejection decisions. Actual operation counts were:

| Operation | Pruning disabled | Pruning enabled | Reduction |
|---|---:|---:|---:|
| Rightward shadow steps | 7,033,295 | 6,768,183 | 3.77% |
| Shadow exact WMP checks | 159,984 | 128,496 | 19.68% |
| Score-bound computations | 6,209,813 | 5,845,186 | 5.87% |
| Generation anchors entered | 862,364 | 791,441 | 8.22% |
| Generation playthrough WMP probes | 5,460,298 | 5,405,608 | 1.00% |

Enabled pruning returned early from **198,781 exact-length checks** and stopped **106,635 rightward branches**. Of those, 35,201 exact returns and 39,539 branch stops selected a base of length 5 or more. These attribute decisions to the selected base; they do not isolate the incremental benefit of longer rows. The corpus also executed 871,019 mask loads. Operation reductions do not account for their cost and are not function speedups.

Six new macOS captures compare **main `89f54e0c` with the whole stack `cf0fbb37`**, using the actual measured PGO binaries and three separate profile seeds. Each capture samples for six seconds after one second of startup. Independent raw call-tree accounting and binary identity checks pass; no nonwaiting samples are unresolved. Pooled exclusive nonwaiting **simulation-worker** shares (34,959 main / 36,618 stack samples) are:

| Function/path | Main | Whole stack |
|---|---:|---:|
| `generate_moves` self, including inlined work | 40.49% | 37.70% |
| Named shadow functions | 32.21% | 31.72% |
| `wordmap_gen_forbidden_subracks` | 2.05% | 1.10% |
| Separately named `wmp_get_word_entry` | 0.00% | 2.55% |
| Named WMP word materialization | 5.30% | 5.00% |
| Named move recording | 2.87% | 3.05% |

These identify affected work, not individual function speedups. Actual PGO assembly shows main inlining WMP hash/probe work into `shadow_record_wmp`, while the stack calls `wmp_get_word_entry` separately. Including callees below shadow gives 32.21% → 32.48%, illustrating the attribution change. Zero named main lookup samples do not mean main performs no lookups.

The first profile seed mostly covers inference, contributing only 1,519 / 2,855 simulation samples; pooling weights the other two captures more heavily. Equal-capture named-shadow shares are 27.36% → 27.08%. One mixed worker root includes one inference sample in the stack simulation denominator, affecting shares by less than 0.003 percentage points. The frozen analysis and this limitation are retained. Throughput comes from the separate 16-pair comparison, not these sample shares.

## Correctness

- Optimized and ASan/UBSan builds pass complete WIT-on/off comparisons across the same **32 seeded CSW24 games / 723 positions**, checking move identities, scores and equities through copy/undo. Repeated configurations validate the same corpus rather than adding independent games.
- An independent literal-occurrence oracle checks every cache cell in small dictionaries across all indexed base lengths, repeated/overlapping occurrences, zero masks, the base itself, board-length words and permuted terminal IDs. It also checks 2,000 randomized suffix queries, missing/foreign/misaligned rows, zero-fingerprint absence, v3/v4 reconstruction and reload-failure cleanup.
- Complete-move fixtures preserve CATS after an impossible shorter completion and after shifting the start left. They also cover longer bases, crossed blocks, both directions, edges, one/two rack blanks, a board blank, single-letter and phony bases, cache removal/restoration, reused game copies, simulation undo and incremental undo.
- The targeted suite passes ASan/UBSan at **BOARD_DIM=15 and 21**. Its normal 21-board CI registration is included. The tiny 21-board fixtures use the two-blank English distribution supported by the existing WMP maker; this is not a full 21-board game corpus.
- Independent review confirms complete-block ownership/containment guards, permissive fallback and branch-local mask lifetime. The observer's 1,000 ordered seeds, scores and turn counts match exactly across modes and an independently regenerated PRNG stream. That is corroborating workload evidence, separate from complete-move correctness.
- Final ASan/UBSan validation and production-PGO tests are bound to the exact submitted source. Formatting, circular dependencies and targeted cppcheck pass; native clang-tidy reports no new diagnostics relative to the parent. All remote CI checks pass on the published head `cf0fbb37`. Both fresh whole-stack PGO binaries also pass the complete 723-position oracle; the candidate passes the native-maker, loaded-cache and positional-length suites.

## What can build on this

The same position-to-length cache can support intersections across additional complete board blocks. Any extension should demonstrate additional rejected shadow work after the current checks, preserve leftward revival and missing-data fallback, and show an incremental gain with its added lookup cost included.
