### PR TITLE
Remove goto statements and prohibit them in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,8 @@ C99 with two C11 exceptions: `_Atomic`/`<stdatomic.h>` and `static_assert`. Do n
 
 Always use `{}` braces for `if`, `else if`, and `else` blocks, even when the body is a single statement. No exceptions.
 
+**No `goto` statements.** Use structured loops, conditionals, early returns, and helper functions. Keep resource ownership explicit so every error path releases what it owns. This rule applies to C control flow; the MAGPIE `goto` navigation command is unrelated.
+
 **No forward declarations** — Never forward-declare a struct that is already defined in another module's header. Use `#include` to bring in that header instead. Forward declarations are only acceptable when the struct or function is defined in the same file.
 
 **Declare enum constants at file scope, never inside a function body.** Named constants belong with the other enum values, not buried where a reader can't find them. A constant shared across modules goes in the relevant `src/def/*_defs.h` header. A constant private to one `.c` file goes in that file's top-of-file anonymous `enum { ... }` block (see `src/impl/endgame.c`). An `enum { FOO = 12 };` declared inside a function is a bug — move it out.

--- a/src/compat/linenoise.c
+++ b/src/compat/linenoise.c
@@ -245,14 +245,18 @@ static int isUnsupportedTerm(void) {
 static int enableRawMode(int fd) {
   struct termios raw;
 
-  if (!isatty(linenoise_get_in_fileno()))
-    goto fatal;
+  if (!isatty(linenoise_get_in_fileno())) {
+    errno = ENOTTY;
+    return -1;
+  }
   if (!atexit_registered) {
     atexit(linenoiseAtExit);
     atexit_registered = 1;
   }
-  if (tcgetattr(fd, &orig_termios) == -1)
-    goto fatal;
+  if (tcgetattr(fd, &orig_termios) == -1) {
+    errno = ENOTTY;
+    return -1;
+  }
 
   raw = orig_termios; /* modify the original mode */
   /* input modes: no break, no CR to NL, no parity check, no strip char,
@@ -271,14 +275,12 @@ static int enableRawMode(int fd) {
   raw.c_cc[VTIME] = 0; /* 1 byte, no timer */
 
   /* put terminal in raw mode after flushing */
-  if (tcsetattr(fd, TCSAFLUSH, &raw) < 0)
-    goto fatal;
+  if (tcsetattr(fd, TCSAFLUSH, &raw) < 0) {
+    errno = ENOTTY;
+    return -1;
+  }
   rawmode = 1;
   return 0;
-
-fatal:
-  errno = ENOTTY;
-  return -1;
 }
 
 static void disableRawMode(int fd) {
@@ -328,15 +330,18 @@ static int getColumns(int ifd, int ofd) {
 
     /* Get the initial position so we can restore it later. */
     start = getCursorPosition(ifd, ofd);
-    if (start == -1)
-      goto failed;
+    if (start == -1) {
+      return 80;
+    }
 
     /* Go to right margin and get position. */
-    if (write(ofd, "\x1b[999C", 6) != 6)
-      goto failed;
+    if (write(ofd, "\x1b[999C", 6) != 6) {
+      return 80;
+    }
     cols = getCursorPosition(ifd, ofd);
-    if (cols == -1)
-      goto failed;
+    if (cols == -1) {
+      return 80;
+    }
 
     /* Restore position. */
     if (cols > start) {
@@ -350,9 +355,6 @@ static int getColumns(int ifd, int ofd) {
   } else {
     return ws.ws_col;
   }
-
-failed:
-  return 80;
 }
 
 /* Clear the screen. Used to handle ctrl+l */

--- a/src/str/peg_string.c
+++ b/src/str/peg_string.c
@@ -601,44 +601,11 @@ static bool peg_moves_match(const Move *m1, const Move *m2);
 static double peg_graded_history_time(const PegPollSnapshot *snap, int slot,
                                       const Move *move);
 
-// Append `text` (an outcomes cell like "W: tok tok ...") wrapped to `avail`
-// columns per line, breaking only at spaces (defensive char-break if a single
-// token exceeds `avail`). The first line continues from whatever the caller
-// already emitted on the current line; each continuation line is preceded by a
-// newline and `indent` spaces so the column stays aligned. At most `max_lines`
-// lines are emitted (0 = unlimited); if more tokens remain, the last line ends
-// with " ..." (kept within `avail`) and *truncated is set true. avail >= 1.
-static void peg_append_wrapped(StringBuilder *sb, const char *text, int indent,
-                               int avail, int max_lines, bool *truncated) {
-  if (avail < 1) {
-    avail = 1;
-  }
-  // Tokenize on spaces (the label "W:"/"L:" is just the first token).
-  int cap = 16;
-  int n_tok = 0;
-  const char **tok = malloc_or_die((size_t)cap * sizeof(char *));
-  int *tok_len = malloc_or_die((size_t)cap * sizeof(int));
-  for (const char *cursor = text; *cursor != '\0';) {
-    while (*cursor == ' ') {
-      cursor++;
-    }
-    if (*cursor == '\0') {
-      break;
-    }
-    const char *start = cursor;
-    while (*cursor != '\0' && *cursor != ' ') {
-      cursor++;
-    }
-    if (n_tok == cap) {
-      cap *= 2;
-      tok = realloc_or_die(tok, (size_t)cap * sizeof(char *));
-      tok_len = realloc_or_die(tok_len, (size_t)cap * sizeof(int));
-    }
-    tok[n_tok] = start;
-    tok_len[n_tok] = (int)(cursor - start);
-    n_tok++;
-  }
-
+// Render borrowed token arrays; the tokenizer retains ownership of them.
+static void peg_append_wrapped_tokens(StringBuilder *sb, const char *const *tok,
+                                      const int *tok_len, int n_tok, int indent,
+                                      int avail, int max_lines,
+                                      bool *truncated) {
   const int ELLIPSIS = 4; // " ..."
   int idx = 0;
   int line = 0;
@@ -668,7 +635,7 @@ static void peg_append_wrapped(StringBuilder *sb, const char *text, int indent,
                 string_builder_truncate(sb, cur_len - 3);
               }
               string_builder_add_string(sb, "...");
-              goto cleanup;
+              return;
             }
             string_builder_add_char(sb, '\n');
             string_builder_add_spaces(sb, indent);
@@ -710,7 +677,48 @@ static void peg_append_wrapped(StringBuilder *sb, const char *text, int indent,
     }
     line++;
   }
-cleanup:
+}
+
+// Append `text` (an outcomes cell like "W: tok tok ...") wrapped to `avail`
+// columns per line, breaking only at spaces (defensive char-break if a single
+// token exceeds `avail`). The first line continues from whatever the caller
+// already emitted on the current line; each continuation line is preceded by a
+// newline and `indent` spaces so the column stays aligned. At most `max_lines`
+// lines are emitted (0 = unlimited); if more tokens remain, the last line ends
+// with " ..." (kept within `avail`) and *truncated is set true. avail >= 1.
+static void peg_append_wrapped(StringBuilder *sb, const char *text, int indent,
+                               int avail, int max_lines, bool *truncated) {
+  if (avail < 1) {
+    avail = 1;
+  }
+  // Tokenize on spaces (the label "W:"/"L:" is just the first token).
+  int cap = 16;
+  int n_tok = 0;
+  const char **tok = malloc_or_die((size_t)cap * sizeof(char *));
+  int *tok_len = malloc_or_die((size_t)cap * sizeof(int));
+  for (const char *cursor = text; *cursor != '\0';) {
+    while (*cursor == ' ') {
+      cursor++;
+    }
+    if (*cursor == '\0') {
+      break;
+    }
+    const char *start = cursor;
+    while (*cursor != '\0' && *cursor != ' ') {
+      cursor++;
+    }
+    if (n_tok == cap) {
+      cap *= 2;
+      tok = realloc_or_die(tok, (size_t)cap * sizeof(char *));
+      tok_len = realloc_or_die(tok_len, (size_t)cap * sizeof(int));
+    }
+    tok[n_tok] = start;
+    tok_len[n_tok] = (int)(cursor - start);
+    n_tok++;
+  }
+
+  peg_append_wrapped_tokens(sb, tok, tok_len, n_tok, indent, avail, max_lines,
+                            truncated);
   free(tok);
   free(tok_len);
 }


### PR DESCRIPTION
## What this does

Remove all seven C `goto` statements on main and explicitly prohibit new ones in AGENTS.md.

- Return directly from terminal setup and column-detection failures, preserving their existing errno and fallback behavior.
- Extract PEG outcome-token rendering into a helper so truncation can return early while the caller always frees its token arrays.
- Require structured control flow and explicit resource ownership. The CLI `goto` navigation command remains supported.

## Validation

- Optimized application and test builds pass.
- PEG and configuration test suites pass (the URL-loading configuration fixtures require network access).
- 8,856 before/after wrapping comparisons pass under ASan/UBSan, including narrow widths, line limits, long-token splitting, and truncation flags.
- Terminal startup and quit smoke checks pass with both supported and unsupported terminal modes.
- Full cppcheck 2.17.1, dependency-cycle check, formatting, and `git diff --check` pass.
- A scan of tracked C sources and headers finds no remaining goto statements.

The WPF loader cleanup is in #678 and has been propagated through its native stack; this PR covers the statements already present on main.
