### PR TITLE
Allocate SmallMove lists contiguously

### DIFF
--- a/src/ent/move.h
+++ b/src/ent/move.h
@@ -522,12 +522,21 @@ static inline void move_list_load_with_empty_small_moves(MoveList *ml,
                                                          int capacity) {
   ml->capacity = capacity;
 
-  ml->small_moves =
-      (SmallMove **)malloc_or_die(sizeof(SmallMove *) * ml->capacity);
-  for (int i = 0; i < ml->capacity; i++) {
-    // FIXME: maybe don't alloc for moves here
-    ml->small_moves[i] = (SmallMove *)malloc_or_die(sizeof(SmallMove));
+  // Keep pointer slots, moves and spare in one allocation. Round the pointer
+  // region to whole SmallMove slots so the moves stay aligned even for odd
+  // capacities on 32-bit targets. Pointer swaps never change the owned base.
+  const size_t pointer_bytes =
+      ((sizeof(SmallMove *) * (size_t)capacity + sizeof(SmallMove) - 1) /
+       sizeof(SmallMove)) *
+      sizeof(SmallMove);
+  ml->small_moves = malloc_or_die(pointer_bytes +
+                                  (sizeof(SmallMove) * ((size_t)capacity + 1)));
+  SmallMove *storage =
+      (SmallMove *)((unsigned char *)ml->small_moves + pointer_bytes);
+  for (int move_idx = 0; move_idx < capacity; move_idx++) {
+    ml->small_moves[move_idx] = &storage[move_idx];
   }
+  ml->spare_small_move = &storage[capacity];
 }
 
 static inline void moves_for_move_list_destroy(MoveList *ml) {
@@ -550,7 +559,6 @@ static inline MoveList *move_list_create(int capacity) {
 static inline MoveList *move_list_create_small(int capacity) {
   MoveList *ml = (MoveList *)malloc_or_die(sizeof(MoveList));
   ml->count = 0;
-  ml->spare_small_move = (SmallMove *)malloc_or_die(sizeof(SmallMove));
   // Create spare_move as well, so that we can use it as a placeholder when
   // converting small moves.
   ml->spare_move = move_create();
@@ -732,9 +740,6 @@ static inline bool move_list_move_exists(const MoveList *ml, const Move *m) {
 }
 
 static inline void small_moves_for_move_list_destroy(MoveList *ml) {
-  for (int i = 0; i < ml->capacity; i++) {
-    small_move_destroy(ml->small_moves[i]);
-  }
   free(ml->small_moves);
 }
 
@@ -756,7 +761,6 @@ static inline void small_move_list_destroy(MoveList *ml) {
     return;
   }
   small_moves_for_move_list_destroy(ml);
-  small_move_destroy(ml->spare_small_move);
   move_destroy(ml->spare_move);
   free(ml);
 }

--- a/test/move_test.c
+++ b/test/move_test.c
@@ -140,9 +140,44 @@ void test_move_set_as_pass(void) {
   move_destroy(m);
 }
 
+static void test_small_move_list_reuse(void) {
+  const int capacities[] = {0, 1, 3, 64};
+  for (unsigned capacity_idx = 0;
+       capacity_idx < sizeof(capacities) / sizeof(capacities[0]);
+       capacity_idx++) {
+    const int capacity = capacities[capacity_idx];
+    MoveList *list = move_list_create_small(capacity);
+    for (int round = 0; round < 3; round++) {
+      small_move_list_reset(list);
+      for (int move_idx = 0; move_idx < capacity; move_idx++) {
+        small_move_set_as_pass(list->spare_small_move);
+        list->spare_small_move->metadata.score = (round * capacity) + move_idx;
+        move_list_insert_spare_small_move(list);
+      }
+      assert(list->count == capacity);
+      // Ordering and reuse can move the original spare into any live slot.
+      for (int move_idx = 0; move_idx < capacity; move_idx++) {
+        assert(small_move_get_score(list->small_moves[move_idx]) ==
+               (round * capacity) + move_idx);
+        assert(list->small_moves[move_idx] != list->spare_small_move);
+        for (int other_idx = move_idx + 1; other_idx < capacity; other_idx++) {
+          assert(list->small_moves[move_idx] != list->small_moves[other_idx]);
+        }
+      }
+      if (capacity > 1) {
+        SmallMove *last = list->small_moves[capacity - 1];
+        list->small_moves[capacity - 1] = list->small_moves[0];
+        list->small_moves[0] = last;
+      }
+    }
+    small_move_list_destroy(list);
+  }
+}
+
 void test_move(void) {
   // The majority of the move and move list functionalities
   // are tested in movegen tests.
+  test_small_move_list_reuse();
   test_move_resize();
   test_move_compare();
   test_move_set_as_pass();


### PR DESCRIPTION
# Allocate SmallMove lists contiguously

Short endgame solves spend substantial time allocating move storage before searching. Allocate each SmallMove list's pointer slots, records and spare in one aligned block, while retaining the existing pointer-swapping interface. Nine endgame worker lists now require 9 storage allocations instead of 2,250,018. Search ordering, pruning, bounds, scoring and full-Move storage are unchanged.

## Performance

Compared with main `0be09d0a` on an M4 Mac mini, macOS 26.6.2, Apple Clang 17, CSW24, nine threads and independently trained production PGO builds:

| Workload | Positions × paired rounds | Geometric speed ratio (95% CI) | Total main / candidate time |
| --- | ---: | ---: | ---: |
| Exact endgames, at most four rack tiles | 64 × 2 | 5.06× [4.81, 5.32] | 3.553 / 0.740 seconds |
| Full-rack endgames, four-ply horizon | 48 × 2 | 1.36× [1.22, 1.52] | 94.506 / 92.461 seconds |
| PEG, unchanged 16/8/4 cascade | 12 × 4 | 1.0495× [1.0243, 1.0786] | 3121.413 / 3072.828 seconds |

All 64 small endgames improved. Full-rack searches improved on 39/48 positions; the median speed ratio was 1.15× and the worst position took 4.0% longer. Hard searches dominate total time, so the aggregate speed ratio was only 1.022×.

PEG improved on 11/12 positions, with a 1.041× median speed ratio and a 0.48% worst latency regression. Its aggregate speed ratio was 1.0158×. All 48 paired PEG runs completed with identical best moves, win estimates and spreads. PEG reuses endgame contexts, so isolated short-solve gains do not translate directly to overall PEG gains.

A separate macOS 15.7.4 campaign used four paired rounds on the same held-out endgame corpora: geometric speed ratios were 2.81× for small exact solves, 1.30× for full-rack four-ply searches and 1.24× with reused contexts. Aggregate full-rack ratios were 1.026× with fresh contexts and 1.015× with reused contexts. OS cohorts are reported separately.

Before/after PGO profiles identify allocation and freeing of individual SmallMoves as the removed hotspot. Long searches remain dominated by move generation and cross-set work. Fixed-duration sample counts describe hotspot changes, not per-function speedups.

## Correctness

- Completed terminal-depth small-endgame values match main. Main independently verifies all 73 distinct moves selected in the Tahoe runs as optimal, including alternative tied moves.
- Separate blank-rack and pass-counter stress positions match main; all 18 distinct selected stress moves pass independent optimality checks.
- PGO move, move-generation, endgame and multi-PV suites pass. Address/undefined-behavior and pointer checks passed with the supported local sanitizer runtime; leak-only checking remains incomplete.
- Regression coverage includes zero, one, odd and larger capacities, repeated insertion/reset, pointer permutation, distinct spare ownership and destruction.

The allocation owner remains the pointer-array base when records and the spare exchange pointers. Rounding the pointer region to a whole SmallMove size preserves record alignment on 32-bit targets. No shared state or struct-layout change is introduced.

Four-ply results are horizon estimates, not terminal proofs. One recorded reused-context choice has a discrepancy against an independent horizon evaluation in both main and the candidate; it is not counted as an optimal tie. This patch does not change that search behavior. Linux/WASM CI must validate the new branch; another PR's CI does not certify this patch.

## Measurement and reproduction

Both arms share data and use identical compiler options, thread counts and independent static-autoplay PGO training (16 games). Tuning and held-out corpora are separate. Endgame validation seeds are 930093001 and 930094001; PEG validation seed is 930096201. Positions come from unfiltered static self-play. Paired runs alternate execution order and reverse position order on odd rounds, with no competing benchmark jobs. Intervals use 20,000 position-bootstrap resamples and are conditional on this host and pair of trained builds.

Build each arm with `make release NPROCS=4 PGO_TRAIN_THREADS=9 PGO_TRAIN_GAMES=16 PGO_CC=clang`, then `make magpie_test BUILD=pgo_use CC=clang NPROCS=4`. The separate C benchmark harness, exact inputs, raw measurements, hashes, profiles and execution scripts are retained in `/Users/olaugh/Documents/ChatGPT/Magpie/endgame-20260909`; see `REPRODUCE.md` for commands. Benchmark tooling is separate from the production diff.
