### PR TITLE
Skip shadow generation for exhaustive non-WMP RecordAll

### DIFF
--- a/src/impl/move_gen.c
+++ b/src/impl/move_gen.c
@@ -3387,7 +3387,8 @@ void gen_shadow_small(MoveGen *gen) {
   anchor_heapify_all(&gen->anchor_heap);
 }
 
-void gen_record_scoring_plays_small(MoveGen *gen) {
+static inline __attribute__((always_inline)) void
+gen_record_scoring_plays_unordered(MoveGen *gen, bool record_small) {
   gen->tiles_played = 0;
   const uint32_t kwg_root_node_index = kwg_get_root_node_index(gen->kwg);
 
@@ -3416,8 +3417,14 @@ void gen_record_scoring_plays_small(MoveGen *gen) {
               gen_cache_get_right_extension_set(gen, col);
           gen->current_anchor_highest_possible_score = EQUITY_MAX_VALUE;
 
-          recursive_gen_small(gen, col, kwg_root_node_index, col, col,
-                              gen->dir == BOARD_HORIZONTAL_DIRECTION, 0, 1, 0);
+          if (record_small) {
+            recursive_gen_small(gen, col, kwg_root_node_index, col, col,
+                                gen->dir == BOARD_HORIZONTAL_DIRECTION, 0, 1,
+                                0);
+          } else {
+            recursive_gen(gen, col, kwg_root_node_index, col, col,
+                          gen->dir == BOARD_HORIZONTAL_DIRECTION, 0, 1, 0);
+          }
           last_anchor_col = col;
           if (!gen_cache_is_empty(gen, col)) {
             last_anchor_col++;
@@ -3563,7 +3570,7 @@ void generate_moves(const MoveGenArgs *args) {
           (gen->tiles_played_bv & gen->target_tiles_bv) == gen->target_tiles_bv;
     }
     if (!gen->threshold_exceeded) {
-      gen_record_scoring_plays_small(gen);
+      gen_record_scoring_plays_unordered(gen, true);
     }
     if (gen->move_record_type == MOVE_RECORD_TILES_PLAYED) {
       // Write the bitvector to the caller's output pointer
@@ -3657,6 +3664,18 @@ void generate_moves(const MoveGenArgs *args) {
     }
 
     if (gen->stop_on_threshold && gen->threshold_exceeded) {
+      gen_record_pass(gen);
+      return;
+    }
+
+    if (gen->move_record_type == MOVE_RECORD_ALL && !gen->stop_on_threshold &&
+        !gen->is_wordsmog && !wmp_move_gen_is_active(&gen->wmp_move_gen)) {
+      // Exhaustive traversal needs no shadow bounds or anchor ordering. The
+      // MoveList still applies its usual capacity and score/equity tie breaks.
+      leave_map_set_current_index(
+          &gen->leave_map,
+          (1 << rack_get_total_letters(&gen->player_rack)) - 1);
+      gen_record_scoring_plays_unordered(gen, false);
       gen_record_pass(gen);
       return;
     }

--- a/test/move_gen_test.c
+++ b/test/move_gen_test.c
@@ -678,6 +678,46 @@ void small_play_recorder_test(void) {
                 (MachineLetter[]){8 | 0x80, 5, 1 | 0x80, 4, 23, 0, 0, 4, 19},
                 9) == 0);
 
+  // Compare complete small-record output with the independent full-Move
+  // traversal, including repeated letters and both blanks. Also check that
+  // changing anchor traversal order preserves bounded-list tie breaking.
+  MoveList *full_moves = move_list_create(100000);
+  MoveList *decoded_moves = move_list_create(expected_count);
+  move_gen_args.move_list = full_moves;
+  move_gen_args.move_record_type = MOVE_RECORD_ALL;
+  move_gen_args.move_sort_type = MOVE_SORT_SCORE;
+  generate_moves(&move_gen_args);
+  assert(move_list_get_count(full_moves) == expected_count);
+  move_list_sort_moves(full_moves);
+  for (int move_idx = 0; move_idx < expected_count; move_idx++) {
+    Move *decoded = move_list_get_spare_move(decoded_moves);
+    small_move_to_move(decoded, move_list->small_moves[move_idx],
+                       game_get_board(game));
+    const Equity equity = move_get_type(decoded) == GAME_EVENT_PASS
+                              ? EQUITY_PASS_VALUE
+                              : move_get_score(decoded);
+    move_list_insert_spare_move(decoded_moves, equity);
+  }
+  move_list_sort_moves(decoded_moves);
+  for (int move_idx = 0; move_idx < expected_count; move_idx++) {
+    assert(compare_moves_without_equity(
+               move_list_get_move(full_moves, move_idx),
+               move_list_get_move(decoded_moves, move_idx), true) == -1);
+  }
+  MoveList *limited_moves = move_list_create(7);
+  move_gen_args.move_list = limited_moves;
+  generate_moves(&move_gen_args);
+  move_list_sort_moves(limited_moves);
+  assert(move_list_get_count(limited_moves) == 7);
+  for (int move_idx = 0; move_idx < 7; move_idx++) {
+    assert(compare_moves_without_equity(
+               move_list_get_move(full_moves, move_idx),
+               move_list_get_move(limited_moves, move_idx), true) == -1);
+  }
+  move_list_destroy(limited_moves);
+  move_list_destroy(decoded_moves);
+  move_list_destroy(full_moves);
+
   free(temp_small_moves);
   small_move_list_destroy(move_list);
   game_destroy(game);


### PR DESCRIPTION
RecordAll computes shadow bounds and heap-orders anchors even when it will
enumerate every scoring play. Reuse the direct row/anchor traversal already
used by AllSmall, calling full move recursion for ordinary RecordAll. Preserve
leave/exchange preparation, scoring, bounded-list selection and pass handling.
WMP, wordsmog and thresholded generation keep their existing paths.

Rebased onto main `277c5b38` after #685 merged. This PR contains only the
RecordAll change and its regression test. The measurements below were collected
before this rebase; their benchmark baseline was main `0be09d0a` plus #685
(`a56bc9ee`).

### Overall random-endgame solve time

**No endgame speedup is established.** This patch targets ordinary non-WMP
RecordAll, not the endgame's AllSmall path. The solver measurements are controls;
the generation gains below should not be presented as a production bottleneck
or endgame improvement.

| Requested depth | Baseline total (s) | Candidate total (s) | Overall speedup | 95% CI |
|---|---:|---:|---:|---:|
| 2 | 10.043 | 10.034 | +0.09% | [-1.51%, +1.50%] |
| 3 | 59.943 | 60.125 | -0.30% | [-1.63%, +0.50%] |
| 4 | 94.592 | 94.914 | -0.34% | [-1.08%, +0.50%] |
| 5 | 488.243 | 494.503 | -1.27% | [-2.65%, +2.15%] |
| Combined | 652.821 | 659.576 | -1.02% | [-1.99%, +1.10%] |

All 128/128 solves per arm completed at each requested depth. Geometric
speedups were +0.16%, +0.23%, -0.28%, and +1.53%; their position-bootstrap
intervals also include zero. Excluding first-use rows gives aggregate changes
of +0.05%, -0.29%, -0.31%, and -1.13%, respectively.

Protocol: 32 unfiltered random empty-bag positions generated by static-equity
selfplay (CSW24, seed 960091001), the same roots at depths 2, 3, 4 and 5. Nine
threads, independently trained production PGO, Apple Clang 17 on macOS 26.6.2
arm64. Four paired rounds rotate execution order and reverse root order.
Contexts are reused, with TT clearing inside the timer before each reused
solve; the first row includes context creation. No search deadline or timed
truncation. These are completed depth-limited horizons, not terminal proofs.
Speedup means `baseline total / candidate total - 1`; positive is faster.
95% confidence intervals resample position clusters, preserving paired rounds.

### RecordAll generation benefit

Held-out equity-sorted generation improves by 10.0% geometric / 3.0% aggregate
for 48 midgame roots and 11.0% / 5.4% for 48 empty-bag roots. Four rotated paired
rounds, 200 warm calls/root; position-bootstrap geometric 95% intervals are
[8.8%, 11.3%] and [9.2%, 12.8%]. Score-sorted and capacity-seven lists also
improve. These function timings exclude setup and sorting. Profiles show
shadow traversal disappears from this path; AllSmall and BestSmall controls
remain near zero.

### Validation

Complete sorted metadata matches baseline in 421,032 records across score,
equity, WMP-on and bounded-list cases. Add a regression comparing all 8,286
plays from independent full/small recursions with repeated letters and two
blanks, plus bounded top-seven selection. Raw unsorted heap order may change.

All 512 paired endgame root values match. Of 147 distinct selected moves checked
independently at their matching horizon, 146 match the reported value, including
every candidate selection. Independent selected-move validation
also reproduced a baseline limitation: one baseline-only four-ply selection
evaluated to 3 against its reported root value of 7 (round 2, position 7,
tiny move 14108590272). The candidate did not select that move in these runs.
Do not interpret matching root values as proof of every baseline choice's
horizon correctness. No solver logic changes are included.

Passed PGO and ASan/UBSan move/movegen/endgame/multipv suites, native 21x21
super-board tests, formatting, cppcheck and circular-dependency checks. Native
clang-tidy 21 reports no new diagnostics in changed code. Linux/WASM CI,
clang-tidy 18, LSan and the full default 15x15 suite remain unverified.

