### PR TITLE
endgame: return TT bounds at PV nodes instead of searching an inverted window

### DIFF
--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -2370,16 +2370,21 @@ int32_t abdada_negamax(EndgameCtxWorker *worker, uint64_t node_key, int depth,
         beta = MIN(beta, score);
       }
       if (alpha >= beta) {
-        if (!pv_node) {
-          // ABDADA: leave node before returning
-          if (abdada_active) {
-            transposition_table_leave_node(worker->solver->transposition_table,
-                                           node_key);
-          }
-          // don't cut-off PV node
-          return score;
+        // The stored bound proves this node cannot improve the caller's
+        // window, so return it at PV nodes too. Continuing the search here
+        // with alpha >= beta gave every child an inverted window; a child's
+        // beta cutoff then also satisfied best_value <= alpha_orig and was
+        // stored as an upper bound, and a later PV re-search that trusted
+        // that bound reported a wrong root value. A root fail is widened and
+        // re-searched by iterative_deepening like any other aspiration fail.
+        // ABDADA: leave node before returning
+        if (abdada_active) {
+          transposition_table_leave_node(worker->solver->transposition_table,
+                                         node_key);
         }
+        return score;
       }
+      assert(alpha < beta);
       // search hash move first
       tt_move = ttentry_move(tt_entry);
     }

--- a/test/endgame_test.c
+++ b/test/endgame_test.c
@@ -552,6 +552,64 @@ void test_ctx_reuse(void) {
   config_destroy(config);
 }
 
+// Regression for transposition-table bound handling at PV nodes in
+// abdada_negamax. Before the fix, a PV node whose window a stored bound had
+// closed (alpha >= beta) kept searching: its children ran with inverted
+// windows, their beta cutoffs were stored as upper bounds, and a later
+// aspiration re-search that trusted one of those bounds published a wrong
+// "exact" root value (here 10 with a 4-point one-tile play instead of 8).
+// The trigger is a nine-thread race that hit roughly 4-6% of depth-2 solves
+// of this position before the fix and never at one thread, so this test
+// repeats the solve and is on-demand only (egttpvbound).
+void test_endgame_tt_pv_bound_repeat(void) {
+  const char *cgp =
+      "cgp 7F3QINS/7E3E2H/6ORBITED1O/3JAMBU2OM2R/1ROATE1L2FAV1T/"
+      "GI5ED1T1OPE/OD6R3WEN/EL5RUNTY2S/1E6N2U3/1Y5AKA1C3/ES1VAgUIsH1C3/"
+      "X2I7A3/I2G11/LOOING9/E2A11 ADLRSTZ/EIINPW 451/296 0 -lex CSW24";
+  Config *config = config_create_or_die(
+      "set -wmp true -s1 equity -s2 equity -threads 9 -eplies 2");
+  load_and_exec_config_or_die(config, cgp);
+
+  Game *game = config_get_game(config);
+  EndgameResults *endgame_results = config_get_endgame_results(config);
+  ErrorStack *error_stack = error_stack_create();
+  EndgameCtx *endgame_ctx = NULL;
+
+  const int num_solves = 400;
+  const int expected_score = 8;
+  for (int solve_idx = 0; solve_idx < num_solves; solve_idx++) {
+    EndgameArgs endgame_args = {0};
+    endgame_args.thread_control = config_get_thread_control(config);
+    endgame_args.game = game;
+    endgame_args.plies = config_get_endgame_plies(config);
+    endgame_args.tt_fraction_of_mem = 0.01;
+    endgame_args.initial_small_move_arena_size =
+        DEFAULT_INITIAL_SMALL_MOVE_ARENA_SIZE;
+    endgame_args.num_threads = 9;
+    endgame_args.use_heuristics = true;
+    endgame_args.num_top_moves = 1;
+    endgame_args.seed = 42;
+    if (endgame_ctx != NULL) {
+      endgame_ctx_clear_transposition_table(endgame_ctx);
+    }
+    endgame_solve(&endgame_ctx, &endgame_args, endgame_results, error_stack);
+    assert(error_stack_is_empty(error_stack));
+
+    const PVLine *pv_line =
+        endgame_results_get_pvline(endgame_results, ENDGAME_RESULT_BEST);
+    if (pv_line->score != expected_score) {
+      printf("solve %d of %d returned %d, expected %d\n", solve_idx + 1,
+             num_solves, (int)pv_line->score, expected_score);
+    }
+    assert(pv_line->score == expected_score);
+  }
+  printf("%d nine-thread solves all returned %d\n", num_solves, expected_score);
+
+  endgame_ctx_destroy(endgame_ctx);
+  error_stack_destroy(error_stack);
+  config_destroy(config);
+}
+
 void test_solve_standard(void) {
   // A standard out-in-two endgame.
   test_single_endgame(

--- a/test/endgame_test.h
+++ b/test/endgame_test.h
@@ -13,6 +13,7 @@ void test_via_mover_bingo_one_ply(void);
 void test_via_opp_must_block_every_depth(void);
 void test_via_interrupted_reasonable_under_time_pressure(void);
 void test_endgame_dynamic_worker_injection(void);
+void test_endgame_tt_pv_bound_repeat(void);
 void test_endgame_first_win_sign(void);
 void test_before_search_callback(void);
 void test_endgame_progress_stream(void);

--- a/test/test.c
+++ b/test/test.c
@@ -164,6 +164,7 @@ static TestEntry on_demand_test_table[] = {
     {"ap_rest", test_autoplay_remaining},
     {"endgame_wasm", test_endgame_wasm},
     {"endgameinject", test_endgame_dynamic_worker_injection},
+    {"egttpvbound", test_endgame_tt_pv_bound_repeat},
     {"viamover", test_via_mover_must_bingo_every_depth},
     {"viaopp", test_via_opp_must_block_every_depth},
     {"viastress", test_via_interrupted_reasonable_under_time_pressure},


### PR DESCRIPTION
## Summary

`abdada_negamax` narrows `alpha`/`beta` from a transposition-table LOWER or UPPER bound at every node, but when the narrowed window closes (`alpha >= beta`) a PV node deliberately kept searching ("don't cut-off PV node"). Every child of such a node was then searched with an inverted window. A child's beta-cutoff value also satisfies `best_value <= alpha_orig`, so `negamax_tt_store` labelled it `TT_UPPER` although it is a lower bound. A later PV re-search that trusted that bogus upper bound cut off on the same reply and published a wrong "exact" root value with the wrong best move.

This PR returns the bound at PV nodes exactly as non-PV nodes already do, and asserts `alpha < beta` after narrowing. A root fail is widened and re-searched by `iterative_deepening` like any other aspiration fail.

It also adds an on-demand regression test, `egttpvbound` (`test_endgame_tt_pv_bound_repeat`): 400 nine-thread depth-2 solves of the trigger position with a reused solver context and the TT cleared between solves, asserting value 8 every time. On unchanged main it aborts at solve 18 with value 10; with the fix all 400 return 8, natively and under ASan/UBSan. It is on-demand because it needs nine threads and about 15 s, and because the trigger is a race (see below).

## History, honestly

- The "don't cut-off PV node" branch has been in `abdada_negamax` since 193fbd43 (January 2025), so every release since then has had this behaviour.
- It was not found by a user report. It surfaced on 2026-09-09 while timing an unrelated move-generation candidate: one of sixteen nine-thread depth-2 runs of one position reported value 10 with a 4-point one-tile play whose single-thread value is -25 (regret 33). It first looked like a defect in that candidate; repeating the position 500 times reproduced it in unchanged main (28/500 with a reused solver, 18/500 with a fresh solver per solve; 0/500 at two threads, 1/500 at three, 0/200 at one thread).
- The mechanism was established with an instrumented build that keeps in-memory per-worker traces and dumps them only when the final value is wrong (stderr tracing perturbed timing enough to hide the race). All 21 wrong solves in a 500-solve run show the same signature: one aspiration re-search whose root window was inverted by another worker's root UPPER bound (alpha 171 from `prev_value - 2 * ASPIRATION_WINDOW`, beta 165 from the TT), three child stores made under inverted or closed windows all flagged `TT_UPPER`, and a final attempt that read one of them, cut off at -165 and reported 165 (spread-relative +10) instead of 163 (+8).
- The fix and its validation were produced by Claude Code sessions driven by @olaugh; every number below comes from logs kept in that workspace.

## Impact, honestly

- **Multi-thread only.** In 4864 single-thread baseline-vs-fix solve pairs (64 heldout roots and 64 small terminal roots at depths 2-4, two fresh 512-root corpora at depths 2-3, stuck/greedy heuristics on and off) there were zero value or move differences. Windows do get inverted at one thread on 12 of those roots, but at one thread the bound that closes a PV window is the node's own previous fail-soft bound and the mislabeled store comes from the very reply that produced it, so the bogus bound is tight. A non-tight bound needs another worker, which is why this only shows up at three or more threads and why no deterministic unit test could be constructed.
- **How often it bites is not well characterised.** On the trigger position it is 4-6% of nine-thread depth-2 solves; over the 64-root corpus replayed 20 times at nine threads it was 2/1280 solves. Rates at other depths, thread counts and time controls were not measured; there is no reason to think the trigger position is unique.
- **After the fix:** 500/500 correct on the trigger position at nine threads; 1280/1280 corpus solves at nine threads equal the single-thread values; depth-3 nine-thread values and the terminal cohort at depth 24 (one and nine threads) equal the baseline's; every distinct move selected in the timing runs was independently re-evaluated single-threaded (77/77, 92/92, 76/76).
- **Speed: no material change.** Independent production PGO build of the fix, paired and rotated eight rounds against the frozen current-main PGO build, nine threads, 64 heldout roots, position-clustered bootstrap CIs, 512/512 solves complete per arm, no paired value differences: depth 2 +1.26% [+0.54%, +2.18%], depth 3 +0.52% [-0.26%, +2.31%], <=4-tile terminal at depth 24 -2.10% [-4.07%, -0.06%]. The terminal cohort is ~4 ms solves and an A/A control of two independently trained PGO builds of unchanged main shows -2.09% on it, so that row is build variation. Single-thread node counts drop by exactly one on five heldout roots and are otherwise unchanged; no search-policy change is intended.
- **Play under a clock: no measurable effect.** The frozen PGO builds played each other with the `egmove1` transducer (nine threads, CSW24, 64 heldout roots each played twice with seats swapped, equal banks). At 5 s and 20 s per player per game every pair mirrored exactly (total spread 0); at 1 s the total was +6 over 128 games (mean +0.05, 95% CI [0.00, +0.14]).

## Why the old behaviour was wrong even in theory

Fail-soft alpha-beta keeps TT bounds consistent only while every searched window satisfies `alpha < beta`. Narrowing at a PV node without returning violates that invariant for the whole subtree, and the `TT_UPPER` / `TT_LOWER` classification in `negamax_tt_store` is only unambiguous when the window is valid.

## Checks (macOS, local tools)

- `python3 format.py --write` on the changed files, whole-repo format check: clean (clang-format-20).
- `make magpie_test BUILD=no_pgo_release`: builds; focused suite (`gameplay cs witcache move movegen endgame multipv`) and the full native suite pass.
- `find_circ_deps.py`: no cycles. `cppcheck.sh` (cppcheck 2.17.1): no errors. clang-tidy 21 on `src/impl/endgame.c`, `test/endgame_test.c`, `test/test.c`: 0 user-code warnings.
- ASan/UBSan (`-fsanitize=address,undefined,pointer-compare,pointer-subtract`, LSan off): focused suite and `egttpvbound` pass with 0 reports.
- `BOARD_DIM=21` build and its test run pass.
- Not run locally: emcc/WASM tests and clang-tidy-18 (the CI versions are not installed here), Linux CI.

## Limitations

- The regression test is probabilistic by nature (a race). 400 repetitions make a missed reproduction on unchanged main very unlikely (<1e-7 at a 4% per-solve rate) but it is kept on-demand.
- Forced actual-move evaluation at nine threads previously showed wide value variation in unchanged main (e.g. 53 to 74 for one move); this fix is expected to remove that too but it was not separately re-measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GP491Esn3k5rUFpDrCY7XV
