### PR TITLE
endgame: initialize cross sets of newly placed tiles during tracked placement

### DIFF
--- a/src/impl/gameplay.c
+++ b/src/impl/gameplay.c
@@ -289,11 +289,9 @@ static void calc_for_across_from_undo(MoveUndo *undo, const Game *game,
         board_get_word_edge(board, row, col_start, WORD_DIRECTION_LEFT);
     game_gen_cross_set_tracked(game, row, right_col + 1, csd, 0, undo);
     game_gen_cross_set_tracked(game, row, left_col - 1, csd, 0, undo);
-    game_gen_cross_set_tracked(game, row, col_start, csd, 0, undo);
     if (!kwgs_are_shared) {
       game_gen_cross_set_tracked(game, row, right_col + 1, csd, 1, undo);
       game_gen_cross_set_tracked(game, row, left_col - 1, csd, 1, undo);
-      game_gen_cross_set_tracked(game, row, col_start, csd, 1, undo);
     }
   }
 }
@@ -301,15 +299,15 @@ static void calc_for_across_from_undo(MoveUndo *undo, const Game *game,
 // calc_for_self using MoveUndo (doesn't need tiles info, just length)
 static void calc_for_self_from_undo(MoveUndo *undo, const Game *game,
                                     int row_start, int col_start, int csd) {
-  for (int col = col_start - 1; col <= col_start + undo->move_tiles_length;
-       col++) {
-    game_gen_cross_set_tracked(game, row_start, col, csd, 0, undo);
-  }
+  // The move's interior is occupied. New tiles were initialized during
+  // placement; played-through tiles already had zero cross sets/scores.
+  game_gen_cross_set_tracked(game, row_start, col_start - 1, csd, 0, undo);
+  game_gen_cross_set_tracked(game, row_start,
+                             col_start + undo->move_tiles_length, csd, 0, undo);
   if (!game_get_data_is_shared(game, PLAYERS_DATA_TYPE_KWG)) {
-    for (int col = col_start - 1; col <= col_start + undo->move_tiles_length;
-         col++) {
-      game_gen_cross_set_tracked(game, row_start, col, csd, 1, undo);
-    }
+    game_gen_cross_set_tracked(game, row_start, col_start - 1, csd, 1, undo);
+    game_gen_cross_set_tracked(
+        game, row_start, col_start + undo->move_tiles_length, csd, 1, undo);
   }
 }
 
@@ -665,6 +663,20 @@ static void play_move_on_board_tracked(const Move *move, const Game *game,
       continue;
     }
     board_set_letter_tracked(board, row_start, col_start + idx, letter, undo);
+    // Occupied squares have no cross set or cross score. The letter write
+    // already saved these squares, so initialize them here without a later
+    // tracked generator call. Preserve the inactive cross index in shared
+    // lexicon mode, matching the existing incremental update policy.
+    const int cross_indices =
+        game_get_data_is_shared(game, PLAYERS_DATA_TYPE_KWG) ? 1 : 2;
+    for (int ci = 0; ci < cross_indices; ci++) {
+      for (int dir = 0; dir < 2; dir++) {
+        Square *square = board_get_writable_square(board, row_start,
+                                                   col_start + idx, dir, ci);
+        square_set_cross_set(square, 0);
+        square_set_cross_score(square, 0);
+      }
+    }
     if (get_is_blanked(letter)) {
       letter = BLANK_MACHINE_LETTER;
     }

--- a/test/gameplay_test.c
+++ b/test/gameplay_test.c
@@ -799,7 +799,8 @@ void test_moves_are_similar(void) {
 // update_cross_set_for_move_from_undo a descendant node performs before move
 // generation, then unplay_move_incremental must restore the board (letters,
 // cross sets, cross scores, extension sets, anchors, flags) byte-for-byte.
-static void assert_incremental_play_roundtrip(Game *game) {
+static void assert_incremental_play_roundtrip(Game *game,
+                                              bool require_both_directions) {
   game_gen_all_cross_sets(game);
   Board *board = game_get_board(game);
   board_set_cross_sets_valid(board, true);
@@ -845,6 +846,10 @@ static void assert_incremental_play_roundtrip(Game *game) {
                    board_get_cross_set(fresh_board, r, c, d, 0));
             assert(board_get_cross_set(board, r, c, d, 1) ==
                    board_get_cross_set(fresh_board, r, c, d, 1));
+            for (int ci = 0; ci < 2; ci++) {
+              assert(board_get_cross_score(board, r, c, d, ci) ==
+                     board_get_cross_score(fresh_board, r, c, d, ci));
+            }
           }
         }
       }
@@ -874,8 +879,11 @@ static void assert_incremental_play_roundtrip(Game *game) {
     }
   }
   // The position must exercise both branches of the transposed lazy update.
-  assert(tested_vertical > 0);
-  assert(tested_horizontal > 0);
+  assert(tested_vertical + tested_horizontal > 0);
+  if (require_both_directions) {
+    assert(tested_vertical > 0);
+    assert(tested_horizontal > 0);
+  }
 
   // A pass round-trips too (no tiles: nothing to update, flags restored).
   Move pass;
@@ -897,7 +905,7 @@ void test_incremental_cross_set_undo(void) {
   Config *config = config_create_or_die("set -lex CSW21 -s1 score -s2 score");
   Game *game = config_game_create(config);
   load_cgp_or_die(game, INCREMENTAL_ROUNDTRIP_ENDGAME_CGP);
-  assert_incremental_play_roundtrip(game);
+  assert_incremental_play_roundtrip(game, true);
   game_destroy(game);
   config_destroy(config);
 
@@ -907,9 +915,19 @@ void test_incremental_cross_set_undo(void) {
       config_create_or_die("set -l1 CSW21 -l2 NWL20 -s1 score -s2 score");
   Game *dual_game = config_game_create(dual_config);
   load_cgp_or_die(dual_game, INCREMENTAL_ROUNDTRIP_ENDGAME_CGP);
-  assert_incremental_play_roundtrip(dual_game);
+  assert_incremental_play_roundtrip(dual_game, true);
   game_destroy(dual_game);
   config_destroy(dual_config);
+
+  Config *wordsmog_config = config_create_or_die(
+      "set -lex CSW21_alpha -wmp false -var wordsmog -s1 score -s2 score");
+  Game *wordsmog_game = config_game_create(wordsmog_config);
+  load_cgp_or_die(wordsmog_game, INCREMENTAL_ROUNDTRIP_ENDGAME_CGP);
+  // The bounded top-score list can contain only horizontal Wordsmog plays.
+  // Both directions' cross fields are still compared after every play.
+  assert_incremental_play_roundtrip(wordsmog_game, false);
+  game_destroy(wordsmog_game);
+  config_destroy(wordsmog_config);
 }
 
 // Regression test: get_top_move_for_player_on_turn (used by autoplay's


### PR DESCRIPTION
Originally stacked on #687, which has since merged; this is the single remaining commit.

## What changes

During tracked tile placement (`play_move_on_board_tracked`), the letter write already saves all four `Square` copies of each newly occupied square. This PR zeroes those squares' active cross sets and cross scores right there (both directions; both cross indices only when the lexicons are not shared, matching the existing incremental policy) and removes the later tracked `game_gen_cross_set` calls on the move's occupied squares:

- `calc_for_self_from_undo` regenerates only the two empty boundary squares of the move instead of every square from `col_start - 1` to `col_start + length`. Played-through interior tiles already hold zero cross sets and scores because every path that occupies a square zeroes them.
- `calc_for_across_from_undo` no longer calls the generator on the placed square itself; the generator's occupied-square path only wrote the two zeros that placement now writes.

Empty-boundary generation, extension sets, WIT block caching (only written for empty squares flanked by tiles), anchors, undo dedup and the transposition-table policy are unchanged. Replaying 24,576 legal endgame states under classic, dual-lexicon and Wordsmog configurations produced identical post-play and restored boards; tracked generator calls fell from 428,064 to 232,768 (classic).

The regression test extends `test_incremental_cross_set_undo` to compare cross scores as well as cross sets after undo, in both directions, for classic and dual-lexicon games.

## Scope: endgame only

The two routines this touches are reachable only through `play_move_incremental`, the tracked play-with-undo path. Its only callers are in `src/impl/endgame.c` (the solver's negamax, greedy leaf playout, depth-0 sweep and PV re-search), and `update_cross_set_for_move_from_undo` is called from that path and from the solver's lazy-update sites. Simulation, autoplay and PEG's own move playing all go through `play_move`, which uses `update_cross_set_for_move` and the untracked `calc_for_self`/`calc_for_across`; that code is unchanged, and PEG only reaches the changed code through its embedded endgame solves. No cross set, cross score, extension set or WIT block cache value changes, only where the zeros for newly occupied squares are written and how many redundant generator calls are made, so move generation with WMP, RIT or WIT sees identical board state.

We also doubt sims would benefit from switching to the incremental path. The simmer takes one full game backup before the simmed play, plays the remaining plies with no backup at all, and restores once at the end of the iteration, so the board copy is already amortized over the rollout. Native samples of the sim benchmark (9 workers, WMP and RIT on, WIT off and on) put `game_backup` plus `game_unplay_last_move` at about 3% of worker time, with move generation at about 90%. An incremental path would still have to save and restore the touched squares, and it would need bag-draw and exchange undo that the tracked path does not have, so the realistic gain is a percent or two at best for meaningful complexity.

## Measured effect

Nine threads, independent production PGO builds (`make release NPROCS=4 PGO_TRAIN_THREADS=9 PGO_TRAIN_GAMES=16`), paired rotated eight rounds against a frozen PGO build of `5c362364`, TT cleared inside the timing, position-clustered bootstrap 95% CIs. Every solve completed in both arms and no paired root value differed.

| corpus | aggregate | 95% CI | geometric | median | wins |
|---|---|---|---|---|---|
| 64 heldout roots, depth 2 | +2.65% | [+1.82%, +3.56%] | +1.88% | +1.74% | 56/64 |
| same roots, depth 3 | +1.38% | [+0.62%, +2.36%] | +1.15% | +1.24% | 44/64 |
| same roots, depth 4 | +0.73% | [+0.17%, +2.21%] | +1.28% | +0.89% | 43/64 |
| 48 confirmation roots, depth 4 | +2.00% | [+0.69%, +4.67%] | +1.44% | +1.28% | 33/48 |
| 64 <=4-tile terminal roots, depth 24 | -1.37% | [-2.65%, -0.02%] | -1.79% | -1.46% | 24/64 |

An A/A control (two independently trained PGO builds of unchanged main) measured -2.09% [-2.96%, -1.22%] on the same terminal cohort (about 4 ms per solve) and -0.09% at depths 2 and 3, so the terminal row is build/layout variation rather than a code effect, while the depth-limited gains exceed build variation. On the earlier `8e607566` baseline (before root PVS) a 48-root depth-4 heldout showed no gain (-0.24% [-1.06%, +0.37%]); the gain is established on current main only. This is a modest change, about 1-3% at depths 2-4.

## Profiling of the changed functions

Method: `sample` (macOS native sampler, 1 ms) over the entire duration of an identical single-thread depth-3 solve of the 64 heldout roots, three alternating repetitions per arm, using the same frozen production PGO binaries as the timing above. Single-threaded, both arms do exactly the same work (14,089,097 nodes, identical values and moves in every run), so sample counts are proportional to time per function. Numbers are mean shares of busy samples (idle coordinator threads excluded); "inclusive" counts a sample anywhere below the function. `play_move_on_board_tracked` and `calc_for_self_from_undo` are inlined by LTO/PGO, so they appear inside their callers.

| function (single-thread, depth 3, equal work) | baseline self | candidate self | baseline inclusive | candidate inclusive |
|---|---|---|---|---|
| `play_move_incremental` (inlines `play_move_on_board_tracked`, now holds the zeroing loop) | 1.52% | 1.63% | 18.77% | 18.26% |
| `update_cross_set_for_move_from_undo` (inlines `calc_for_self_from_undo`) | 0.09% | 0.06% | 13.41% | 12.77% |
| `calc_for_across_from_undo` | 0.46% | 0.45% | 8.70% | 8.50% |
| `game_gen_cross_set_tracked` | 1.94% | 1.60% | 1.94% | 1.60% |
| `game_gen_cross_set` (generator itself; all callers) | 11.00% | 10.73% | 11.00% | 10.73% |

What this shows: the tracked generator wrapper loses about 18% of its self time and the generator itself about 2.5% (the removed calls were its cheap occupied-square exits, so the saving is in call overhead, bounds checks and undo bookkeeping rather than in cross-set computation), `update_cross_set_for_move_from_undo` drops by about 5% inclusive, and placement gains a little from the new zeroing loop. Net, about 0.5 percentage points of single-thread solve time move out of the touched code. Sampled wall time over the three alternating repetitions: 95.56 s vs 94.63 s (+0.97% faster, range of the three baseline runs 94.05-96.70 s, candidate 94.02-94.97 s). Per-function counts from the earlier fixed-duration nine-thread samples move the same way (generator self share 12.7% to 11.4%, tracked wrapper 2.5% to 1.8%) but those are shares over different work and are not speedups. Cross-set generation is a somewhat larger share of worker time at nine threads than at one, which is consistent with the paired nine-thread gains being larger than the single-thread per-function delta, though that link is not established. Call counts from the 24,576-state replay observer: tracked generator calls 428,064 to 232,768 (classic), 855,968 to 465,408 (dual lexicon), 696,208 to 351,520 (Wordsmog); final undo sizes unchanged.

Raw samples: `evidence/funcprofile-d3-1thread-*.sample.txt` in the investigation workspace.

## Correctness

All distinct selected moves matched independent single-thread evaluation: 91 at depth 3, 100 at depth 4, 77 terminal, 66/54 on the confirmation corpus, and 79 of 80 at depth 2. The one depth-2 failure was the solver defect fixed by #687, reproduced in unchanged main at the same rate (28/500 vs 31/500 nine-thread solves of that position; 0 at one thread). 224 targeted terminal solves across classic WMP/WIT on and off, dual CSW21/NWL20 and Wordsmog at one and nine threads matched, and all 233 distinct selections passed independent evaluation.

## Checks

In a clean checkout of `5c362364` plus this change: `format.py --write` then whole-repo format check; `make magpie_test BUILD=no_pgo_release`; focused gameplay/cs/witcache/move/movegen/endgame/multipv suites; the full native `run_all` suite (66 tests, after generating the missing lexicon wordmaps with `magpie convert text2wordmap`); `find_circ_deps.py`; `cppcheck.sh` (cppcheck 2.17.1, no errors); clang-tidy 21 on both changed files (0 warnings); ASan/UBSan focused suite (0 reports); `BOARD_DIM=21` build and tests. Rebuilt and re-ran the focused suites on this stacked branch. Not run locally: WASM tests and clang-tidy-18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxtN4jvLjaWPG4HBb1vamN
