### PR TITLE
endgame: prune words that cross-checks make unplayable

### DIFF
--- a/src/impl/endgame.c
+++ b/src/impl/endgame.c
@@ -731,7 +731,15 @@ void endgame_ctx_reset(EndgameCtx *es, EndgameResults *results,
       const KWG *full_kwg =
           player_get_kwg(game_get_player(endgame_args->game, player_idx));
       DictionaryWordList *word_list = dictionary_word_list_create();
-      generate_possible_words(endgame_args->game, full_kwg, word_list);
+      // Cross-check-aware pruning is only sound for classic play with a
+      // shared lexicon; see generate_possible_words_with_cross_checks.
+      if (game_get_variant(endgame_args->game) == GAME_VARIANT_CLASSIC &&
+          shared_kwg) {
+        generate_possible_words_with_cross_checks(endgame_args->game, full_kwg,
+                                                  word_list);
+      } else {
+        generate_possible_words(endgame_args->game, full_kwg, word_list);
+      }
       es->pruned_kwgs[player_idx] = make_kwg_from_words_small(
           word_list, KWG_MAKER_OUTPUT_GADDAG, KWG_MAKER_MERGE_EXACT);
       dictionary_word_list_destroy(word_list);

--- a/src/impl/word_prune.c
+++ b/src/impl/word_prune.c
@@ -433,3 +433,314 @@ void generate_possible_words(const Game *game, const KWG *override_kwg,
   dictionary_word_list_unique(temp_list, possible_word_list);
   dictionary_word_list_destroy(temp_list);
 }
+// ---------------------------------------------------------------------------
+// Cross-check-aware pruning. See word_prune.h.
+// ---------------------------------------------------------------------------
+
+enum { WORD_PRUNE_NUM_LANES = BOARD_DIM * 2 };
+
+// Letters that some accepted playthrough placement put on each empty square,
+// per lane. Lanes 0..BOARD_DIM-1 are rows indexed by column; the rest are
+// columns indexed by row.
+typedef struct LaneLetterSets {
+  uint32_t letters[WORD_PRUNE_NUM_LANES][BOARD_DIM];
+} LaneLetterSets;
+
+typedef struct CrossCheckContext {
+  const BoardRows *lanes;
+  int lane;
+  // Letter sets recorded by the previous pass, or NULL on the first pass.
+  const LaneLetterSets *previous;
+  LaneLetterSets *current;
+  DictionaryWordList *word_list;
+} CrossCheckContext;
+
+static inline int perpendicular_lane(int lane, int pos) {
+  return lane < BOARD_DIM ? BOARD_DIM + pos : pos;
+}
+
+static inline int perpendicular_pos(int lane) {
+  return lane < BOARD_DIM ? lane : lane - BOARD_DIM;
+}
+
+// True when the square at (lane, pos) already has a tile directly before or
+// after it in the perpendicular lane.
+static inline bool has_fixed_perpendicular_neighbor(const BoardRows *lanes,
+                                                    int lane, int pos) {
+  const BoardRow *perp = &lanes->rows[perpendicular_lane(lane, pos)];
+  const int perp_pos = perpendicular_pos(lane);
+  return (perp_pos > 0 &&
+          perp->letters[perp_pos - 1] != ALPHABET_EMPTY_SQUARE_MARKER) ||
+         (perp_pos < BOARD_DIM - 1 &&
+          perp->letters[perp_pos + 1] != ALPHABET_EMPTY_SQUARE_MARKER);
+}
+
+static inline bool cross_check_allows(const CrossCheckContext *ctx, int pos,
+                                      MachineLetter ml) {
+  if (ctx->previous == NULL ||
+      !has_fixed_perpendicular_neighbor(ctx->lanes, ctx->lane, pos)) {
+    return true;
+  }
+  const uint32_t letters =
+      ctx->previous->letters[perpendicular_lane(ctx->lane, pos)]
+                            [perpendicular_pos(ctx->lane)];
+  return (letters >> ml) & 1;
+}
+
+static BoardRows *all_lanes_create(const Game *game) {
+  BoardRows *container = malloc_or_die(sizeof(BoardRows));
+  const Board *board = game_get_board(game);
+  for (int row = 0; row < BOARD_DIM; row++) {
+    for (int col = 0; col < BOARD_DIM; col++) {
+      const MachineLetter unblanked =
+          get_unblanked_machine_letter(board_get_letter(board, row, col));
+      container->rows[row].letters[col] = unblanked;
+      container->rows[BOARD_DIM + col].letters[row] = unblanked;
+    }
+  }
+  container->num_rows = WORD_PRUNE_NUM_LANES;
+  return container;
+}
+
+static void cross_check_record_word(CrossCheckContext *ctx,
+                                    const MachineLetter *strip, int leftstrip,
+                                    int rightstrip) {
+  const BoardRow *row = &ctx->lanes->rows[ctx->lane];
+  for (int pos = leftstrip; pos <= rightstrip; pos++) {
+    if (row->letters[pos] == ALPHABET_EMPTY_SQUARE_MARKER) {
+      ctx->current->letters[ctx->lane][pos] |= (uint32_t)1 << strip[pos];
+    }
+  }
+  dictionary_word_list_add_word(ctx->word_list, strip + leftstrip,
+                                rightstrip - leftstrip + 1);
+}
+
+static void cross_check_words_go_on(CrossCheckContext *ctx, const KWG *kwg,
+                                    Rack *rack, int current_col, int anchor_col,
+                                    MachineLetter current_letter,
+                                    uint32_t new_node_index, bool accepts,
+                                    int leftstrip, int rightstrip,
+                                    int leftmost_col, int tiles_played,
+                                    MachineLetter *strip);
+
+// Mirrors playthrough_words_recursive_gen, with the cross-check on pool
+// letters placed on empty squares.
+static void cross_check_words_recursive_gen(CrossCheckContext *ctx,
+                                            const KWG *kwg, Rack *rack, int col,
+                                            int anchor_col, uint32_t node_index,
+                                            int leftstrip, int rightstrip,
+                                            int leftmost_col, int tiles_played,
+                                            MachineLetter *strip) {
+  const BoardRow *board_row = &ctx->lanes->rows[ctx->lane];
+  const MachineLetter current_letter = board_row->letters[col];
+  if (current_letter != ALPHABET_EMPTY_SQUARE_MARKER) {
+    uint32_t next_node_index = 0;
+    bool accepts = false;
+    for (uint32_t node_idx = node_index;; node_idx++) {
+      const uint32_t node = kwg_node(kwg, node_idx);
+      if (kwg_node_tile(node) == current_letter) {
+        next_node_index = kwg_node_arc_index_prefetch(node, kwg);
+        accepts = kwg_node_accepts(node);
+        break;
+      }
+      if (kwg_node_is_end(node)) {
+        break;
+      }
+    }
+    cross_check_words_go_on(ctx, kwg, rack, col, anchor_col, current_letter,
+                            next_node_index, accepts, leftstrip, rightstrip,
+                            leftmost_col, tiles_played, strip);
+  } else if (!rack_is_empty(rack)) {
+    for (uint32_t node_idx = node_index;; node_idx++) {
+      const uint32_t node = kwg_node(kwg, node_idx);
+      const MachineLetter ml = kwg_node_tile(node);
+      if (ml != SEPARATION_MACHINE_LETTER && cross_check_allows(ctx, col, ml)) {
+        const uint32_t next_node_index = kwg_node_arc_index_prefetch(node, kwg);
+        const bool accepts = kwg_node_accepts(node);
+        if (rack_get_letter(rack, ml) > 0) {
+          rack_take_letter(rack, ml);
+          cross_check_words_go_on(
+              ctx, kwg, rack, col, anchor_col, ml, next_node_index, accepts,
+              leftstrip, rightstrip, leftmost_col, tiles_played + 1, strip);
+          rack_add_letter(rack, ml);
+        } else if (rack_get_letter(rack, BLANK_MACHINE_LETTER) > 0) {
+          rack_take_letter(rack, BLANK_MACHINE_LETTER);
+          cross_check_words_go_on(
+              ctx, kwg, rack, col, anchor_col, ml, next_node_index, accepts,
+              leftstrip, rightstrip, leftmost_col, tiles_played + 1, strip);
+          rack_add_letter(rack, BLANK_MACHINE_LETTER);
+        }
+      }
+      if (kwg_node_is_end(node)) {
+        break;
+      }
+    }
+  }
+}
+
+// Mirrors playthrough_words_go_on, recording accepted placements.
+static void cross_check_words_go_on(CrossCheckContext *ctx, const KWG *kwg,
+                                    Rack *rack, int current_col, int anchor_col,
+                                    MachineLetter current_letter,
+                                    uint32_t new_node_index, bool accepts,
+                                    int leftstrip, int rightstrip,
+                                    int leftmost_col, int tiles_played,
+                                    MachineLetter *strip) {
+  const BoardRow *board_row = &ctx->lanes->rows[ctx->lane];
+  if (current_col <= anchor_col) {
+    strip[current_col] =
+        board_row->letters[current_col] != ALPHABET_EMPTY_SQUARE_MARKER
+            ? board_row->letters[current_col]
+            : current_letter;
+    leftstrip = current_col;
+    if (accepts && tiles_played > 0) {
+      cross_check_record_word(ctx, strip, leftstrip, rightstrip);
+    }
+    if (new_node_index == 0) {
+      return;
+    }
+    if (current_col > leftmost_col) {
+      cross_check_words_recursive_gen(
+          ctx, kwg, rack, current_col - 1, anchor_col, new_node_index,
+          leftstrip, rightstrip, leftmost_col, tiles_played, strip);
+    }
+    const bool no_letter_directly_left =
+        current_col == 0 ||
+        board_row->letters[current_col - 1] == ALPHABET_EMPTY_SQUARE_MARKER;
+    const uint32_t separation_node_index =
+        kwg_get_next_node_index(kwg, new_node_index, SEPARATION_MACHINE_LETTER);
+    if (separation_node_index != 0 && no_letter_directly_left &&
+        anchor_col < BOARD_DIM - 1) {
+      cross_check_words_recursive_gen(
+          ctx, kwg, rack, anchor_col + 1, anchor_col, separation_node_index,
+          leftstrip, rightstrip, leftmost_col, tiles_played, strip);
+    }
+  } else {
+    strip[current_col] =
+        board_row->letters[current_col] != ALPHABET_EMPTY_SQUARE_MARKER
+            ? board_row->letters[current_col]
+            : current_letter;
+    rightstrip = current_col;
+    const bool no_letter_directly_right =
+        current_col == BOARD_DIM - 1 ||
+        board_row->letters[current_col + 1] == ALPHABET_EMPTY_SQUARE_MARKER;
+    if (accepts && no_letter_directly_right && tiles_played > 0) {
+      cross_check_record_word(ctx, strip, leftstrip, rightstrip);
+    }
+    if (new_node_index != 0 && current_col < BOARD_DIM - 1) {
+      cross_check_words_recursive_gen(
+          ctx, kwg, rack, current_col + 1, anchor_col, new_node_index,
+          leftstrip, rightstrip, leftmost_col, tiles_played, strip);
+    }
+  }
+}
+
+// Mirrors add_playthrough_words_from_row for one lane of the context.
+static void cross_check_add_playthrough_words_from_lane(CrossCheckContext *ctx,
+                                                        const KWG *kwg,
+                                                        Rack *pool) {
+  const BoardRow *board_row = &ctx->lanes->rows[ctx->lane];
+  MachineLetter strip[BOARD_DIM];
+  const uint32_t gaddag_root = kwg_get_root_node_index(kwg);
+  int leftmost_col = 0;
+  for (int col = 0; col < BOARD_DIM; col++) {
+    if (board_row->letters[col] == ALPHABET_EMPTY_SQUARE_MARKER) {
+      continue;
+    }
+    while (col < BOARD_DIM - 1 &&
+           board_row->letters[col + 1] != ALPHABET_EMPTY_SQUARE_MARKER) {
+      col++;
+    }
+    const MachineLetter current_letter = board_row->letters[col];
+    uint32_t next_node_index = 0;
+    for (uint32_t node_idx = gaddag_root;; node_idx++) {
+      const uint32_t node = kwg_node(kwg, node_idx);
+      if (kwg_node_tile(node) == current_letter) {
+        next_node_index = kwg_node_arc_index_prefetch(node, kwg);
+        break;
+      }
+      if (kwg_node_is_end(node)) {
+        break;
+      }
+    }
+    cross_check_words_go_on(ctx, kwg, pool, col, col, current_letter,
+                            next_node_index, false, col, col, leftmost_col, 0,
+                            strip);
+    // leave an empty-space gap
+    leftmost_col = col + 2;
+  }
+}
+
+void generate_possible_words_with_cross_checks(
+    const Game *game, const KWG *override_kwg,
+    DictionaryWordList *possible_word_list) {
+  const KWG *kwg = override_kwg;
+  if (kwg == NULL) {
+    kwg = player_get_kwg(
+        game_get_player(game, game_get_player_on_turn_index(game)));
+  }
+  const int ld_size = ld_get_size(game_get_ld(game));
+  Rack pool;
+  rack_set_dist_size_and_reset(&pool, ld_size);
+  const Bag *bag = game_get_bag(game);
+  for (int ml = 0; ml < ld_size; ml++) {
+    for (int count = 0; count < bag_get_letter(bag, ml); count++) {
+      rack_add_letter(&pool, ml);
+    }
+    for (int player_index = 0; player_index < 2; player_index++) {
+      const Rack *rack = player_get_rack(game_get_player(game, player_index));
+      for (int count = 0; count < rack_get_letter(rack, ml); count++) {
+        rack_add_letter(&pool, ml);
+      }
+    }
+  }
+  BoardRows *lanes = all_lanes_create(game);
+  int max_nonplaythrough_spaces = 0;
+  for (int lane = 0; lane < lanes->num_rows; lane++) {
+    const int spaces = max_nonplaythrough_spaces_in_row(&lanes->rows[lane]);
+    if (spaces > max_nonplaythrough_spaces) {
+      max_nonplaythrough_spaces = spaces;
+    }
+  }
+
+  DictionaryWordList *temp_list = dictionary_word_list_create();
+  MachineLetter word[BOARD_DIM];
+  add_words_without_playthrough_gaddag(kwg, &pool, max_nonplaythrough_spaces,
+                                       word, temp_list);
+
+  // Pass one: unconstrained, recording which letters each placement puts on
+  // each empty square. Nearly all of the reduction comes from applying those
+  // sets once; iterating to a fixed point removes about two percent more at
+  // more than double the cost, so exactly two passes are made.
+  LaneLetterSets *first_pass = malloc_or_die(sizeof(LaneLetterSets));
+  memset(first_pass, 0, sizeof(LaneLetterSets));
+  DictionaryWordList *discarded = dictionary_word_list_create();
+  for (int lane = 0; lane < lanes->num_rows; lane++) {
+    CrossCheckContext ctx = {.lanes = lanes,
+                             .lane = lane,
+                             .previous = NULL,
+                             .current = first_pass,
+                             .word_list = discarded};
+    cross_check_add_playthrough_words_from_lane(&ctx, kwg, &pool);
+  }
+  dictionary_word_list_destroy(discarded);
+
+  // Pass two: constrained by the first pass's letter sets.
+  LaneLetterSets *second_pass = malloc_or_die(sizeof(LaneLetterSets));
+  memset(second_pass, 0, sizeof(LaneLetterSets));
+  for (int lane = 0; lane < lanes->num_rows; lane++) {
+    CrossCheckContext ctx = {.lanes = lanes,
+                             .lane = lane,
+                             .previous = first_pass,
+                             .current = second_pass,
+                             .word_list = temp_list};
+    cross_check_add_playthrough_words_from_lane(&ctx, kwg, &pool);
+  }
+  free(second_pass);
+  free(first_pass);
+  board_rows_destroy(lanes);
+
+  dictionary_word_list_sort(temp_list);
+  dictionary_word_list_unique(temp_list, possible_word_list);
+  dictionary_word_list_destroy(temp_list);
+}

--- a/src/impl/word_prune.h
+++ b/src/impl/word_prune.h
@@ -17,4 +17,25 @@ typedef struct BoardRows {
 void generate_possible_words(const Game *game, const KWG *override_kwg,
                              DictionaryWordList *possible_word_list);
 
+// Like generate_possible_words, but also drops playthrough words that could
+// never be played because of cross-checks. For every square that already has
+// a tile directly before or after it in the perpendicular lane, any word that
+// will ever cover that square must, in that perpendicular lane, contain the
+// existing tile: so the letters that can ever occupy the square are exactly
+// the letters that the perpendicular lane's playthrough words put there. A
+// first unconstrained pass records those letters per lane and square; a
+// second pass regenerates the playthrough words, refusing a pool letter on
+// such a square unless the perpendicular lane recorded it. Both passes draw
+// from the union of every unseen tile, so the result is a subset of
+// generate_possible_words and a superset of every word playable in any
+// position reachable from this one.
+//
+// Only sound for classic play with one shared lexicon: Wordsmog cross words
+// are order-free, and in informed dual-lexicon mode a cross word legal only
+// in the other player's lexicon can place a letter this lexicon's pass never
+// records. Callers must fall back to generate_possible_words otherwise.
+void generate_possible_words_with_cross_checks(
+    const Game *game, const KWG *override_kwg,
+    DictionaryWordList *possible_word_list);
+
 #endif // WORD_PRUNE_H

--- a/test/word_prune_test.c
+++ b/test/word_prune_test.c
@@ -1,8 +1,10 @@
 #include "word_prune_test.h"
 
+#include "../src/def/equity_defs.h"
 #include "../src/def/game_defs.h"
+#include "../src/def/game_history_defs.h"
+#include "../src/def/letter_distribution_defs.h"
 #include "../src/def/move_defs.h"
-#include "../src/ent/board.h"
 #include "../src/ent/dictionary_word.h"
 #include "../src/ent/endgame_results.h"
 #include "../src/ent/game.h"
@@ -18,6 +20,7 @@
 #include "../src/util/io_util.h"
 #include "test_util.h"
 #include <assert.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/word_prune_test.c
+++ b/test/word_prune_test.c
@@ -1,12 +1,25 @@
 #include "word_prune_test.h"
 
+#include "../src/def/game_defs.h"
+#include "../src/def/move_defs.h"
+#include "../src/ent/board.h"
 #include "../src/ent/dictionary_word.h"
+#include "../src/ent/endgame_results.h"
 #include "../src/ent/game.h"
+#include "../src/ent/kwg.h"
+#include "../src/ent/move.h"
+#include "../src/ent/player.h"
+#include "../src/ent/words.h"
 #include "../src/impl/config.h"
+#include "../src/impl/endgame.h"
+#include "../src/impl/gameplay.h"
+#include "../src/impl/move_gen.h"
 #include "../src/impl/word_prune.h"
+#include "../src/util/io_util.h"
 #include "test_util.h"
 #include <assert.h>
 #include <stdlib.h>
+#include <string.h>
 
 void test_possible_words(void) {
   Config *config = config_create_or_die(
@@ -66,4 +79,179 @@ void test_possible_words(void) {
   config_destroy(config);
 }
 
-void test_word_prune(void) { test_possible_words(); }
+static bool word_list_contains(const DictionaryWordList *list,
+                               const MachineLetter *word, int length) {
+  int low = 0;
+  int high = dictionary_word_list_get_count(list) - 1;
+  while (low <= high) {
+    const int mid = (low + high) / 2;
+    const DictionaryWord *entry = dictionary_word_list_get_word(list, mid);
+    const int entry_length = dictionary_word_get_length(entry);
+    const int common = length < entry_length ? length : entry_length;
+    int cmp = memcmp(dictionary_word_get_word(entry), word, (size_t)common);
+    if (cmp == 0) {
+      cmp = entry_length - length;
+    }
+    if (cmp == 0) {
+      return true;
+    }
+    if (cmp < 0) {
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+  return false;
+}
+
+// Every word formed by every tile move in every position reachable within
+// plies_left (all sequences, both players, full-lexicon move generation) must
+// be in the pruned list. Passes form no words; the bag is empty so there are
+// no exchanges. Returns the number of moves played.
+static int assert_reachable_words_are_kept(Game *game,
+                                           const DictionaryWordList *pruned,
+                                           int plies_left) {
+  if (plies_left == 0 ||
+      game_get_game_end_reason(game) != GAME_END_REASON_NONE) {
+    return 0;
+  }
+  MoveList *moves = move_list_create(100000);
+  const MoveGenArgs args = {.game = game,
+                            .move_list = moves,
+                            .move_record_type = MOVE_RECORD_ALL,
+                            .move_sort_type = MOVE_SORT_SCORE,
+                            .override_kwg = NULL,
+                            .eq_margin_movegen = 0,
+                            .target_equity = EQUITY_MAX_VALUE,
+                            .target_leave_size_for_exchange_cutoff =
+                                UNSET_LEAVE_SIZE};
+  generate_moves(&args);
+  int moves_played = 0;
+  for (int move_idx = 0; move_idx < move_list_get_count(moves); move_idx++) {
+    const Move *move = move_list_get_move(moves, move_idx);
+    if (move_get_type(move) != GAME_EVENT_TILE_PLACEMENT_MOVE) {
+      continue;
+    }
+    FormedWords *formed = formed_words_create(game_get_board(game), move);
+    for (int word_idx = 0; word_idx < formed_words_get_num_words(formed);
+         word_idx++) {
+      assert(
+          word_list_contains(pruned, formed_words_get_word(formed, word_idx),
+                             formed_words_get_word_length(formed, word_idx)));
+    }
+    formed_words_destroy(formed);
+    play_move(move, game, NULL); // backs up the game itself
+    moves_played++;
+    moves_played +=
+        assert_reachable_words_are_kept(game, pruned, plies_left - 1);
+    game_unplay_last_move(game);
+  }
+  move_list_destroy(moves);
+  return moves_played;
+}
+
+static void assert_cross_check_pruning(Game *game, int plies,
+                                       int min_moves_expected) {
+  const KWG *kwg = player_get_kwg(game_get_player(game, 0));
+  DictionaryWordList *plain = dictionary_word_list_create();
+  DictionaryWordList *pruned = dictionary_word_list_create();
+  generate_possible_words(game, kwg, plain);
+  generate_possible_words_with_cross_checks(game, kwg, pruned);
+  // A subset of the plain list.
+  assert(dictionary_word_list_get_count(pruned) <=
+         dictionary_word_list_get_count(plain));
+  for (int word_idx = 0; word_idx < dictionary_word_list_get_count(pruned);
+       word_idx++) {
+    const DictionaryWord *word =
+        dictionary_word_list_get_word(pruned, word_idx);
+    assert(word_list_contains(plain, dictionary_word_get_word(word),
+                              dictionary_word_get_length(word)));
+  }
+  // A superset of every word any reachable move can form.
+  game_set_backup_mode(game, BACKUP_MODE_SIMULATION);
+  const int moves_played = assert_reachable_words_are_kept(game, pruned, plies);
+  assert(moves_played >= min_moves_expected);
+  dictionary_word_list_destroy(pruned);
+  dictionary_word_list_destroy(plain);
+}
+
+// With static leaves the depth-limited search is exact, so pruning with cross
+// checks must reproduce the unpruned search's value and node count exactly.
+static void
+assert_endgame_unchanged_by_cross_check_pruning(const Config *config,
+                                                Game *game, int plies) {
+  int values[2];
+  uint64_t nodes[2];
+  for (int mode = 0; mode < 2; mode++) {
+    EndgameCtx *solver = NULL;
+    EndgameResults *results = endgame_results_create();
+    ErrorStack *error_stack = error_stack_create();
+    EndgameArgs args = {.game = game,
+                        .thread_control = config_get_thread_control(config),
+                        .plies = plies,
+                        .tt_fraction_of_mem = 0.01,
+                        .initial_small_move_arena_size =
+                            DEFAULT_INITIAL_SMALL_MOVE_ARENA_SIZE,
+                        .num_threads = 1,
+                        .num_top_moves = 1,
+                        .use_heuristics = false,
+                        .skip_word_pruning = mode == 1,
+                        .seed = 42};
+    endgame_solve(&solver, &args, results, error_stack);
+    assert(error_stack_is_empty(error_stack));
+    values[mode] = endgame_results_get_value(results, ENDGAME_RESULT_BEST);
+    nodes[mode] = endgame_ctx_get_nodes_searched(solver);
+    endgame_ctx_destroy(solver);
+    endgame_results_destroy(results);
+    error_stack_destroy(error_stack);
+  }
+  assert(values[0] == values[1]);
+  assert(nodes[0] == nodes[1]);
+}
+
+void test_possible_words_with_cross_checks(void) {
+  Config *config = config_create_or_die("set -lex CSW21 -threads 1");
+  Game *game = config_game_create(config);
+
+  // Every reachable position of two small endgames (whole game trees).
+  const char tiny_a[400] =
+      "7Q6B/BEENTO1u6U/5READVISE1K/7Y5WE/4VAUDOO3I1/5X2HUP2L1/6G3E2LI/"
+      "T4ARChERY1EF/I5A3I2R1/FORAGING2DANS1/T2HUNDO2OMA2/1JAIL1S3TON2/6I3EWE2/"
+      "COMPEER4T3/7ZATIS3 N/L 380/528 0 lex CSW21;";
+  load_cgp_or_die(game, tiny_a);
+  assert_cross_check_pruning(game, 24, 10);
+  assert_endgame_unchanged_by_cross_check_pruning(config, game, 24);
+
+  const char tiny_b[400] =
+      "6WILGA4/10BRAND/5TOFU3R2/6MANDATES1/9I2N1E/5BUNGY1GI1V/7E1A1AT1O/"
+      "6HUP2PETS/5DIRE1QI1R1/1JURA2O3E1O1/3ELVaNITEs1L1/MINX2DIF2T1L1/E6C5E1/"
+      "ZO9KARA/EW7COYISH ES/OO 494/436 0 lex CSW21;";
+  load_cgp_or_die(game, tiny_b);
+  assert_cross_check_pruning(game, 24, 10);
+  assert_endgame_unchanged_by_cross_check_pruning(config, game, 24);
+
+  // Every first move of a fourteen-tile endgame, and a depth-two exact search.
+  const char full_racks[400] =
+      "7F3QINS/7E3E2H/6ORBITED1O/3JAMBU2OM2R/1ROATE1L2FAV1T/GI5ED1T1OPE/"
+      "OD6R3WEN/EL5RUNTY2S/1E6N2U3/1Y5AKA1C3/ES1VAgUIsH1C3/X2I7A3/I2G11/"
+      "LOOING9/E2A11 ADLRSTZ/EIINPW 451/296 0 lex CSW21;";
+  load_cgp_or_die(game, full_racks);
+  assert_cross_check_pruning(game, 1, 100);
+  assert_endgame_unchanged_by_cross_check_pruning(config, game, 2);
+
+  // The existing fixtures: the cross-check list is never larger.
+  const char taurine[300] =
+      "15/3Q7U3/3U2TAURINE2/1CHANSONS2W3/2AI6JO3/DIRL1PO3IN3/E1D2EF3V4/"
+      "F1I2p1TRAIK3/O1L2T4E4/ABy1PIT2BRIG2/ME1MOZELLE5/1GRADE1O1NOH3/WE3R1V7/"
+      "AT5E7/G6D7 ENOSTXY/ACEISUY 356/378 0 lex CSW21;";
+  load_cgp_or_die(game, taurine);
+  assert_cross_check_pruning(game, 1, 50);
+
+  game_destroy(game);
+  config_destroy(config);
+}
+
+void test_word_prune(void) {
+  test_possible_words();
+  test_possible_words_with_cross_checks();
+}


### PR DESCRIPTION
## What this does

The endgame solver prunes the lexicon to a GADDAG of words that can be placed somewhere on the board using unseen tiles, then searches with that. The pruner ignored cross-checks entirely: a word that needs letter L on a square whose perpendicular neighbour admits no word containing L there can never be played, but it was kept.

`generate_possible_words_with_cross_checks` fixes that with two enumeration passes over all 30 lanes. The first, unconstrained, records for every empty square the letters that its accepted playthrough placements put there. A square that already has a tile directly before or after it in the perpendicular lane can only ever hold a letter that some word through that existing tile puts there, so the second pass regenerates the playthrough words refusing any pool letter the perpendicular lane's recorded set excludes. Squares with no fixed perpendicular neighbour stay unconstrained (their eventual cross word is unknowable), non-playthrough words are unchanged, and both passes draw from the union of every unseen tile, exactly as before. The result is a subset of `generate_possible_words` and a superset of every word playable in any reachable position. Iterating to a fixed point removes about 2% more at more than double the cost, so exactly two passes are made.

The endgame uses it only for classic play with a shared lexicon. Wordsmog cross words are order-free, and in informed dual-lexicon mode a cross word legal only in the other player's lexicon can place a letter this lexicon's pass never records; those configurations keep `generate_possible_words`. PEG still builds its own pruned KWGs with the old function; adopting this there is a separate change.

## Why it is safe

By induction over the passes: the first pass contains every placement that occurs in any reachable position, so its recorded sets contain every (square, letter) of every such placement, so the second pass excludes none of them. The same over-approximations as today are kept (one shared pool for both racks, no tile-count coupling between a word and its cross words).

Checked exhaustively in the new unit test and on the benchmark corpora: every word formed by every tile move in every position reachable from all 64 four-tile-or-fewer endgame roots (whole game trees, 205,215 moves, 238,118 words), every first move of 64 fourteen-tile roots (139,360 moves, 233,518 words), and a 30-wide two-ply sample (58,112 moves): none missing. With static leaves the depth-limited search is exact, and 192 solves of the 64 fourteen-tile roots at depths 3 and 4 plus the tiny roots at depth 24 reproduced the unpruned search's value and node count exactly; the unit test asserts the same on three fixtures.

Depth-limited values *with* heuristic leaves are not a pure function of the position in the existing solver: the greedy leaf playout picks the first best-scoring move in generation order, and generation order follows the GADDAG. Any change to the pruned GADDAG can therefore shift some depth-limited values and node counts; the paired runs below nevertheless showed no value differences.

## Measured effect

On the 64 fourteen-tile roots the pruned list shrinks from about 6,800 to about 4,500 words per position (ratio 0.62, range 0.31 to 0.89); pruning costs about 4 ms per position instead of 2 ms, against solves of a second or more. Pruning as a whole is 0.3% of depth-3 solve time.

Paired nine-thread benchmark of this exact production form: independently trained production PGO builds (`make release NPROCS=4 PGO_TRAIN_THREADS=9 PGO_TRAIN_GAMES=16`) of the merge-base `main` and of this branch, eight rotated rounds per cohort, TT of 5% of memory, `egspeedbench`, position-clustered bootstrap CIs. Every one of the 1,536 paired solves completed and no paired root value differed. Direction is spelled out in words; "faster" is good.

| cohort | `main` | this PR | result |
|---|---|---|---|
| 64 endgame roots (14 unseen tiles), depth 3 | 201.5 s | 194.3 s | **3.6% faster** (95% CI 2.8% to 5.0% faster; geometric 5.1%; 62/64 roots faster) |
| same 64 roots, depth 4 | 341.9 s | 330.9 s | **3.2% faster** (CI 1.6% to 6.6% faster; geometric 4.4%; 57/64 faster) |
| 64 roots with at most 4 unseen tiles, depth 24 (exact) | 0.684 s | 0.730 s | **6.6% slower** (CI 3.0% to 13.0% slower): about 90 µs more per 1.4 ms solve for the second enumeration pass |

For scale: two production PGO builds of identical source differ by about ±0.5% on the depth-limited cohorts and about ±2% on the tiny cohort (measured with an A/A control earlier today), so the depth-3 and depth-4 gains are well outside build variation while the tiny-solve loss is real but worth microseconds.



## Profiling

Native `sample` (1 ms) over the whole of a single-thread depth-3 solve of the 64 fourteen-tile roots, two alternating repetitions per build, same production PGO binaries as the table above. Single-threaded the two builds do nearly the same work (14,073,354 vs 14,087,475 nodes; heuristic tie-breaking follows the GADDAG), so costs are normalised per node. Wall time on these sampled runs: 95.6 s and 97.4 s for `main`, 92.4 s and 92.3 s for this PR, **4.3% faster**.

| function | `main` self samples per million nodes | this PR | result |
|---|---|---|---|
| `recursive_gen_small` (GADDAG walk in the endgame move generator) | 1,034 | 953 | 7.8% less |
| `go_on_small` | 497 | 462 | 7.0% less |
| `game_gen_cross_set` (cross sets from the pruned GADDAG) | 636 | 591 | 7.0% less |
| `shadow_play_for_anchor_small` | 963 | 938 | 2.6% less |
| `shadow_play_right_small` | 841 | 816 | 3.0% less |
| word pruning enumeration, inclusive (`generate_possible_words` → `generate_possible_words_with_cross_checks`), once per solve | 109 samples (0.13% of solve time) | 129 samples (0.16%) | 18% more (two passes instead of one) |
| pruned GADDAG build, inclusive (`make_kwg_from_words_fast`), once per solve | 158 samples (0.19%) | 95 samples (0.12%) | 40% less (a third fewer words to merge) |
| both together (`endgame_ctx_reset` inclusive) | 267 samples (0.33%) | 227 samples (0.29%) | 15% less |

Pruning is a rounding error at this depth either way, and the PR makes it slightly cheaper rather than dearer. The greedy leaf playout remains about 81% of solve time inclusive in both builds; the gain is spread over its move generation and cross-set work rather than concentrated in one function.

## Checks

In a fresh clone at the merge-base plus this branch:

- `python3 format.py --write` on the changed files, then whole-repository format check: pass.
- `find_circ_deps.py`: pass.
- `cppcheck.sh` (cppcheck 2.17.1): clean (one `constParameterPointer` finding in the new test was fixed and the re-run is clean).
- clang-tidy 21 on `src/impl/word_prune.c` and `test/word_prune_test.c`: 0 warnings; on `src/impl/endgame.c`: 1 pre-existing clang-analyzer warning at line 1827 (June code, outside this change).
- `make magpie_test BUILD=no_pgo_release`: pass; `wordprune endgame gameplay movegen multipv` suites: pass; full `run_all` suite: 68/68 pass.
- ASan/UBSan (`-fsanitize=address,undefined,pointer-compare,pointer-subtract`, LSan off) on `wordprune endgame gameplay movegen`: pass, 0 reports.
- Not run locally: WASM tests, clang-tidy-18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxtN4jvLjaWPG4HBb1vamN
