### PR TITLE
peg: prune with cross checks for classic shared-lexicon play

### DIFF
--- a/src/impl/config.h
+++ b/src/impl/config.h
@@ -82,6 +82,9 @@ double config_get_p2_utility_spread_scale(const Config *config);
 PlayersData *config_get_players_data(const Config *config);
 LetterDistribution *config_get_ld(const Config *config);
 ThreadControl *config_get_thread_control(const Config *config);
+// Fills peg_args with the peg command's arguments (defaults plus any -peg*
+// settings), leaving the poll and only/protect move sets unset.
+void config_fill_peg_args(Config *config, PegArgs *peg_args);
 exec_mode_t config_get_exec_mode(const Config *config);
 Game *config_get_game(const Config *config);
 GameHistory *config_get_game_history(const Config *config);

--- a/src/impl/peg.c
+++ b/src/impl/peg.c
@@ -11,6 +11,7 @@
 #include "../def/letter_distribution_defs.h"
 #include "../def/move_defs.h"
 #include "../def/peg_defs.h"
+#include "../def/players_data_defs.h"
 #include "../def/rack_defs.h"
 #include "../def/thread_control_defs.h"
 #include "../ent/bag.h"
@@ -1057,6 +1058,19 @@ static uint64_t peg_board_signature(const Game *game) {
   return hash == 0 ? 1 : hash; // reserve 0 as the empty-slot sentinel
 }
 
+// Prunes the lexicon to the words this position can still form. Cross-check
+// aware pruning is only sound for classic play with one shared lexicon; see
+// generate_possible_words_with_cross_checks.
+static void peg_generate_possible_words(const Game *game, const KWG *kwg,
+                                        DictionaryWordList *word_list) {
+  if (game_get_variant(game) == GAME_VARIANT_CLASSIC &&
+      game_get_data_is_shared(game, PLAYERS_DATA_TYPE_KWG)) {
+    generate_possible_words_with_cross_checks(game, kwg, word_list);
+  } else {
+    generate_possible_words(game, kwg, word_list);
+  }
+}
+
 // Return the per-candidate pruned KWG for this leaf's board, building it once
 // (chained off the parent prune on the game) and caching it by board signature.
 // Builds run outside the lock; a rare insert race just discards the loser's
@@ -1080,7 +1094,7 @@ static const KWG *peg_prune_cache_get(PegPruneCache *cache, const Game *game,
 
   const KWG *parent_kwg = game_get_effective_kwg(game, mover_idx);
   DictionaryWordList *word_list = dictionary_word_list_create();
-  generate_possible_words(game, parent_kwg, word_list);
+  peg_generate_possible_words(game, parent_kwg, word_list);
   KWG *built = make_kwg_from_words_small(word_list, KWG_MAKER_OUTPUT_GADDAG,
                                          KWG_MAKER_MERGE_EXACT);
   dictionary_word_list_destroy(word_list);
@@ -2704,7 +2718,7 @@ void peg_solve(const PegArgs *args, PegResult *out, ErrorStack *error_stack) {
   // regenerates all cross-sets (the dominant per-leaf cost).
   DictionaryWordList *word_list = dictionary_word_list_create();
   const KWG *full_kwg = player_get_kwg(game_get_player(game, mover_idx));
-  generate_possible_words(game, full_kwg, word_list);
+  peg_generate_possible_words(game, full_kwg, word_list);
   KWG *pruned_kwg = make_kwg_from_words_small(
       word_list, KWG_MAKER_OUTPUT_GADDAG, KWG_MAKER_MERGE_EXACT);
   dictionary_word_list_destroy(word_list);

--- a/test/peg_speed_bench_test.c
+++ b/test/peg_speed_bench_test.c
@@ -1,0 +1,117 @@
+#include "peg_speed_bench_test.h"
+
+#include "../src/compat/ctime.h"
+#include "../src/ent/game.h"
+#include "../src/impl/cgp.h"
+#include "../src/impl/config.h"
+#include "../src/impl/peg.h"
+#include "../src/str/move_string.h"
+#include "../src/util/io_util.h"
+#include "../src/util/string_util.h"
+#include "test_util.h"
+#include <assert.h>
+#include <stdio.h>
+
+// Fixed-work PEG timing benchmark. Each entry point solves the positions of a
+// committed notes/peg_positions fixture with the peg command's default
+// arguments (config_fill_peg_args) and no time budget, so two builds do
+// identical work and their wall times compare directly. Prints one row per
+// position (seconds, best move, win, spread, last completed stage) and a total
+// line; the PEG result on each row should be identical between the two builds.
+//
+// As in benchmark_peg_test.c there are deliberately no environment-variable
+// knobs: the fixture, position count, thread count and stage schedule are
+// hardcoded in the entry points below — edit them in source to sweep
+// different values.
+
+typedef struct PegSpeedBenchConfig {
+  const char *cgp_file;
+  int max_positions;
+  int num_threads;
+  const int *stage_top_k; // NULL = the peg command's default cascade
+  int num_stages;
+} PegSpeedBenchConfig;
+
+static void run_peg_speed_bench(const PegSpeedBenchConfig *cfg) {
+  log_set_level(LOG_FATAL);
+  char settings[128];
+  (void)snprintf(settings, sizeof(settings),
+                 "set -lex CSW24 -threads %d -pegoutcomes false",
+                 cfg->num_threads);
+  Config *config = config_create_or_die(settings);
+  load_and_exec_config_or_die(config, "new");
+  FILE *file = fopen_or_die(cfg->cgp_file, "re");
+  printf("  PEG fixed-work timing [%s]: up to %d positions, %d threads, %d "
+         "stages\n",
+         cfg->cgp_file, cfg->max_positions, cfg->num_threads, cfg->num_stages);
+  printf("  %4s  %10s  %-16s  %7s  %8s  %5s\n", "Pos", "seconds", "move", "win",
+         "spread", "stage");
+  char line[4096];
+  int index = 0;
+  double total_seconds = 0;
+  while (index < cfg->max_positions && fgets(line, sizeof(line), file)) {
+    if (line[0] == '\n' || line[0] == '\0') {
+      continue;
+    }
+    ErrorStack *error_stack = error_stack_create();
+    game_load_cgp(config_get_game(config), line, error_stack);
+    assert(error_stack_is_empty(error_stack));
+    PegArgs args;
+    config_fill_peg_args(config, &args);
+    args.time_budget_seconds = 0; // unlimited: fixed work
+    if (cfg->num_stages > 0) {
+      args.stage_top_k = cfg->stage_top_k;
+      args.num_stages = cfg->num_stages;
+    }
+    args.include_per_scenario = false;
+    PegResult result;
+    Timer timer;
+    ctimer_start(&timer);
+    peg_solve(&args, &result, error_stack);
+    const double elapsed = ctimer_elapsed_seconds(&timer);
+    assert(error_stack_is_empty(error_stack));
+    StringBuilder *move_sb = string_builder_create();
+    string_builder_add_move(move_sb, game_get_board(config_get_game(config)),
+                            &result.best_move,
+                            game_get_ld(config_get_game(config)), false);
+    printf("  %4d  %10.3f  %-16s  %7.4f  %+8.3f  %5d\n", index, elapsed,
+           string_builder_peek(move_sb), result.best_win, result.best_spread,
+           result.last_completed_stage);
+    (void)fflush(stdout);
+    string_builder_destroy(move_sb);
+    peg_result_destroy(&result);
+    error_stack_destroy(error_stack);
+    total_seconds += elapsed;
+    index++;
+  }
+  fclose_or_die(file);
+  printf("  total: positions=%d threads=%d stages=%d seconds=%.3f\n", index,
+         cfg->num_threads, cfg->num_stages, total_seconds);
+  config_destroy(config);
+}
+
+// Stage schedule 4,2 keeps a position to seconds (1 in bag) or about a minute
+// (2 in bag) rather than the default cascade's minutes.
+void test_peg_speed_bench_1(void) {
+  static const int stage_top_k[] = {4, 2};
+  const PegSpeedBenchConfig cfg = {
+      .cgp_file = "notes/peg_positions/random_1peg.txt",
+      .max_positions = 24,
+      .num_threads = 9,
+      .stage_top_k = stage_top_k,
+      .num_stages = 2,
+  };
+  run_peg_speed_bench(&cfg);
+}
+
+void test_peg_speed_bench_2(void) {
+  static const int stage_top_k[] = {4, 2};
+  const PegSpeedBenchConfig cfg = {
+      .cgp_file = "notes/peg_positions/random_2peg.txt",
+      .max_positions = 12,
+      .num_threads = 9,
+      .stage_top_k = stage_top_k,
+      .num_stages = 2,
+  };
+  run_peg_speed_bench(&cfg);
+}

--- a/test/peg_speed_bench_test.h
+++ b/test/peg_speed_bench_test.h
@@ -1,0 +1,9 @@
+#ifndef PEG_SPEED_BENCH_TEST_H
+#define PEG_SPEED_BENCH_TEST_H
+
+// On-demand fixed-work PEG timing benchmarks over the committed
+// notes/peg_positions/random_{1,2}peg.txt fixtures (run from the repo root).
+void test_peg_speed_bench_1(void);
+void test_peg_speed_bench_2(void);
+
+#endif

--- a/test/test.c
+++ b/test/test.c
@@ -46,6 +46,7 @@
 #include "peg_pess_test.h"
 #include "peg_poll_test.h"
 #include "peg_pool_test.h"
+#include "peg_speed_bench_test.h"
 #include "peg_test.h"
 #include "play_chooser_test.h"
 #include "players_data_test.h"
@@ -157,6 +158,8 @@ static TestEntry test_table[] = {
 
 // Tests that only run when explicitly requested (not included in run_all)
 static TestEntry on_demand_test_table[] = {
+    {"pegspeedbench1", test_peg_speed_bench_1},
+    {"pegspeedbench2", test_peg_speed_bench_2},
     {"positionloaded", test_position_lengths_loaded},
     {"witdiff", test_wit_cache_differential},
     {"witcopy", test_wit_cache_copy},


### PR DESCRIPTION
Uses the cross-check-aware word pruning from #689 (now merged) in the pre-endgame solver, and adds a fixed-work PEG timing benchmark.

## What this does

PEG builds a pruned GADDAG once at the root (with the full lexicon) and, for nested inner solves, per-leaf pruned GADDAGs chained off the parent prune, then hands them to its leaf endgame solves through `skip_word_pruning`. Both builds now use `generate_possible_words_with_cross_checks` from #689, under the same gate (classic variant, shared lexicon; everything else keeps `generate_possible_words`).

The soundness argument is the same as in #689 and does not depend on the bag being empty: the enumeration pool is every unseen tile (bag plus both racks), so any word that can ever appear in a position reachable from the root is enumerated by the unconstrained first pass, and the second pass only refuses a letter on a square that already has a fixed perpendicular neighbour when no word through that neighbour can ever put the letter there. PEG's own comment on the root prune already relies on the pre-candidate board's words being a superset of every post-candidate position's; that stays true.

## Benchmark

Fixed-work PEG timing benchmarks are added as the on-demand tests `pegspeedbench1` and `pegspeedbench2` (first commit). Each solves the positions of a committed `notes/peg_positions` fixture with the `peg` command's default arguments and no time budget, so two builds do identical work and their wall times compare directly; each row also prints the PEG result so the two builds can be checked for agreement. As in `benchmark_peg_test.c` there are no environment-variable knobs: the fixture, position count, thread count and stage schedule are constants in the entry points (24 one-in-bag and 12 two-in-bag positions, nine threads, stage schedule 4,2 so a position takes seconds rather than minutes). `config_fill_peg_args` is declared in `config.h` so the test uses exactly the command's defaults.

Paired production PGO builds (independent `make release` PGO training for the harness commit and for this branch), rounds rotated between the two binaries, position-clustered bootstrap CI. Every paired solve produced the same PEG result (win/spread/move) on both builds.

| corpus | positions × rounds | base total | this PR total | this PR is | 95% CI | positions faster |
|---|---|---|---|---|---|---|
| `notes/peg_positions/random_1peg.txt` (1 in bag) | 24 × 6 | 474.4 s | 447.8 s | **5.6% faster** | 4.7% to 6.7% faster | 23 / 24 |
| `notes/peg_positions/random_2peg.txt` (2 in bag) | 12 × 4 | 3018.3 s | 2875.8 s | **4.7% faster** | 2.9% to 7.0% faster | 12 / 12 |

For scale, an identical-source PGO rebuild differs by about ±0.5% on this kind of fixed-work timing, so both rows are well outside build noise.

## Checks

- `format.py`: clean
- `check_include_cycles.py`: no cycles
- cppcheck: 0 findings
- clang-tidy with the repo's `tidy.sh` check list on `peg.c`, `config.h`, `peg_speed_bench_test.c`: clean
- `peg` unit suite and the full suite (68 tests): pass on a no-PGO build
- ASan build, full suite: 0 reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxtN4jvLjaWPG4HBb1vamN
